### PR TITLE
Feature/new-mech-fees-daily-tracking

### DIFF
--- a/shared/new-mech-fees/schema.graphql
+++ b/shared/new-mech-fees/schema.graphql
@@ -25,3 +25,20 @@ type MechTransaction @entity(immutable: true) {
   balance: BigInt
   rateDiff: BigInt
 }
+
+type DailyTotals @entity(immutable: false) {
+  id: ID!
+  date: Int!
+  totalFeesInUSD: BigDecimal!
+  totalFeesOutUSD: BigDecimal!
+}
+
+type MechDaily @entity(immutable: false) {
+  id: ID!
+  mech: Mech!
+  date: Int!
+  feesInUSD: BigDecimal!
+  feesOutUSD: BigDecimal!
+  feesInRaw: BigDecimal!
+  feesOutRaw: BigDecimal!
+}

--- a/shared/new-mech-fees/token-utils.ts
+++ b/shared/new-mech-fees/token-utils.ts
@@ -1,0 +1,92 @@
+import { Address, BigDecimal, BigInt, Bytes, log } from "@graphprotocol/graph-ts";
+import { BalancerV2Vault } from "./generated/BalanceTrackerFixedPriceToken/BalancerV2Vault";
+
+function getPoolTokenBalances(
+  vault: BalancerV2Vault,
+  poolId: Bytes,
+  olasAddress: Address,
+  stablecoinAddress: Address
+): Array<BigInt> {
+  const poolTokensResult = vault.try_getPoolTokens(poolId);
+  if (poolTokensResult.reverted) {
+    log.error("Could not get pool tokens for pool {}", [poolId.toHexString()]);
+    return [BigInt.zero(), BigInt.zero()];
+  }
+
+  const tokens = poolTokensResult.value.getTokens();
+  const balances = poolTokensResult.value.getBalances();
+
+  let olasBalance = BigInt.zero();
+  let stablecoinBalance = BigInt.zero();
+
+  for (let i = 0; i < tokens.length; i++) {
+    if (tokens[i].equals(olasAddress)) {
+      olasBalance = balances[i];
+    } else if (tokens[i].equals(stablecoinAddress)) {
+      stablecoinBalance = balances[i];
+    }
+  }
+
+  return [olasBalance, stablecoinBalance];
+}
+
+function calculateOlasPriceFromPool(
+  olasAmount: BigInt,
+  olasBalance: BigInt,
+  stablecoinBalance: BigInt,
+  stablecoinDecimals: i32
+): BigDecimal {
+  const olasDecimalsBigInt = BigInt.fromI32(10).pow(18);
+  const stablecoinDecimalsBigInt = BigInt.fromI32(10).pow(stablecoinDecimals as u8);
+
+  const olasAmountDecimal = olasAmount.toBigDecimal().div(olasDecimalsBigInt.toBigDecimal());
+  const olasBalanceDecimal = olasBalance.toBigDecimal().div(olasDecimalsBigInt.toBigDecimal());
+  const stablecoinBalanceDecimal = stablecoinBalance
+    .toBigDecimal()
+    .div(stablecoinDecimalsBigInt.toBigDecimal());
+
+  const pricePerOlas = stablecoinBalanceDecimal.div(olasBalanceDecimal);
+  return olasAmountDecimal.times(pricePerOlas);
+}
+
+export function calculateOlasInUsd(
+  vaultAddress: Address,
+  poolId: Bytes,
+  olasAddress: Address,
+  stablecoinAddress: Address,
+  stablecoinDecimals: i32,
+  olasAmount: BigInt
+): BigDecimal {
+  if (
+    poolId.equals(
+      Bytes.fromHexString(
+        "0x0000000000000000000000000000000000000000000000000000000000000000"
+      )
+    )
+  ) {
+    log.warning("Zero pool ID provided for OLAS price calculation", []);
+    return BigDecimal.fromString("0");
+  }
+
+  const vault = BalancerV2Vault.bind(vaultAddress);
+  const balances = getPoolTokenBalances(
+    vault,
+    poolId,
+    olasAddress,
+    stablecoinAddress
+  );
+  const olasBalance = balances[0];
+  const stablecoinBalance = balances[1];
+
+  if (olasBalance.isZero() || stablecoinBalance.isZero()) {
+    log.warning("Invalid pool balances for pool {}", [poolId.toHexString()]);
+    return BigDecimal.fromString("0");
+  }
+
+  return calculateOlasPriceFromPool(
+    olasAmount,
+    olasBalance,
+    stablecoinBalance,
+    stablecoinDecimals
+  );
+} 

