### PR TITLE
Feat/operator-count

### DIFF
--- a/subgraphs/service-registry/common/mappers/mapping.ts
+++ b/subgraphs/service-registry/common/mappers/mapping.ts
@@ -28,7 +28,7 @@ import {
   createDailyActiveMultisig,
   createOrUpdateAgentRegistration,
   getMostRecentAgentId,
-  getOrCreateOperator,
+  updateUniqueOperators,
 } from "../utils";
 
 function updateDailyAgentPerformance(
@@ -124,8 +124,8 @@ export function handleRegisterInstance(event: RegisterInstance): void {
   }
   service.save();
 
-  // Track unique operators
-  getOrCreateOperator(event.params.operator);
+  // Track unique operators (updates Global.totalOperators on first seen)
+  updateUniqueOperators(event.params.operator);
 }
 
 export function handleCreateMultisig(event: CreateMultisigWithAgents): void {

--- a/subgraphs/service-registry/common/mappers/mapping.ts
+++ b/subgraphs/service-registry/common/mappers/mapping.ts
@@ -28,6 +28,7 @@ import {
   createDailyActiveMultisig,
   createOrUpdateAgentRegistration,
   getMostRecentAgentId,
+  getOrCreateOperator,
 } from "../utils";
 
 function updateDailyAgentPerformance(
@@ -122,6 +123,9 @@ export function handleRegisterInstance(event: RegisterInstance): void {
     service.agentIds = agentIds;
   }
   service.save();
+
+  // Track unique operators
+  getOrCreateOperator(event.params.operator);
 }
 
 export function handleCreateMultisig(event: CreateMultisigWithAgents): void {

--- a/subgraphs/service-registry/common/schema.graphql
+++ b/subgraphs/service-registry/common/schema.graphql
@@ -76,4 +76,9 @@ type Global @entity(immutable: false) {
   id: ID!
   txCount: BigInt!
   lastUpdated: BigInt!
+  totalOperators: Int!
+}
+
+type Operator @entity(immutable: false) {
+  id: ID! # operator address
 }

--- a/subgraphs/service-registry/common/schema.graphql
+++ b/subgraphs/service-registry/common/schema.graphql
@@ -80,5 +80,5 @@ type Global @entity(immutable: false) {
 }
 
 type Operator @entity(immutable: false) {
-  id: ID! # operator address
+  id: Bytes! # operator address
 }

--- a/subgraphs/service-registry/common/utils.ts
+++ b/subgraphs/service-registry/common/utils.ts
@@ -12,6 +12,7 @@ import {
   Global,
   Multisig,
   Service,
+  Operator,
 } from "./generated/schema";
 
 const ONE_DAY = BigInt.fromI32(86400);
@@ -124,6 +125,7 @@ export function getGlobal(): Global {
     global = new Global("");
     global.txCount = BigInt.fromI32(0);
     global.lastUpdated = BigInt.fromI32(0);
+    global.totalOperators = 0;
     global.save();
   }
   return global;
@@ -139,6 +141,19 @@ export function getOrCreateAgentPerformance(
     agent.save();
   }
   return agent;
+}
+
+export function getOrCreateOperator(operatorAddress: Bytes): Operator {
+  let operator = Operator.load(operatorAddress);
+  if (operator == null) {
+    operator = new Operator(operatorAddress);
+    operator.save();
+
+    const global = getGlobal();
+    global.totalOperators = global.totalOperators + 1;
+    global.save();
+  }
+  return operator;
 }
 
 export function createDailyUniqueAgent(

--- a/subgraphs/service-registry/common/utils.ts
+++ b/subgraphs/service-registry/common/utils.ts
@@ -148,12 +148,19 @@ export function getOrCreateOperator(operatorAddress: Bytes): Operator {
   if (operator == null) {
     operator = new Operator(operatorAddress);
     operator.save();
+  }
+  return operator;
+}
 
+export function updateUniqueOperators(operatorAddress: Bytes): void {
+  let existed = Operator.load(operatorAddress);
+  if (existed == null) {
+    // Create then increment global unique operators
+    getOrCreateOperator(operatorAddress);
     const global = getGlobal();
     global.totalOperators = global.totalOperators + 1;
     global.save();
   }
-  return operator;
 }
 
 export function createDailyUniqueAgent(

--- a/subgraphs/service-registry/service-registry-arbitrum/subgraph.arbitrum.yaml
+++ b/subgraphs/service-registry/service-registry-arbitrum/subgraph.arbitrum.yaml
@@ -22,6 +22,7 @@ dataSources:
         - DailyActiveMultisigs
         - Agent
         - GlobalMetrics
+        - Operator
       abis:
         - name: ServiceRegistryL2
           file: ../../../abis/ServiceRegistryL2.json
@@ -57,6 +58,7 @@ templates:
         - DailyActiveMultisigs
         - Agent
         - GlobalMetrics
+        - Operator
       abis:
         - name: GnosisSafe
           file: ../../../abis/GnosisSafe.json

--- a/subgraphs/service-registry/service-registry-base/subgraph.base.yaml
+++ b/subgraphs/service-registry/service-registry-base/subgraph.base.yaml
@@ -24,6 +24,7 @@ dataSources:
         - DailyActiveMultisigs
         - Agent
         - GlobalMetrics
+        - Operator
       abis:
         - name: ServiceRegistryL2
           file: ../../../abis/ServiceRegistryL2.json
@@ -59,6 +60,7 @@ templates:
         - DailyActiveMultisigs
         - Agent
         - GlobalMetrics
+        - Operator
       abis:
         - name: GnosisSafe
           file: ../../../abis/GnosisSafe.json

--- a/subgraphs/service-registry/service-registry-celo/subgraph.celo.yaml
+++ b/subgraphs/service-registry/service-registry-celo/subgraph.celo.yaml
@@ -22,6 +22,7 @@ dataSources:
         - DailyActiveMultisigs
         - Agent
         - GlobalMetrics
+        - Operator
       abis:
         - name: ServiceRegistryL2
           file: ../../../abis/ServiceRegistryL2.json
@@ -57,6 +58,7 @@ templates:
         - DailyActiveMultisigs
         - Agent
         - GlobalMetrics
+        - Operator
       abis:
         - name: GnosisSafe
           file: ../../../abis/GnosisSafe.json

--- a/subgraphs/service-registry/service-registry-eth/src/mapping.ts
+++ b/subgraphs/service-registry/service-registry-eth/src/mapping.ts
@@ -28,6 +28,7 @@ import {
   createDailyActiveMultisig,
   createOrUpdateAgentRegistration,
   getMostRecentAgentId,
+  updateUniqueOperators,
 } from "../../common/utils";
 
 function updateDailyAgentPerformance(
@@ -122,6 +123,9 @@ export function handleRegisterInstance(event: RegisterInstance): void {
     service.agentIds = agentIds;
   }
   service.save();
+
+  // Track unique operators (updates Global.totalOperators on first seen)
+  updateUniqueOperators(event.params.operator);
 }
 
 export function handleCreateMultisig(event: CreateMultisigWithAgents): void {

--- a/subgraphs/service-registry/service-registry-eth/subgraph.yaml
+++ b/subgraphs/service-registry/service-registry-eth/subgraph.yaml
@@ -23,6 +23,7 @@ dataSources:
         - DailyActiveMultisigs
         - Agent
         - GlobalMetrics
+        - Operator
       abis:
         - name: ServiceRegistry
           file: ../../../abis/ServiceRegistry.json
@@ -58,6 +59,7 @@ templates:
         - DailyActiveMultisigs
         - Agent
         - GlobalMetrics
+        - Operator
       abis:
         - name: GnosisSafe
           file: ../../../abis/GnosisSafe.json

--- a/subgraphs/service-registry/service-registry-gnosis/subgraph.gnosis.yaml
+++ b/subgraphs/service-registry/service-registry-gnosis/subgraph.gnosis.yaml
@@ -22,6 +22,7 @@ dataSources:
         - DailyActiveMultisigs
         - Agent
         - GlobalMetrics
+        - Operator
       abis:
         - name: ServiceRegistryL2
           file: ../../../abis/ServiceRegistryL2.json
@@ -57,6 +58,7 @@ templates:
         - DailyActiveMultisigs
         - Agent
         - GlobalMetrics
+        - Operator
       abis:
         - name: GnosisSafe
           file: ../../../abis/GnosisSafe.json

--- a/subgraphs/service-registry/service-registry-mode/subgraph.mode.yaml
+++ b/subgraphs/service-registry/service-registry-mode/subgraph.mode.yaml
@@ -23,6 +23,7 @@ dataSources:
         - DailyActiveMultisigs
         - Agent
         - GlobalMetrics
+        - Operator
       abis:
         - name: ServiceRegistryL2
           file: ../../../abis/ServiceRegistryL2.json
@@ -58,6 +59,7 @@ templates:
         - DailyActiveMultisigs
         - Agent
         - GlobalMetrics
+        - Operator
       abis:
         - name: GnosisSafe
           file: ../../../abis/GnosisSafe.json

--- a/subgraphs/service-registry/service-registry-optimism/subgraph.optimism.yaml
+++ b/subgraphs/service-registry/service-registry-optimism/subgraph.optimism.yaml
@@ -22,6 +22,7 @@ dataSources:
         - DailyActiveMultisigs
         - Agent
         - GlobalMetrics
+        - Operator
       abis:
         - name: ServiceRegistryL2
           file: ../../../abis/ServiceRegistryL2.json
@@ -59,6 +60,7 @@ templates:
         - DailyActiveMultisigs
         - Agent
         - GlobalMetrics
+        - Operator
       abis:
         - name: GnosisSafe
           file: ../../../abis/GnosisSafe.json

--- a/subgraphs/service-registry/service-registry-polygon/subgraph.polygon.yaml
+++ b/subgraphs/service-registry/service-registry-polygon/subgraph.polygon.yaml
@@ -22,6 +22,7 @@ dataSources:
         - DailyActiveMultisigs
         - Agent
         - GlobalMetrics
+        - Operator
       abis:
         - name: ServiceRegistryL2
           file: ../../../abis/ServiceRegistryL2.json
@@ -57,6 +58,7 @@ templates:
         - DailyActiveMultisigs
         - Agent
         - GlobalMetrics
+        - Operator
       abis:
         - name: GnosisSafe
           file: ../../../abis/GnosisSafe.json


### PR DESCRIPTION
## feat: Add unique operator tracking to service-registry subgraph
### Summary:
This PR introduces functionality to track the number of unique operators in the service-registry subgraph. This aligns our analytics more closely with on-chain activity, providing a key metric for network growth.

Changes:

- GraphQL Schema:
	- Added a new Operator entity to store unique operator addresses.
	- Added a totalOperators counter to the Global entity.
- Mappings & Utilities:
	- Updated the handleRegisterInstance function to process the operator address from the event.
	- Introduced a getOrCreateOperator utility to handle entity creation and increment the global counter.
- Manifests:
	- Updated all subgraph.*.yaml files to include the new Operator entity.