### PR TITLE
Feature/daa subgraphs with agent ids single truth service

### DIFF
--- a/shared/service-registry/schema.graphql
+++ b/shared/service-registry/schema.graphql
@@ -10,13 +10,11 @@ type Multisig @entity(immutable: false) {
   creator: Bytes!
   creationTimestamp: BigInt!
   txHash: Bytes!
-  agentIds: [Int!]!
 }
-type DailyServiceActivity @entity(immutable: true) {
+type DailyMultisigActivity @entity(immutable: true) {
   id: ID!
-  service: Service!
+  multisig: Multisig!
   dayTimestamp: BigInt!
-  agentIds: [Int!]!
 }
 
 type DailyActiveAgent @entity(immutable: false) {
@@ -32,4 +30,3 @@ type DailyAgentActivity @entity(immutable: false) {
   dayTimestamp: BigInt!
   txCount: Int!
 }
-

--- a/subgraphs/service-registry/service-registry-eth/schema.graphql
+++ b/subgraphs/service-registry/service-registry-eth/schema.graphql
@@ -10,13 +10,11 @@ type Multisig @entity(immutable: false) {
   creator: Bytes!
   creationTimestamp: BigInt!
   txHash: Bytes!
-  agentIds: [Int!]!
 }
-type DailyServiceActivity @entity(immutable: true) {
+type DailyMultisigActivity @entity(immutable: true) {
   id: ID!
-  service: Service!
+  multisig: Multisig!
   dayTimestamp: BigInt!
-  agentIds: [Int!]!
 }
 
 type DailyActiveAgent @entity(immutable: false) {
@@ -31,4 +29,4 @@ type DailyAgentActivity @entity(immutable: false) {
   agentId: Int!
   dayTimestamp: BigInt!
   txCount: Int!
-} 
+}

--- a/subgraphs/service-registry/service-registry-eth/src/mapping.ts
+++ b/subgraphs/service-registry/service-registry-eth/src/mapping.ts
@@ -13,7 +13,7 @@ import {
 import {
   Multisig,
   Service,
-  DailyServiceActivity,
+  DailyMultisigActivity,
   DailyActiveAgent,
   DailyAgentActivity,
 } from "../generated/schema";
@@ -25,9 +25,12 @@ function getDayTimestamp(event: ethereum.Event): BigInt {
   return event.block.timestamp.div(ONE_DAY).times(ONE_DAY);
 }
 
-function getDailyActivityId(serviceId: string, event: ethereum.Event): string {
+function getDailyActivityId(multisigId: string, event: ethereum.Event): string {
   const dayTimestamp = getDayTimestamp(event);
-  return "day-".concat(dayTimestamp.toString()).concat("-service-").concat(serviceId);
+  return "day-"
+    .concat(dayTimestamp.toString())
+    .concat("-multisig-")
+    .concat(multisigId);
 }
 
 function getDailyActiveAgentId(event: ethereum.Event): string {
@@ -37,7 +40,7 @@ function getDailyActiveAgentId(event: ethereum.Event): string {
 
 function getDailyAgentActivityId(
   event: ethereum.Event,
-  agentId: BigInt
+  agentId: BigInt,
 ): string {
   const dayTimestamp = getDayTimestamp(event);
   return "day-"
@@ -48,11 +51,11 @@ function getDailyAgentActivityId(
 
 function updateDailyAgentActivity(
   event: ethereum.Event,
-  multisig: Multisig
+  service: Service,
 ): void {
   const dayTimestamp = getDayTimestamp(event);
-  for (let i = 0; i < multisig.agentIds.length; i++) {
-    const agentId = multisig.agentIds[i];
+  for (let i = 0; i < service.agentIds.length; i++) {
+    const agentId = service.agentIds[i];
     const id = getDailyAgentActivityId(event, BigInt.fromI32(agentId));
     let dailyAgentActivity = DailyAgentActivity.load(id);
 
@@ -68,7 +71,10 @@ function updateDailyAgentActivity(
   }
 }
 
-function updateDailyActiveAgents(event: ethereum.Event, multisig: Multisig): void {
+function updateDailyActiveAgents(
+  event: ethereum.Event,
+  service: Service,
+): void {
   const id = getDailyActiveAgentId(event);
   let dailyActiveAgent = DailyActiveAgent.load(id);
 
@@ -80,8 +86,8 @@ function updateDailyActiveAgents(event: ethereum.Event, multisig: Multisig): voi
   }
 
   const newAgentIds: Array<i32> = [];
-  for (let i = 0; i < multisig.agentIds.length; i++) {
-    const agentId = multisig.agentIds[i];
+  for (let i = 0; i < service.agentIds.length; i++) {
+    const agentId = service.agentIds[i];
     if (!dailyActiveAgent.agentIds.includes(agentId)) {
       newAgentIds.push(agentId);
     }
@@ -95,19 +101,17 @@ function updateDailyActiveAgents(event: ethereum.Event, multisig: Multisig): voi
   dailyActiveAgent.save();
 }
 
-function updateDailyActivity(
-  service: Service,
-  event: ethereum.Event,
+function updateDailyMultisigActivity(
   multisig: Multisig,
+  event: ethereum.Event,
 ): void {
-  const id = getDailyActivityId(service.id, event);
-  const dailyActivity = DailyServiceActivity.load(id);
+  const id = getDailyActivityId(multisig.id.toHexString(), event);
+  const dailyActivity = DailyMultisigActivity.load(id);
 
   if (dailyActivity == null) {
-    const newDailyActivity = new DailyServiceActivity(id);
-    newDailyActivity.service = service.id;
+    const newDailyActivity = new DailyMultisigActivity(id);
+    newDailyActivity.multisig = multisig.id;
     newDailyActivity.dayTimestamp = getDayTimestamp(event);
-    newDailyActivity.agentIds = multisig.agentIds;
     newDailyActivity.save();
   }
 }
@@ -126,16 +130,6 @@ export function handleRegisterInstance(event: RegisterInstance): void {
   if (service != null) {
     service.agentIds = [event.params.agentId.toI32()];
     service.save();
-
-    // PATCH: Also update existing multisig with new agent
-    let multisigAddress = service.multisig;
-    if (multisigAddress) {
-      let multisig = Multisig.load(multisigAddress);
-      if (multisig) {
-        multisig.agentIds = [event.params.agentId.toI32()];
-        multisig.save();
-      }
-    }
   }
 }
 
@@ -144,21 +138,21 @@ export function handleCreateMultisig(event: CreateMultisigWithAgents): void {
   let multisig = Multisig.load(multisigAddress);
   let service = Service.load(event.params.serviceId.toString());
 
-  if (multisig == null && service != null) {
+  if (service != null) {
     // Update Service entity
     service.multisig = multisigAddress;
     service.save();
 
-    // Create Multisig entity
-    multisig = new Multisig(multisigAddress);
+    // Create Multisig entity if it does not exist, otherwise update it
+    if (multisig == null) {
+      multisig = new Multisig(multisigAddress);
+      multisig.creator = event.transaction.from;
+      multisig.creationTimestamp = event.block.timestamp;
+      GnosisSafeTemplate.create(event.params.multisig);
+    }
     multisig.serviceId = event.params.serviceId.toI32();
-    multisig.creator = event.transaction.from;
-    multisig.creationTimestamp = event.block.timestamp;
     multisig.txHash = event.transaction.hash;
-    multisig.agentIds = service.agentIds; // Copy agent IDs from service
     multisig.save();
-
-    GnosisSafeTemplate.create(event.params.multisig);
   }
 }
 
@@ -187,19 +181,9 @@ export function handleExecutionSuccess(event: ExecutionSuccess): void {
     let serviceId = multisig.serviceId.toString();
     let service = Service.load(serviceId);
     if (service != null) {
-      let dailyActivityId = getDailyActivityId(serviceId, event);
-      let dailyServiceActivity = DailyServiceActivity.load(dailyActivityId);
-
-      if (dailyServiceActivity == null) {
-        dailyServiceActivity = new DailyServiceActivity(dailyActivityId);
-        dailyServiceActivity.service = service.id;
-        dailyServiceActivity.dayTimestamp = getDayTimestamp(event);
-        dailyServiceActivity.agentIds = multisig.agentIds;
-        dailyServiceActivity.save();
-      }
-
-      updateDailyActiveAgents(event, multisig);
-      updateDailyAgentActivity(event, multisig);
+      updateDailyMultisigActivity(multisig, event);
+      updateDailyActiveAgents(event, service);
+      updateDailyAgentActivity(event, service);
     } else {
       log.error("Service {} not found for multisig {}", [
         serviceId,
@@ -210,26 +194,16 @@ export function handleExecutionSuccess(event: ExecutionSuccess): void {
 }
 
 export function handleExecutionFromModuleSuccess(
-  event: ExecutionFromModuleSuccess
+  event: ExecutionFromModuleSuccess,
 ): void {
   let multisig = Multisig.load(event.address);
   if (multisig != null) {
     let serviceId = multisig.serviceId.toString();
     let service = Service.load(serviceId);
     if (service != null) {
-      let dailyActivityId = getDailyActivityId(serviceId, event);
-      let dailyServiceActivity = DailyServiceActivity.load(dailyActivityId);
-
-      if (dailyServiceActivity == null) {
-        dailyServiceActivity = new DailyServiceActivity(dailyActivityId);
-        dailyServiceActivity.service = service.id;
-        dailyServiceActivity.dayTimestamp = getDayTimestamp(event);
-        dailyServiceActivity.agentIds = multisig.agentIds;
-        dailyServiceActivity.save();
-      }
-
-      updateDailyActiveAgents(event, multisig);
-      updateDailyAgentActivity(event, multisig);
+      updateDailyMultisigActivity(multisig, event);
+      updateDailyActiveAgents(event, service);
+      updateDailyAgentActivity(event, service);
     } else {
       log.error("Service {} not found for multisig {}", [
         serviceId,
@@ -237,4 +211,4 @@ export function handleExecutionFromModuleSuccess(
       ]);
     }
   }
-} 
+}


### PR DESCRIPTION
### Title: refactor(service-registry): Implement Single Source of Truth Model

### Summary

This PR refactors the service registry subgraphs (L1 & L2) to fix data inconsistencies and ensure historical accuracy. It
establishes the Service entity as the single source of truth for agent configurations.

### Changes

• Schema:
 • Removed agentIds from the Multisig entity to prevent stale data.
 • Renamed DailyServiceActivity to DailyMultisigActivity for clarity.
• Mappings:
 • Transaction handlers now fetch agentIds from the Service entity, ensuring historical accuracy.
 • Fixed a bug where reused multisigs were not correctly updated.