--- a/shared/new-mech-fees/utils.ts
+++ b/shared/new-mech-fees/utils.ts
@@ -1,5 +1,5 @@
 import { BigDecimal, BigInt, ethereum } from "@graphprotocol/graph-ts";
-import { Global, MechTransaction } from "./generated/schema";
+import { Global, MechTransaction, Mech } from "./generated/schema";
 import { 
   TOKEN_RATIO_GNOSIS,
   TOKEN_DECIMALS_GNOSIS,
@@ -8,11 +8,7 @@ import {
   CHAINLINK_PRICE_FEED_DECIMALS,
   ETH_DECIMALS,
 } from "../constants";
-import { Address, Bytes } from "@graphprotocol/graph-ts";
-import { BalancerV2Vault } from "./generated/BalanceTrackerFixedPriceToken/BalancerV2Vault";
-import { log } from "@graphprotocol/graph-ts";
-import { Mech } from "./generated/schema";
-import { MechDaily, DailyTotals } from "./generated/schema";
+import { Address, Bytes, log } from "@graphprotocol/graph-ts";
 
 const GLOBAL_ID = "1";
 const FEE_IN = "FEE_IN";
@@ -102,15 +98,22 @@ export function convertBaseNativeWeiToUsd(
     .pow(ETH_DECIMALS as u8)
     .toBigDecimal();
 
-  return amountInWei.toBigDecimal().times(ethPrice.toBigDecimal()).div(priceDivisor).div(ethDivisor);
+  return amountInWei
+    .toBigDecimal()
+    .times(ethPrice.toBigDecimal())
+    .div(priceDivisor)
+    .div(ethDivisor);
 }
 
 // For NVM fees on Gnosis
 export function calculateGnosisNvmFeesIn(deliveryRate: BigInt): BigDecimal {
-  const tokenDivisor = BigInt.fromI32(10).pow(TOKEN_DECIMALS_GNOSIS as u8).toBigDecimal();
+  const tokenDivisor = BigInt.fromI32(10)
+    .pow(TOKEN_DECIMALS_GNOSIS as u8)
+    .toBigDecimal();
   const ethDivisor = BigInt.fromI32(10).pow(18).toBigDecimal();
 
-  return deliveryRate.toBigDecimal()
+  return deliveryRate
+    .toBigDecimal()
     .times(TOKEN_RATIO_GNOSIS)
     .div(ethDivisor)
     .div(tokenDivisor);
@@ -118,10 +121,13 @@ export function calculateGnosisNvmFeesIn(deliveryRate: BigInt): BigDecimal {
 
 // For NVM fees on Base
 export function calculateBaseNvmFeesIn(deliveryRate: BigInt): BigDecimal {
-  const tokenDivisor = BigInt.fromI32(10).pow(TOKEN_DECIMALS_BASE as u8).toBigDecimal();
+  const tokenDivisor = BigInt.fromI32(10)
+    .pow(TOKEN_DECIMALS_BASE as u8)
+    .toBigDecimal();
   const ethDivisor = BigInt.fromI32(10).pow(18).toBigDecimal();
 
-  return deliveryRate.toBigDecimal()
+  return deliveryRate
+    .toBigDecimal()
     .times(TOKEN_RATIO_BASE)
     .div(ethDivisor)
     .div(tokenDivisor);
@@ -132,20 +138,16 @@ export function calculateBaseNvmFeesInUsd(
   deliveryRate: BigInt,
   ethPrice: BigInt
 ): BigDecimal {
-  // First calculate the NVM fee amount in ETH
   const feeInEth = calculateBaseNvmFeesIn(deliveryRate);
-  
-  // Then convert to USD using the ETH price from Chainlink
   const priceDivisor = BigInt.fromI32(10)
     .pow(CHAINLINK_PRICE_FEED_DECIMALS as u8)
     .toBigDecimal();
-  
   return feeInEth.times(ethPrice.toBigDecimal()).div(priceDivisor);
 }
 
 // For USDC withdrawals on Base (assumes 1 USDC = 1 USD)
 export function convertBaseUsdcToUsd(amountInUsdc: BigInt): BigDecimal {
-  const usdcDivisor = BigInt.fromI32(10).pow(6).toBigDecimal(); // USDC has 6 decimals
+  const usdcDivisor = BigInt.fromI32(10).pow(6).toBigDecimal();
   return amountInUsdc.toBigDecimal().div(usdcDivisor);
 }
 
@@ -163,7 +165,11 @@ export function getOrInitializeMech(mechId: string): Mech {
 }
 
 // Helper function to update mech fees in
-export function updateMechFeesIn(mechId: string, amountUsd: BigDecimal, amountRaw: BigDecimal): void {
+export function updateMechFeesIn(
+  mechId: string,
+  amountUsd: BigDecimal,
+  amountRaw: BigDecimal
+): void {
   const mech = getOrInitializeMech(mechId);
   mech.totalFeesInUSD = mech.totalFeesInUSD.plus(amountUsd);
   mech.totalFeesInRaw = mech.totalFeesInRaw.plus(amountRaw);
@@ -171,90 +177,19 @@ export function updateMechFeesIn(mechId: string, amountUsd: BigDecimal, amountRa
 }
 
 // Helper function to update mech fees out
-export function updateMechFeesOut(mechId: string, amountUsd: BigDecimal, amountRaw: BigDecimal): void {
+export function updateMechFeesOut(
+  mechId: string,
+  amountUsd: BigDecimal,
+  amountRaw: BigDecimal
+): void {
   const mech = getOrInitializeMech(mechId);
   mech.totalFeesOutUSD = mech.totalFeesOutUSD.plus(amountUsd);
   mech.totalFeesOutRaw = mech.totalFeesOutRaw.plus(amountRaw);
   mech.save();
 }
 
-// Helper function to get token balances from Balancer pool
-function getPoolTokenBalances(
-  vault: BalancerV2Vault,
-  poolId: Bytes,
-  olasAddress: Address,
-  stablecoinAddress: Address
-): Array<BigInt> {
-  const poolTokensResult = vault.try_getPoolTokens(poolId);
-  
-  if (poolTokensResult.reverted) {
-    log.error("Could not get pool tokens for pool {}", [poolId.toHexString()]);
-    return [BigInt.zero(), BigInt.zero()];
-  }
-
-  const tokens = poolTokensResult.value.getTokens();
-  const balances = poolTokensResult.value.getBalances();
-  
-  let olasBalance = BigInt.zero();
-  let stablecoinBalance = BigInt.zero();
-
-  for (let i = 0; i < tokens.length; i++) {
-    if (tokens[i].equals(olasAddress)) {
-      olasBalance = balances[i];
-    } else if (tokens[i].equals(stablecoinAddress)) {
-      stablecoinBalance = balances[i];
-    }
-  }
-  
-  return [olasBalance, stablecoinBalance];
-}
-
-// Helper function to calculate OLAS price from pool balances
-function calculateOlasPriceFromPool(
-  olasAmount: BigInt,
-  olasBalance: BigInt,
-  stablecoinBalance: BigInt,
-  stablecoinDecimals: i32
-): BigDecimal {
-  const olasDecimalsBigInt = BigInt.fromI32(10).pow(18);
-  const stablecoinDecimalsBigInt = BigInt.fromI32(10).pow(stablecoinDecimals as u8);
-  
-  const olasAmountDecimal = olasAmount.toBigDecimal().div(olasDecimalsBigInt.toBigDecimal());
-  const olasBalanceDecimal = olasBalance.toBigDecimal().div(olasDecimalsBigInt.toBigDecimal());
-  const stablecoinBalanceDecimal = stablecoinBalance.toBigDecimal().div(stablecoinDecimalsBigInt.toBigDecimal());
-  
-  const pricePerOlas = stablecoinBalanceDecimal.div(olasBalanceDecimal);
-  return olasAmountDecimal.times(pricePerOlas);
-}
-
-// Common function for OLAS fees
-export function calculateOlasInUsd(
-  vaultAddress: Address,
-  poolId: Bytes,
-  olasAddress: Address,
-  stablecoinAddress: Address,
-  stablecoinDecimals: i32,
-  olasAmount: BigInt
-): BigDecimal {
-  // Check for zero pool ID - return zero instead of fallback
-  if (poolId.equals(Bytes.fromHexString("0x0000000000000000000000000000000000000000000000000000000000000000"))) {
-    log.warning("Zero pool ID provided for OLAS price calculation", []);
-    return BigDecimal.fromString("0");
-  }
-
-  const vault = BalancerV2Vault.bind(vaultAddress);
-  const balances = getPoolTokenBalances(vault, poolId, olasAddress, stablecoinAddress);
-  const olasBalance = balances[0];
-  const stablecoinBalance = balances[1];
-
-  // Return zero if we can't get valid balances
-  if (olasBalance.isZero() || stablecoinBalance.isZero()) {
-    log.warning("Invalid pool balances for pool {}", [poolId.toHexString()]);
-    return BigDecimal.fromString("0");
-  }
-
-  return calculateOlasPriceFromPool(olasAmount, olasBalance, stablecoinBalance, stablecoinDecimals);
-} 
+// ---------------- Daily aggregation helpers ----------------
+import { MechDaily, DailyTotals } from "./generated/schema";
 
 function dayStart(timestamp: BigInt): i32 {
   return (timestamp.toI32() / 86400) * 86400;
@@ -291,14 +226,20 @@ function getOrInitMechDaily(mechId: string, timestamp: BigInt): MechDaily {
   return md as MechDaily;
 }
 
-export function updateDailyTotalsIn(amountUsd: BigDecimal, timestamp: BigInt): void {
+export function updateDailyTotalsIn(
+  amountUsd: BigDecimal,
+  timestamp: BigInt
+): void {
   if (amountUsd.le(BigDecimal.fromString("0"))) return;
   const d = getOrInitDailyTotals(timestamp);
   d.totalFeesInUSD = d.totalFeesInUSD.plus(amountUsd);
   d.save();
 }
 
-export function updateDailyTotalsOut(amountUsd: BigDecimal, timestamp: BigInt): void {
+export function updateDailyTotalsOut(
+  amountUsd: BigDecimal,
+  timestamp: BigInt
+): void {
   if (amountUsd.le(BigDecimal.fromString("0"))) return;
   const d = getOrInitDailyTotals(timestamp);
   d.totalFeesOutUSD = d.totalFeesOutUSD.plus(amountUsd);
@@ -311,7 +252,11 @@ export function updateMechDailyIn(
   amountRaw: BigDecimal,
   timestamp: BigInt
 ): void {
-  if (amountUsd.le(BigDecimal.fromString("0")) && amountRaw.le(BigDecimal.fromString("0"))) return;
+  if (
+    amountUsd.le(BigDecimal.fromString("0")) &&
+    amountRaw.le(BigDecimal.fromString("0"))
+  )
+    return;
   const md = getOrInitMechDaily(mechId, timestamp);
   md.feesInUSD = md.feesInUSD.plus(amountUsd);
   md.feesInRaw = md.feesInRaw.plus(amountRaw);
@@ -324,7 +269,11 @@ export function updateMechDailyOut(
   amountRaw: BigDecimal,
   timestamp: BigInt
 ): void {
-  if (amountUsd.le(BigDecimal.fromString("0")) && amountRaw.le(BigDecimal.fromString("0"))) return;
+  if (
+    amountUsd.le(BigDecimal.fromString("0")) &&
+    amountRaw.le(BigDecimal.fromString("0"))
+  )
+    return;
   const md = getOrInitMechDaily(mechId, timestamp);
   md.feesOutUSD = md.feesOutUSD.plus(amountUsd);
   md.feesOutRaw = md.feesOutRaw.plus(amountRaw);

--- a/subgraphs/new-mech-fees/README.md
+++ b/subgraphs/new-mech-fees/README.md
@@ -176,3 +176,89 @@ This query returns the total fees processed by the subgraph across all mechs.
   }
 }
 ``` 
+
+### Daily Aggregation (New)
+
+- **Entities**
+  - `MechDaily`: per‑mech, per‑day totals (USD + raw)
+  - `DailyTotals`: global per‑day totals (USD)
+- **IDs**
+  - `DailyTotals.id`: unix start-of-day (UTC) as string, e.g. `"1710460800"`
+  - `MechDaily.id`: `${mech}-${dayStart}`, e.g. `"0xabc...-1710460800"`
+- **When updated**
+  - On `MechBalanceAdjusted` (fee-in) and `Withdraw` (fee-out) across all payment models
+- **Units**
+  - USD fields are cross-model comparable; raw fields are model-specific (same rules as above)
+
+### Sample Queries — Daily
+
+```graphql
+# Per‑mech daily totals for a date range
+{
+  mechDailies(
+    where: {
+      mech: "0xMECH_ADDRESS",
+      date_gte: 1710460800,
+      date_lt: 1711065600
+    },
+    orderBy: date,
+    orderDirection: asc
+  ) {
+    id
+    date
+    feesInUSD
+    feesOutUSD
+    feesInRaw
+    feesOutRaw
+  }
+}
+```
+
+```graphql
+# Single day per‑mech by composite id
+{
+  mechDaily(id: "0xMECH_ADDRESS-1710460800") {
+    id
+    date
+    mech { id }
+    feesInUSD
+    feesOutUSD
+    feesInRaw
+    feesOutRaw
+  }
+}
+```
+
+```graphql
+# Global daily totals in a range
+# Note: list field is dailyTotals_collection
+{
+  dailyTotals_collection(
+    where: { date_gte: 1710460800, date_lt: 1711065600 },
+    orderBy: date,
+    orderDirection: asc
+  ) {
+    id
+    date
+    totalFeesInUSD
+    totalFeesOutUSD
+  }
+}
+```
+
+```graphql
+# Top mechs by fees on a specific day
+{
+  mechDailies(
+    where: { date: 1710460800 },
+    orderBy: feesInUSD,
+    orderDirection: desc,
+    first: 20
+  ) {
+    mech { id }
+    date
+    feesInUSD
+    feesOutUSD
+  }
+}
+``` 

--- a/subgraphs/new-mech-fees/new-native-mech-fees-base/src/mapping.ts
+++ b/subgraphs/new-mech-fees/new-native-mech-fees-base/src/mapping.ts
@@ -17,7 +17,11 @@ import {
   updateMechFeesIn,
   updateMechFeesOut,
   createMechTransactionForAccrued,
-  createMechTransactionForCollected
+  createMechTransactionForCollected,
+  updateDailyTotalsIn,
+  updateDailyTotalsOut,
+  updateMechDailyIn,
+  updateMechDailyOut
 } from "../../../../shared/new-mech-fees/utils"
 import { AggregatorV3Interface } from "../../../../shared/new-mech-fees/generated/BalanceTrackerFixedPriceNative/AggregatorV3Interface"
 
@@ -43,6 +47,8 @@ export function handleMechBalanceAdjustedForNative(event: MechBalanceAdjusted): 
 
   updateTotalFeesIn(deliveryRateUsd);
   updateMechFeesIn(mechId, deliveryRateUsd, deliveryRateEth.toBigDecimal());
+  updateDailyTotalsIn(deliveryRateUsd, event.block.timestamp);
+  updateMechDailyIn(mechId, deliveryRateUsd, deliveryRateEth.toBigDecimal(), event.block.timestamp);
 
   // Create MechTransaction for the accrued fees
   const mech = Mech.load(mechId);
@@ -83,6 +89,8 @@ export function handleWithdrawForNative(event: Withdraw): void {
 
   updateTotalFeesOut(withdrawalAmountUsd);
   updateMechFeesOut(mechId, withdrawalAmountUsd, withdrawalAmountWei.toBigDecimal());
+  updateDailyTotalsOut(withdrawalAmountUsd, event.block.timestamp);
+  updateMechDailyOut(mechId, withdrawalAmountUsd, withdrawalAmountWei.toBigDecimal(), event.block.timestamp);
 
   // Create MechTransaction for the collected fees
   const mech = Mech.load(mechId);

--- a/subgraphs/new-mech-fees/new-native-mech-fees-gnosis/src/mapping.ts
+++ b/subgraphs/new-mech-fees/new-native-mech-fees-gnosis/src/mapping.ts
@@ -14,7 +14,11 @@ import {
   updateMechFeesIn,
   updateMechFeesOut,
   createMechTransactionForAccrued,
-  createMechTransactionForCollected
+  createMechTransactionForCollected,
+  updateDailyTotalsIn,
+  updateDailyTotalsOut,
+  updateMechDailyIn,
+  updateMechDailyOut
 } from "../../../../shared/new-mech-fees/utils"
 
 const BURN_ADDRESS = Address.fromString(BURN_ADDRESS_MECH_FEES_GNOSIS);
@@ -27,6 +31,8 @@ export function handleMechBalanceAdjustedForNative(event: MechBalanceAdjusted): 
 
   updateTotalFeesIn(earningsAmountUsd);
   updateMechFeesIn(mechId, earningsAmountUsd, earningsAmountWei.toBigDecimal());
+  updateDailyTotalsIn(earningsAmountUsd, event.block.timestamp);
+  updateMechDailyIn(mechId, earningsAmountUsd, earningsAmountWei.toBigDecimal(), event.block.timestamp);
 
   // Create MechTransaction for the accrued fees
   const mech = Mech.load(mechId);
@@ -56,6 +62,8 @@ export function handleWithdrawForNative(event: Withdraw): void {
 
   updateTotalFeesOut(withdrawalAmountUsd);
   updateMechFeesOut(mechId, withdrawalAmountUsd, withdrawalAmountWei.toBigDecimal());
+  updateDailyTotalsOut(withdrawalAmountUsd, event.block.timestamp);
+  updateMechDailyOut(mechId, withdrawalAmountUsd, withdrawalAmountWei.toBigDecimal(), event.block.timestamp);
 
   // Create MechTransaction for the collected fees
   const mech = Mech.load(mechId);

--- a/subgraphs/new-mech-fees/new-nvm-mech-fees-base/src/mapping.ts
+++ b/subgraphs/new-mech-fees/new-nvm-mech-fees-base/src/mapping.ts
@@ -20,7 +20,11 @@ import {
   updateMechFeesIn,
   updateMechFeesOut,
   createMechTransactionForAccrued,
-  createMechTransactionForCollected
+  createMechTransactionForCollected,
+  updateDailyTotalsIn,
+  updateDailyTotalsOut,
+  updateMechDailyIn,
+  updateMechDailyOut
 } from "../../../../shared/new-mech-fees/utils";
 
 const BURN_ADDRESS = Address.fromString(BURN_ADDRESS_MECH_FEES_BASE);
@@ -36,6 +40,8 @@ export function handleMechBalanceAdjustedForNvm(event: MechBalanceAdjusted): voi
   updateTotalFeesIn(deliveryRateUsd);
   // Store credits as raw value (not converted to USDC)
   updateMechFeesIn(mechId, deliveryRateUsd, deliveryRateCredits.toBigDecimal());
+  updateDailyTotalsIn(deliveryRateUsd, event.block.timestamp);
+  updateMechDailyIn(mechId, deliveryRateUsd, deliveryRateCredits.toBigDecimal(), event.block.timestamp);
 
   // Create the transaction record
   const mech = Mech.load(mechId);
@@ -75,6 +81,8 @@ export function handleWithdrawForNvm(event: Withdraw): void {
   updateTotalFeesOut(withdrawalAmountUsd);
   // Store credits as raw value (converted from USDC)
   updateMechFeesOut(mechId, withdrawalAmountUsd, withdrawalCredits);
+  updateDailyTotalsOut(withdrawalAmountUsd, event.block.timestamp);
+  updateMechDailyOut(mechId, withdrawalAmountUsd, withdrawalCredits, event.block.timestamp);
 
   // Create MechTransaction for the collected fees
   const mech = Mech.load(mechId);

--- a/subgraphs/new-mech-fees/new-nvm-mech-fees-gnosis/src/mapping.ts
+++ b/subgraphs/new-mech-fees/new-nvm-mech-fees-gnosis/src/mapping.ts
@@ -20,7 +20,11 @@ import {
   updateMechFeesIn,
   updateMechFeesOut,
   createMechTransactionForAccrued,
-  createMechTransactionForCollected
+  createMechTransactionForCollected,
+  updateDailyTotalsIn,
+  updateDailyTotalsOut,
+  updateMechDailyIn,
+  updateMechDailyOut
 } from "../../../../shared/new-mech-fees/utils"
 
 const BURN_ADDRESS = Address.fromString(BURN_ADDRESS_MECH_FEES_GNOSIS);
@@ -35,6 +39,8 @@ export function handleMechBalanceAdjustedForNvm(event: MechBalanceAdjusted): voi
   updateTotalFeesIn(earningsAmountUsd);
   // Store credits as raw value (not converted to xDAI wei)
   updateMechFeesIn(mechId, earningsAmountUsd, deliveryRateCredits.toBigDecimal());
+  updateDailyTotalsIn(earningsAmountUsd, event.block.timestamp);
+  updateMechDailyIn(mechId, earningsAmountUsd, deliveryRateCredits.toBigDecimal(), event.block.timestamp);
 
   // Create MechTransaction for the accrued fees
   const mech = Mech.load(mechId);
@@ -75,6 +81,8 @@ export function handleWithdrawForNvm(event: Withdraw): void {
   updateTotalFeesOut(withdrawalAmountUsd);
   // Store credits as raw value (converted from xDAI wei)
   updateMechFeesOut(mechId, withdrawalAmountUsd, withdrawalCredits);
+  updateDailyTotalsOut(withdrawalAmountUsd, event.block.timestamp);
+  updateMechDailyOut(mechId, withdrawalAmountUsd, withdrawalCredits, event.block.timestamp);
 
   // Create MechTransaction for the collected fees
   const mech = Mech.load(mechId);

--- a/subgraphs/new-mech-fees/new-token-mech-fees-base/src/mapping.ts
+++ b/subgraphs/new-mech-fees/new-token-mech-fees-base/src/mapping.ts
@@ -14,7 +14,6 @@ import {
 import {
   updateTotalFeesIn,
   updateTotalFeesOut,
-  calculateOlasInUsd,
   updateMechFeesIn,
   updateMechFeesOut,
   createMechTransactionForAccrued,
@@ -24,6 +23,7 @@ import {
   updateMechDailyIn,
   updateMechDailyOut
 } from "../../../../shared/new-mech-fees/utils"
+import { calculateOlasInUsd } from "../../../../shared/new-mech-fees/token-utils"
 import { BalancerV2WeightedPool } from "../../../../shared/new-mech-fees/generated/BalanceTrackerFixedPriceToken/BalancerV2WeightedPool";
 
 const BURN_ADDRESS = Address.fromString(BURN_ADDRESS_MECH_FEES_BASE);

--- a/subgraphs/new-mech-fees/new-token-mech-fees-base/src/mapping.ts
+++ b/subgraphs/new-mech-fees/new-token-mech-fees-base/src/mapping.ts
@@ -18,7 +18,11 @@ import {
   updateMechFeesIn,
   updateMechFeesOut,
   createMechTransactionForAccrued,
-  createMechTransactionForCollected
+  createMechTransactionForCollected,
+  updateDailyTotalsIn,
+  updateDailyTotalsOut,
+  updateMechDailyIn,
+  updateMechDailyOut
 } from "../../../../shared/new-mech-fees/utils"
 import { BalancerV2WeightedPool } from "../../../../shared/new-mech-fees/generated/BalanceTrackerFixedPriceToken/BalancerV2WeightedPool";
 
@@ -57,6 +61,8 @@ export function handleMechBalanceAdjustedForToken(event: MechBalanceAdjusted): v
 
   updateTotalFeesIn(deliveryRateUsd);
   updateMechFeesIn(mechId, deliveryRateUsd, deliveryRateOlas.toBigDecimal());
+  updateDailyTotalsIn(deliveryRateUsd, event.block.timestamp);
+  updateMechDailyIn(mechId, deliveryRateUsd, deliveryRateOlas.toBigDecimal(), event.block.timestamp);
 
   // Create MechTransaction for the accrued fees
   const mech = Mech.load(mechId);
@@ -95,6 +101,8 @@ export function handleWithdrawForToken(event: Withdraw): void {
 
   updateTotalFeesOut(withdrawalAmountUsd);
   updateMechFeesOut(mechId, withdrawalAmountUsd, withdrawalAmountOlas.toBigDecimal());
+  updateDailyTotalsOut(withdrawalAmountUsd, event.block.timestamp);
+  updateMechDailyOut(mechId, withdrawalAmountUsd, withdrawalAmountOlas.toBigDecimal(), event.block.timestamp);
 
   // Create MechTransaction for the collected fees
   const mech = Mech.load(mechId);

--- a/subgraphs/new-mech-fees/new-token-mech-fees-gnosis/src/mapping.ts
+++ b/subgraphs/new-mech-fees/new-token-mech-fees-gnosis/src/mapping.ts
@@ -14,7 +14,6 @@ import {
 import {
   updateTotalFeesIn,
   updateTotalFeesOut,
-  calculateOlasInUsd,
   updateMechFeesIn,
   updateMechFeesOut,
   createMechTransactionForAccrued,
@@ -24,7 +23,7 @@ import {
   updateMechDailyIn,
   updateMechDailyOut
 } from "../../../../shared/new-mech-fees/utils"
-import { BalancerV2Vault } from "../../../../shared/new-mech-fees/generated/BalanceTrackerFixedPriceToken/BalancerV2Vault";
+import { calculateOlasInUsd } from "../../../../shared/new-mech-fees/token-utils"
 import { BalancerV2WeightedPool } from "../../../../shared/new-mech-fees/generated/BalanceTrackerFixedPriceToken/BalancerV2WeightedPool";
 
 const BURN_ADDRESS = Address.fromString(BURN_ADDRESS_MECH_FEES_GNOSIS);

--- a/subgraphs/new-mech-fees/new-token-mech-fees-gnosis/src/mapping.ts
+++ b/subgraphs/new-mech-fees/new-token-mech-fees-gnosis/src/mapping.ts
@@ -18,7 +18,11 @@ import {
   updateMechFeesIn,
   updateMechFeesOut,
   createMechTransactionForAccrued,
-  createMechTransactionForCollected
+  createMechTransactionForCollected,
+  updateDailyTotalsIn,
+  updateDailyTotalsOut,
+  updateMechDailyIn,
+  updateMechDailyOut
 } from "../../../../shared/new-mech-fees/utils"
 import { BalancerV2Vault } from "../../../../shared/new-mech-fees/generated/BalanceTrackerFixedPriceToken/BalancerV2Vault";
 import { BalancerV2WeightedPool } from "../../../../shared/new-mech-fees/generated/BalanceTrackerFixedPriceToken/BalancerV2WeightedPool";
@@ -61,6 +65,8 @@ export function handleMechBalanceAdjustedForToken(event: MechBalanceAdjusted): v
 
   updateTotalFeesIn(deliveryRateUsd);
   updateMechFeesIn(mechId, deliveryRateUsd, deliveryRateOlas.toBigDecimal());
+  updateDailyTotalsIn(deliveryRateUsd, event.block.timestamp);
+  updateMechDailyIn(mechId, deliveryRateUsd, deliveryRateOlas.toBigDecimal(), event.block.timestamp);
 
   // Create MechTransaction for the accrued fees
   const mech = Mech.load(mechId);
@@ -100,6 +106,8 @@ export function handleWithdrawForToken(event: Withdraw): void {
 
   updateTotalFeesOut(withdrawalAmountUsd);
   updateMechFeesOut(mechId, withdrawalAmountUsd, withdrawalAmountOlas.toBigDecimal());
+  updateDailyTotalsOut(withdrawalAmountUsd, event.block.timestamp);
+  updateMechDailyOut(mechId, withdrawalAmountUsd, withdrawalAmountOlas.toBigDecimal(), event.block.timestamp);
 
   // Create MechTransaction for the collected fees
   const mech = Mech.load(mechId);


### PR DESCRIPTION
- Add daily aggregation: MechDaily (per‑mech) and DailyTotals (global).
- Update all new mech-fees handlers to record daily in/out (USD + raw), keep MechTransaction.
- Isolate OLAS pricing into shared/new-mech-fees/token-utils.ts to avoid cross‑subgraph deps.
- Update subgraphs/new-mech-fees/README.md with daily model docs and sample queries.
