### PR TITLE
Feature/daa-economies 

### DIFF
--- a/shared/service-registry/mappers/mapping.ts
+++ b/shared/service-registry/mappers/mapping.ts
@@ -45,8 +45,11 @@ export function handleCreateMultisig(event: CreateMultisigWithAgents): void {
     service.agentIds = [];
     service.save();
 
-    // Create a link between the serviceId and the service entity
-    let serviceIdLink = new ServiceIdLink(event.params.serviceId.toString());
+    // Create or update the link between the serviceId and the service entity
+    let serviceIdLink = ServiceIdLink.load(event.params.serviceId.toString());
+    if (serviceIdLink == null) {
+      serviceIdLink = new ServiceIdLink(event.params.serviceId.toString());
+    }
     serviceIdLink.service = service.id;
     serviceIdLink.save();
 

--- a/shared/service-registry/mappers/mapping.ts
+++ b/shared/service-registry/mappers/mapping.ts
@@ -127,6 +127,7 @@ export function handleServiceActivity(event: ExecutionSuccess): void {
         let dailyActiveAgentCount = DailyActiveAgentCount.load(dailyActiveAgentCountId);
         if (dailyActiveAgentCount == null) {
           dailyActiveAgentCount = new DailyActiveAgentCount(dailyActiveAgentCountId);
+          dailyActiveAgentCount.dayTimestamp = dayID;
           dailyActiveAgentCount.agentId = agentId;
           dailyActiveAgentCount.count = 0;
         }

--- a/shared/service-registry/schema.graphql
+++ b/shared/service-registry/schema.graphql
@@ -78,6 +78,9 @@ type DailyActiveAgentCount @entity(immutable: false) {
   "Unique ID: {dayTimestamp}-{agentId}"
   id: ID!
 
+  "The UNIX timestamp for the start of the day."
+  dayTimestamp: BigInt!
+
   "The agent ID."
   agentId: Int!
 

--- a/shared/service-registry/schema.graphql
+++ b/shared/service-registry/schema.graphql
@@ -6,7 +6,7 @@
 A Service entity represents a single autonomous service created by the registry.
 The ID is the address of the service's multisig wallet, making it unique.
 """
-type Service @entity(immutable: true) {
+type Service @entity(immutable: false) {
   "The multisig address of the service."
   id: Bytes!
 
@@ -18,6 +18,20 @@ type Service @entity(immutable: true) {
 
   "The transaction hash of the creation event."
   txHash: Bytes!
+
+  "The agent IDs associated with this service"
+  agentIds: [Int!]!
+}
+
+"""
+This entity links the serviceId to the service entity.
+"""
+type ServiceIdLink @entity(immutable: true) {
+  "The serviceId."
+  id: ID!
+
+  "The Service entity."
+  service: Service!
 }
 
 """
@@ -45,5 +59,28 @@ type DailyActiveServiceCount @entity(immutable: false) {
   id: ID!
 
   "The total number of unique active services on this day."
+  count: Int!
+}
+
+"""
+This entity acts as a 'seen' list for agent activity to prevent double-counting.
+The ID is a composite key: {dayTimestamp}-{agentId}-{service.id}, ensuring uniqueness.
+"""
+type DailyAgentActivity @entity(immutable: true) {
+  "Unique ID: {dayTimestamp}-{agentId}-{service.id}"
+  id: ID!
+}
+
+"""
+This entity aggregates the total count of unique active services per agent for a given day.
+"""
+type DailyActiveAgentCount @entity(immutable: false) {
+  "Unique ID: {dayTimestamp}-{agentId}"
+  id: ID!
+
+  "The agent ID."
+  agentId: Int!
+
+  "The total number of unique active services for this agent on this day."
   count: Int!
 } 

--- a/shared/service-registry/schema.graphql
+++ b/shared/service-registry/schema.graphql
@@ -26,7 +26,7 @@ type Service @entity(immutable: false) {
 """
 This entity links the serviceId to the service entity.
 """
-type ServiceIdLink @entity(immutable: true) {
+type ServiceIdLink @entity(immutable: false) {
   "The serviceId."
   id: ID!
 

--- a/subgraphs/service-registry/service-registry-base/subgraph.base.yaml
+++ b/subgraphs/service-registry/service-registry-base/subgraph.base.yaml
@@ -35,6 +35,8 @@ dataSources:
         # The signature is updated to match the ABI you provided.
         - event: CreateMultisigWithAgents(indexed uint256,indexed address)
           handler: handleCreateMultisig
+        - event: RegisterInstance(indexed address,indexed uint256,indexed address,uint256)
+          handler: handleRegisterInstance
       file: ../../../shared/service-registry/mappers/mapping.ts
 
 templates:
@@ -58,5 +60,7 @@ templates:
         # This event signals that the service has performed an action.
         # It's a reliable indicator of "activity".
         - event: ExecutionSuccess(bytes32,uint256)
+          handler: handleServiceActivity
+        - event: ExecutionFromModuleSuccess(indexed address)
           handler: handleServiceActivity
       file: ../../../shared/service-registry/mappers/mapping.ts 

--- a/subgraphs/service-registry/service-registry-base/subgraph.base.yaml
+++ b/subgraphs/service-registry/service-registry-base/subgraph.base.yaml
@@ -10,12 +10,8 @@ dataSources:
     name: ServiceRegistryL2
     network: base
     source:
-      # The address of the ServiceRegistryL2 contract on Polygon.
-      # Make sure this is the correct address for the network you are deploying to.
       address: "0x3d77596beb0f130a4415df3D2D8232B3d3D31e44"
       abi: ServiceRegistryL2
-      # It's good practice to set a startBlock to speed up initial syncing.
-      # Find the block number when the contract was deployed.
       startBlock: 116423039
     mapping:
       kind: ethereum/events
@@ -31,8 +27,6 @@ dataSources:
         - name: GnosisSafe
           file: ../../../abis/GnosisSafe.json
       eventHandlers:
-        # This is the handler for the service creation event.
-        # The signature is updated to match the ABI you provided.
         - event: CreateMultisigWithAgents(indexed uint256,indexed address)
           handler: handleCreateMultisig
         - event: RegisterInstance(indexed address,indexed uint256,indexed address,uint256)
@@ -57,8 +51,6 @@ templates:
         - name: GnosisSafe
           file: ../../../abis/GnosisSafe.json
       eventHandlers:
-        # This event signals that the service has performed an action.
-        # It's a reliable indicator of "activity".
         - event: ExecutionSuccess(bytes32,uint256)
           handler: handleServiceActivity
         - event: ExecutionFromModuleSuccess(indexed address)

--- a/subgraphs/service-registry/service-registry-eth/subgraph.yaml
+++ b/subgraphs/service-registry/service-registry-eth/subgraph.yaml
@@ -8,14 +8,10 @@ dataSources:
   # to discover when new services are created.
   - kind: ethereum/contract
     name: ServiceRegistryL2
-    network: mainnet # The Graph's network name for Polygon
+    network: mainnet # The Graph's network name for Ethereum
     source:
-      # The address of the ServiceRegistryL2 contract on Polygon.
-      # Make sure this is the correct address for the network you are deploying to.
       address: "0x48b6af7B12C71f09e2fC8aF4855De4Ff54e775cA"
       abi: ServiceRegistryL2
-      # It's good practice to set a startBlock to speed up initial syncing.
-      # Find the block number when the contract was deployed.
       startBlock: 15178299
     mapping:
       kind: ethereum/events
@@ -31,8 +27,6 @@ dataSources:
         - name: GnosisSafe
           file: ../../../abis/GnosisSafe.json
       eventHandlers:
-        # This is the handler for the service creation event.
-        # The signature is updated to match the ABI you provided.
         - event: CreateMultisigWithAgents(indexed uint256,indexed address)
           handler: handleCreateMultisig
         - event: RegisterInstance(indexed address,indexed uint256,indexed address,uint256)
@@ -57,8 +51,6 @@ templates:
         - name: GnosisSafe
           file: ../../../abis/GnosisSafe.json
       eventHandlers:
-        # This event signals that the service has performed an action.
-        # It's a reliable indicator of "activity".
         - event: ExecutionSuccess(bytes32,uint256)
           handler: handleServiceActivity
         - event: ExecutionFromModuleSuccess(indexed address)

--- a/subgraphs/service-registry/service-registry-eth/subgraph.yaml
+++ b/subgraphs/service-registry/service-registry-eth/subgraph.yaml
@@ -35,6 +35,8 @@ dataSources:
         # The signature is updated to match the ABI you provided.
         - event: CreateMultisigWithAgents(indexed uint256,indexed address)
           handler: handleCreateMultisig
+        - event: RegisterInstance(indexed address,indexed uint256,indexed address,uint256)
+          handler: handleRegisterInstance
       file: ../../../shared/service-registry/mappers/mapping.ts
 
 templates:
@@ -58,5 +60,7 @@ templates:
         # This event signals that the service has performed an action.
         # It's a reliable indicator of "activity".
         - event: ExecutionSuccess(bytes32,uint256)
+          handler: handleServiceActivity
+        - event: ExecutionFromModuleSuccess(indexed address)
           handler: handleServiceActivity
       file: ../../../shared/service-registry/mappers/mapping.ts 

--- a/subgraphs/service-registry/service-registry-gnosis/subgraph.gnosis.yaml
+++ b/subgraphs/service-registry/service-registry-gnosis/subgraph.gnosis.yaml
@@ -35,6 +35,8 @@ dataSources:
         # The signature is updated to match the ABI you provided.
         - event: CreateMultisigWithAgents(indexed uint256,indexed address)
           handler: handleCreateMultisig
+        - event: RegisterInstance(indexed address,indexed uint256,indexed address,uint256)
+          handler: handleRegisterInstance
       file: ../../../shared/service-registry/mappers/mapping.ts
 
 templates:
@@ -58,5 +60,7 @@ templates:
         # This event signals that the service has performed an action.
         # It's a reliable indicator of "activity".
         - event: ExecutionSuccess(bytes32,uint256)
+          handler: handleServiceActivity
+        - event: ExecutionFromModuleSuccess(indexed address)
           handler: handleServiceActivity
       file: ../../../shared/service-registry/mappers/mapping.ts 

--- a/subgraphs/service-registry/service-registry-gnosis/subgraph.gnosis.yaml
+++ b/subgraphs/service-registry/service-registry-gnosis/subgraph.gnosis.yaml
@@ -10,13 +10,9 @@ dataSources:
     name: ServiceRegistryL2
     network: gnosis
     source:
-      # The address of the ServiceRegistryL2 contract on Polygon.
-      # Make sure this is the correct address for the network you are deploying to.
-      address: "0x3d77596beb0f130a4415df3D2D8232B3d3D31e44"
+      address: "0x9338b5153AE39BB89f50468E608eD9d764B755fD"
       abi: ServiceRegistryL2
-      # It's good practice to set a startBlock to speed up initial syncing.
-      # Find the block number when the contract was deployed.
-      startBlock: 116423039
+      startBlock: 27871084
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -31,8 +27,6 @@ dataSources:
         - name: GnosisSafe
           file: ../../../abis/GnosisSafe.json
       eventHandlers:
-        # This is the handler for the service creation event.
-        # The signature is updated to match the ABI you provided.
         - event: CreateMultisigWithAgents(indexed uint256,indexed address)
           handler: handleCreateMultisig
         - event: RegisterInstance(indexed address,indexed uint256,indexed address,uint256)
@@ -57,8 +51,6 @@ templates:
         - name: GnosisSafe
           file: ../../../abis/GnosisSafe.json
       eventHandlers:
-        # This event signals that the service has performed an action.
-        # It's a reliable indicator of "activity".
         - event: ExecutionSuccess(bytes32,uint256)
           handler: handleServiceActivity
         - event: ExecutionFromModuleSuccess(indexed address)

--- a/subgraphs/service-registry/service-registry-optimism/subgraph.optimism.yaml
+++ b/subgraphs/service-registry/service-registry-optimism/subgraph.optimism.yaml
@@ -10,12 +10,8 @@ dataSources:
     name: ServiceRegistryL2
     network: optimism
     source:
-      # The address of the ServiceRegistryL2 contract on Polygon.
-      # Make sure this is the correct address for the network you are deploying to.
       address: "0x3d77596beb0f130a4415df3D2D8232B3d3D31e44"
       abi: ServiceRegistryL2
-      # It's good practice to set a startBlock to speed up initial syncing.
-      # Find the block number when the contract was deployed.
       startBlock: 116423039
     mapping:
       kind: ethereum/events
@@ -31,8 +27,6 @@ dataSources:
         - name: GnosisSafe
           file: ../../../abis/GnosisSafe.json
       eventHandlers:
-        # This is the handler for the service creation event.
-        # The signature is updated to match the ABI you provided.
         - event: CreateMultisigWithAgents(indexed uint256,indexed address)
           handler: handleCreateMultisig
         - event: RegisterInstance(indexed address,indexed uint256,indexed address,uint256)
@@ -57,8 +51,6 @@ templates:
         - name: GnosisSafe
           file: ../../../abis/GnosisSafe.json
       eventHandlers:
-        # This event signals that the service has performed an action.
-        # It's a reliable indicator of "activity".
         - event: ExecutionSuccess(bytes32,uint256)
           handler: handleServiceActivity
         - event: ExecutionFromModuleSuccess(indexed address)

--- a/subgraphs/service-registry/service-registry-optimism/subgraph.optimism.yaml
+++ b/subgraphs/service-registry/service-registry-optimism/subgraph.optimism.yaml
@@ -35,6 +35,8 @@ dataSources:
         # The signature is updated to match the ABI you provided.
         - event: CreateMultisigWithAgents(indexed uint256,indexed address)
           handler: handleCreateMultisig
+        - event: RegisterInstance(indexed address,indexed uint256,indexed address,uint256)
+          handler: handleRegisterInstance
       file: ../../../shared/service-registry/mappers/mapping.ts
 
 templates:
@@ -58,5 +60,7 @@ templates:
         # This event signals that the service has performed an action.
         # It's a reliable indicator of "activity".
         - event: ExecutionSuccess(bytes32,uint256)
+          handler: handleServiceActivity
+        - event: ExecutionFromModuleSuccess(indexed address)
           handler: handleServiceActivity
       file: ../../../shared/service-registry/mappers/mapping.ts 


### PR DESCRIPTION
feat(service-registry): Add Daily Active Agent tracking

This PR introduces a new feature to the service registry subgraph to track the number of Daily Active services, aggregated by their registered agent IDs. This provides more granular insight into the activity of different types of agents within the ecosystem.

### Key Changes:

- **Agent-Level DAA Tracking**:
    - The subgraph now listens for `RegisterInstance` events to associate `agentId`s with their respective services.
    - A new entity, `DailyActiveAgentCount`, has been added to store the daily unique active service count for each `agentId`.

- **Comprehensive Activity Tracking**:
    - The definition of "service activity" has been expanded to include both `ExecutionSuccess` and `ExecutionFromModuleSuccess` events from the Gnosis Safe contracts. This ensures that activity initiated via modules is also counted.

- **Technical Implementation**:
    - A `ServiceIdLink` entity was introduced to create an efficient, internal mapping between a service's numeric ID and its address, avoiding the need for slow contract calls during indexing.
    - Updated all relevant network configurations (Base, Ethereum, Gnosis, Optimism) for the service registry.
