### PR TITLE
PRO-849 : Terminated services Handling

### DIFF
--- a/subgraphs/service-registry/schema.graphql
+++ b/subgraphs/service-registry/schema.graphql
@@ -1,9 +1,18 @@
+enum ServiceState {
+  PreRegistration
+  ActiveRegistration
+  FinishedRegistration
+  Deployed
+  TerminatedBonded
+}
+
 type Service @entity(immutable: false) {
   id: ID! # service ID
   multisig: Bytes
   agentIds: [Int!]!
   creationTimestamp: BigInt!
   configHash: Bytes
+  state: ServiceState!
 }
 
 type AgentRegistration @entity(immutable: false) {

--- a/subgraphs/service-registry/src/mapping.ts
+++ b/subgraphs/service-registry/src/mapping.ts
@@ -104,6 +104,7 @@ function updateGlobalMetrics(event: ethereum.Event): void {
 export function handleCreateService(event: CreateService): void {
   let service = getOrCreateService(event.params.serviceId, event.block.timestamp);
   service.configHash = event.params.configHash;
+  service.state = "PreRegistration";
   service.save();
 }
 
@@ -136,6 +137,7 @@ export function handleCreateMultisig(event: CreateMultisigWithAgents): void {
   if (service != null) {
     const multisig = getOrCreateMultisig(event.params.multisig, event);
     service.multisig = multisig.id;
+    service.state = "Deployed";
     service.save();
 
     GnosisSafeTemplate.create(event.params.multisig);
@@ -169,47 +171,45 @@ export function handleTerminateService(event: TerminateService): void {
   let service = Service.load(event.params.serviceId.toString());
   if (service != null) {
     service.agentIds = [];
-    service.multisig = null;
+    service.state = "TerminatedBonded";
     service.save();
   }
 }
 
 export function handleExecutionSuccess(event: ExecutionSuccess): void {
   let multisig = Multisig.load(event.address);
-  if (multisig != null) {
-    let service = Service.load(multisig.serviceId.toString());
-    if (service != null) {
-      updateDailyActivity(service, event, multisig);
-      updateDailyUniqueAgents(event, multisig);
-      updateDailyAgentPerformance(event, multisig);
-      updateDailyActiveMultisigs(event, multisig);
-      updateGlobalMetrics(event);
-    } else {
-      log.error("Service {} not found for multisig {}", [
-        multisig.serviceId.toString(),
-        event.address.toHexString(),
-      ]);
-    }
+  if (multisig == null) {
+    return;
   }
+
+  let service = Service.load(multisig.serviceId.toString());
+  if (service == null || service.state != "Deployed") {
+    return;
+  }
+
+  updateDailyActivity(service, event, multisig);
+  updateDailyUniqueAgents(event, multisig);
+  updateDailyAgentPerformance(event, multisig);
+  updateDailyActiveMultisigs(event, multisig);
+  updateGlobalMetrics(event);
 }
 
 export function handleExecutionFromModuleSuccess(
   event: ExecutionFromModuleSuccess
 ): void {
   let multisig = Multisig.load(event.address);
-  if (multisig != null) {
-    let service = Service.load(multisig.serviceId.toString());
-    if (service != null) {
-      updateDailyActivity(service, event, multisig);
-      updateDailyUniqueAgents(event, multisig);
-      updateDailyAgentPerformance(event, multisig);
-      updateDailyActiveMultisigs(event, multisig);
-      updateGlobalMetrics(event);
-    } else {
-      log.error("Service {} not found for multisig {}", [
-        multisig.serviceId.toString(),
-        event.address.toHexString(),
-      ]);
-    }
+  if (multisig == null) {
+    return;
   }
+
+  let service = Service.load(multisig.serviceId.toString());
+  if (service == null || service.state != "Deployed") {
+    return;
+  }
+
+  updateDailyActivity(service, event, multisig);
+  updateDailyUniqueAgents(event, multisig);
+  updateDailyAgentPerformance(event, multisig);
+  updateDailyActiveMultisigs(event, multisig);
+  updateGlobalMetrics(event);
 }

--- a/subgraphs/service-registry/src/mapping.ts
+++ b/subgraphs/service-registry/src/mapping.ts
@@ -169,6 +169,7 @@ export function handleTerminateService(event: TerminateService): void {
   let service = Service.load(event.params.serviceId.toString());
   if (service != null) {
     service.agentIds = [];
+    service.multisig = null;
     service.save();
   }
 }

--- a/subgraphs/service-registry/src/utils.ts
+++ b/subgraphs/service-registry/src/utils.ts
@@ -30,6 +30,7 @@ export function getOrCreateService(
     service = new Service(serviceId.toString());
     service.agentIds = [];
     service.creationTimestamp = timestamp;
+    service.state = "PreRegistration";
     service.save();
   }
   return service;


### PR DESCRIPTION
Problem
The Scenario:

1. Service Terminated: agentIds are cleared [], but multisig remains set to the old address (this is the on-chain behavior).
2. Service Re-activated: ActivateRegistration event is emitted on-chain, but the subgraph has no handler for it.
3. Instances Registered: RegisterInstance events are emitted.

The Result in Subgraph:

- agentIds: Contains the new agent IDs from the new registration
- multisig: Still points to the previous (old) multisig address
- The multisig field is only updated when deploy is called again, emitting CreateMultisigWithAgents.

Additional Issue:

If the old multisig makes transactions after terminate but before new deploy, those transactions would still be tracked in DailyServiceActivity and agent performance metrics — associating them with a terminated service.
The Fix
1. Added ServiceState enum to the Service entity to mirror on-chain states:
   - PreRegistration, ActiveRegistration, FinishedRegistration, Deployed, TerminatedBonded
2. Track state transitions in handlers:

    - handleCreateService → PreRegistration
    - handleCreateMultisig → Deployed
    - handleTerminateService → TerminatedBonded

3. Added state check in execution handlers:

    - handleExecutionSuccess and handleExecutionFromModuleSuccess now skip activity tracking if service.state != "Deployed"
    - Prevents old multisig transactions from creating DailyServiceActivity entries for terminated services

Result:
On-chain parity maintained (multisig reference is NOT cleared on terminate)
Consumers can filter by state to distinguish service lifecycle stages
Old multisig activity after termination is not tracked against the service