### PR TITLE
Docs/monorepo-migration-complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,117 @@
-# Tokenomics App Subgraph
+# Autonolas Subgraphs Monorepo (GRAPH HOSTED)
 
-This repository contains a subgraph for [The Graph](https://thegraph.com), specifically for the [tokenomics contracts](https://github.com/valory-xyz/autonolas-tokenomics)
-
+This repository contains multiple subgraphs for [The Graph](https://thegraph.com), primarily indexing contracts related to the Autonolas ecosystem.
 
 ## Getting Started
 
 - Prerequisites: `yarn global add @graphprotocol/graph-cli`
 - Install dependencies by running `yarn install`
+
+## Monorepo Architecture
+
+This repository is a monorepo that houses multiple subgraph projects. The goal is to maintain a centralized, organized, and consistent structure for all subgraphs related to the Autonolas ecosystem which are not self hosted. or are hosted on platform like The Graph Studio or Alchemy.
+
+### Key Directories
+
+-   `abis/`: A central directory for all contract ABI JSON files. ABIs stored here are shared and can be referenced by any subgraph.
+-   `scripts/`: Contains scripts for automating tasks, such as building manifests and deploying subgraphs. The `deploy-studio.js` script is particularly important for managing deployments.
+-   `subgraphs/`: The main directory containing all the individual subgraph projects. Each subdirectory represents a different subgraph category (e.g., `tokenomics`, `service-registry`, `staking`).
+
+### Multi-Network Subgraph Patterns
+
+We use two primary patterns for managing subgraphs that are deployed across multiple networks.
+
+#### 1. Template (`subgraph.template.yaml`) Pattern
+
+This is the **preferred pattern for new multi-network subgraphs**, especially when they involve complex configurations or many networks.
+
+-   **Structure**: A `subgraph.template.yaml` file serves as a base template. A `networks.json` file contains a list of networks with their specific contract addresses and start blocks.
+-   **Generation**: A script (e.g., `scripts/generate-manifests.js`) consumes the template and the `networks.json` file to generate the final `subgraph.<network>.yaml` manifest for each network.
+-   **Example**: `staking`.
+
+#### 2. Shared Code (`common/`) Pattern
+
+This pattern is suitable for simpler multi-network subgraphs, particularly when the network-specific differences are minimal and primarily involve contract addresses and start blocks.
+
+-   **Structure**: A `common/` directory within the subgraph's main folder (e.g., `subgraphs/service-registry/common/`) holds the shared `schema.graphql`, mapping files in `mappers/`, and utility functions.
+-   **Network-Specific Manifests**: Each supported network has its own subdirectory (e.g., `service-registry-arbitrum/`) containing a `subgraph.<network>.yaml` file. This manifest references the shared schema and mappers from the `common/` directory but specifies network-specific details like contract addresses and start blocks.
+-   **Examples**: `service-registry` and `tokenomics` (for L2s).
+
+## Adding a New Subgraph
+
+Here is a step-by-step guide to adding a new subgraph to this repository.
+
+### Step 1: Create the Subgraph Directory
+
+1.  Create a new directory under `subgraphs/` for your project (e.g., `subgraphs/my-new-subgraph/`).
+2.  If it's a multi-network subgraph, **consider using the Template Pattern as described above.** Otherwise, follow the Shared Code (`common/`) Pattern by creating a `common/` directory for your shared logic and separate directories for each network (e.g., `my-new-subgraph-mainnet/`).
+3.  Add your `schema.graphql`, `subgraph.yaml` (or `subgraph.template.yaml` if using the template pattern), and `src/mapping.ts` files as you normally would.
+
+### Step 2: Add ABIs
+
+Place the JSON ABI files for all required smart contracts into the root `/abis` directory. This ensures they can be easily referenced by your subgraph and other projects.
+
+### Step 3: Update `package.json`
+
+You must add scripts to `package.json` to codegen and build your new subgraph.
+
+1.  **Add a `codegen` script**:
+    -   Create a script named `codegen-my-new-subgraph` that runs `graph codegen`.
+    -   If you're using the `common/` pattern, make sure the output (`-o`) is directed to your `common/generated` directory.
+    ```json
+    "codegen-my-new-subgraph": "graph codegen subgraphs/my-new-subgraph/my-new-subgraph-mainnet/subgraph.yaml -o subgraphs/my-new-subgraph/common/generated",
+    ```
+
+2.  **Add `build` scripts**:
+    -   Create a build script for each network your subgraph supports (e.g., `build-my-new-subgraph:mainnet`).
+    -   This script should first run your `codegen` script and then `graph build` with the path to the specific network's manifest file.
+    ```json
+    "build-my-new-subgraph:mainnet": "yarn codegen-my-new-subgraph && graph build subgraphs/my-new-subgraph/my-new-subgraph-mainnet/subgraph.yaml",
+    ```
+
+### Step 4: Update the Deployment Script
+
+To make your subgraph deployable via the interactive script, you need to add it to `scripts/deploy-studio.js`.
+
+1.  Open `scripts/deploy-studio.js`.
+2.  Add a new entry to the `networkTypes` object for your subgraph category.
+3.  For each network, provide the path to its manifest file, a short description, and the name of the `build` script you created in `package.json`.
+
+```javascript
+// Example from scripts/deploy-studio.js
+'9': { // Use a new number
+  name: 'My New Subgraph',
+  description: 'This is my new subgraph.',
+  networks: {
+    'mainnet': {
+      path: 'subgraphs/my-new-subgraph/my-new-subgraph-mainnet/subgraph.yaml',
+      description: 'Ethereum Mainnet',
+      buildCommand: 'yarn build-my-new-subgraph:mainnet'
+    },
+    // ... other networks
+  }
+},
+```
+
+### Step 5: Add a README.md
+
+Create a `README.md` file inside your subgraph's main directory (e.g., `subgraphs/my-new-subgraph/README.md`). Please follow the structure of the existing READMEs (`service-registry/README.md`, `tokenomics/README.md`) to ensure consistency.
+
+Your README should include:
+-   A brief overview.
+-   The architecture of your subgraph.
+-   A list of indexed contracts.
+-   A description of the core entities in your schema.
+-   A list of supported networks.
+-   GraphQL query examples.
+
+## Development Workflow
+
+1.  **Install Dependencies**: Run `yarn install` from the root of the repository.
+2.  **Generate Types**: Run the `codegen` script for your subgraph (e.g., `yarn codegen-my-new-subgraph`).
+3.  **Build**: Run the `build` script for the specific network you are working on (e.g., `yarn build-my-new-subgraph:mainnet`).
+4.  **Test**: Use `graph test` to run any unit tests.
+5.  **Deploy**: Use the interactive deployment script `yarn deploy-studio` to deploy to The Graph Studio or Alchemy.
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains multiple subgraphs for [The Graph](https://thegraph.com
 
 ## Monorepo Architecture
 
-This repository is a monorepo that houses multiple subgraph projects. The goal is to maintain a centralized, organized, and consistent structure for all subgraphs related to the Autonolas ecosystem which are not self hosted. or are hosted on platform like The Graph Studio or Alchemy.
+This repository is a monorepo that houses multiple subgraph projects. The goal is to maintain a centralized, organized, and consistent structure for all subgraphs related to the Autonolas ecosystem which are hosted on platform like The Graph Studio or Alchemy.
 
 ### Key Directories
 

--- a/subgraphs/service-registry/README.md
+++ b/subgraphs/service-registry/README.md
@@ -1,0 +1,113 @@
+# Service Registry Subgraph
+
+This directory contains subgraphs for tracking the lifecycle of services, including agent registration, multisig creation, and daily activity metrics across Ethereum mainnet and various L2 networks.
+
+## Architecture
+
+The project is structured with a shared core logic and network-specific configurations:
+
+-   **Common Logic (`common/`)**: This directory contains the shared GraphQL schema (`schema.graphql`), mapping logic (`mappers/mapping.ts`), and utility functions (`utils.ts`) used by all network subgraphs.
+-   **Network Subgraphs (`service-registry-*/`)**: Each supported network has its own directory containing the `subgraph.<network>.yaml` manifest file. These manifests define the specific contract addresses and start blocks for that network while referencing the common mapping and schema.
+
+## Indexed Contracts
+
+The subgraphs index data from the following contracts:
+
+-   **`ServiceRegistry` (Mainnet)**: The core contract on Ethereum mainnet for managing services, agent registrations, and multisig deployments.
+-   **`ServiceRegistryL2` (L2s)**: The equivalent contract deployed on various L2 networks.
+-   **`GnosisSafe` (All Networks)**: The multisig wallet contract used by services. This is indexed dynamically using a template when a new multisig is created for a service.
+
+## Core Entities
+
+-   **`Service`**: Represents a service, linking it to its registered agent instances and multisig wallet.
+-   **`Multisig`**: Tracks Gnosis Safe wallets, including their creator, creation timestamp, and associated agent instances.
+-   **`Agent`**: Represents a unique autonomous agent.
+-   **`AgentRegistration`**: Records the registration of an agent to a service, capturing the timestamp.
+-   **`AgentPerformance`**: Aggregates the total transaction count for each agent across all their activity.
+-   **`Global`**: A singleton entity for global statistics, such as the total transaction count and the total number of unique agents.
+
+### Daily Aggregation Entities
+
+To provide insights into daily activity, the subgraph generates several daily snapshot entities:
+
+-   **`DailyServiceActivity`**: Tracks the active agents for each service on a daily basis.
+-   **`DailyUniqueAgents`**: Counts the number of unique active agents across all services each day.
+-   **`DailyAgentPerformance`**: Records the daily transaction count for each agent.
+-   **`DailyActiveMultisigs`**: Tracks the number of multisig wallets that had on-chain activity each day.
+
+## Supported Networks
+
+-   **Ethereum Mainnet**: `service-registry-eth/subgraph.yaml`
+-   **Arbitrum**: `service-registry-arbitrum/subgraph.arbitrum.yaml`
+-   **Base**: `service-registry-base/subgraph.base.yaml`
+-   **Celo**: `service-registry-celo/subgraph.celo.yaml`
+-   **Gnosis**: `service-registry-gnosis/subgraph.gnosis.yaml`
+-   **Mode**: `service-registry-mode/subgraph.mode.yaml`
+-   **Optimism**: `service-registry-optimism/subgraph.optimism.yaml`
+-   **Polygon**: `service-registry-polygon/subgraph.polygon.yaml`
+
+## Usage Examples
+
+### 1. Daily Active Agents (DAA) per Agent ID
+
+This query fetches the number of distinct active multisigs for a specific agent (`agentId: 40`) per day.
+
+```graphql
+query GetDAAForAgent {
+  dailyAgentPerformances(
+    # Use a Unix timestamp for the desired start date
+    where: { agentId: 40, dayTimestamp_gte: "1672531200" }
+    orderBy: dayTimestamp
+    orderDirection: desc
+  ) {
+    dayTimestamp
+    activeMultisigCount
+  }
+}
+```
+
+### 2. Daily Active Agents (DAA) Across All Agents
+
+This query fetches the total count of distinct active multisigs across all agents for each day.
+
+```graphql
+query GetDAAOverall {
+  dailyActiveMultisigs(
+    orderBy: dayTimestamp
+    orderDirection: desc
+    # Use a Unix timestamp for the desired start date
+    where: { dayTimestamp_gte: "1672531200" }
+  ) {
+    dayTimestamp
+    count
+  }
+}
+```
+
+### 3. Total Transactions per Agent
+
+This query lists all agents and their total transaction counts, sorted in descending order.
+
+```graphql
+query GetTotalTxsPerAgent {
+  agentPerformances(
+    orderBy: txCount
+    orderDirection: desc
+  ) {
+    id # Agent ID
+    txCount
+  }
+}
+```
+
+### 4. Total Transactions on the Chain
+
+This query retrieves the total number of transactions processed across all services on the network.
+
+```graphql
+query GetTotalTxsPerChain {
+  global(id: "") {
+    txCount
+  }
+}
+``` 

--- a/subgraphs/tokenomics/README.md
+++ b/subgraphs/tokenomics/README.md
@@ -1,0 +1,55 @@
+# Tokenomics Subgraph
+
+This directory contains subgraphs for tracking the economic activity and mechanisms of the OLAS token across Ethereum mainnet and various L2 networks.
+
+## Architecture
+
+The project is structured into two main parts:
+
+-   **Ethereum Mainnet Subgraph (`tokenomics-eth`)**: A comprehensive subgraph that indexes the full OLAS tokenomics system, including bonding, staking incentives, and epoch settlements.
+-   **L2 Subgraphs (`tokenomics-*/`)**: A set of lighter subgraphs for various L2 networks that focus primarily on OLAS token transfers and holder balances. These subgraphs share a common schema and mapping logic from the `common` directory.
+
+## Ethereum Mainnet Subgraph
+
+The mainnet subgraph, located in `tokenomics-eth/`, provides a detailed view of the OLAS token's economic activity on Ethereum.
+
+### Indexed Contracts
+
+-   **`OLAS`**: The OLAS ERC20 token contract.
+-   **`veOLAS`**: The voting-escrowed OLAS contract for staking.
+-   **`Tokenomics`**: The core contract managing epochs, rewards, and economic parameters.
+-   **`DepositoryV1` & `DepositoryV2`**: Contracts for creating and managing bonding products.
+-   **`DispenserV1` & `DispenserV2`**: Contracts for distributing rewards and incentives.
+
+### Core Entities
+
+-   **`Epoch`**: Tracks epoch settlements, including rewards, top-ups, available incentives, and bond-related data.
+-   **`Token` / `TokenHolder`**: Tracks OLAS token supply and individual holder balances.
+-   **`VeolasDepositor`**: Tracks veOLAS deposits and lock times.
+-   **Event Entities**: A wide range of entities that log events from the indexed contracts, such as:
+    -   `CreateProduct` / `CloseProduct`: Events related to bonding products.
+    -   `CreateBond` / `RedeemBond`: Events for bond creation and redemption.
+    -   `IncentivesClaimed`: Events for developer and staker incentive claims.
+    -   `EpochSettled`: Detailed records of each epoch settlement.
+
+## L2 Network Subgraphs
+
+These subgraphs track OLAS token activity on various L2 networks. They share a common schema (`common/schema-l2.graphql`) and mapping logic (`common/mappers/olas-l2.ts`).
+
+### Core Entities (L2)
+
+-   **`Token`**: Represents the OLAS token on the specific L2.
+-   **`TokenHolder`**: Tracks the balance of each OLAS holder on the L2.
+-   **`Transfer`**: Logs every OLAS token transfer event.
+
+## Supported Networks
+
+-   **Ethereum Mainnet**: `tokenomics-eth/subgraph.yaml`
+-   **L2 Networks**:
+    -   Arbitrum: `tokenomics-arbitrum/subgraph.arbitrum.yaml`
+    -   Base: `tokenomics-base/subgraph.base.yaml`
+    -   Celo: `tokenomics-celo/subgraph.celo.yaml`
+    -   Gnosis: `tokenomics-gnosis/subgraph.gnosis.yaml`
+    -   Mode: `tokenomics-mode/subgraph.mode.yaml`
+    -   Optimism: `tokenomics-optimism/subgraph.optimism.yaml`
+    -   Polygon: `tokenomics-polygon/subgraph.polygon.yaml`


### PR DESCRIPTION
This is PR which updates the readme present the in the repo and makes sure that the readmes are relevant wherever i had context i've reviewed them diligently

added the contribution and Monorepo structure details and how to contribute , also made sure that the manifests are generated just fine witch each subgraph working independently and does not interfere with the builds of others

This should conclude the cleanup and refactoring of this repo to be a monorepo