### PR TITLE
docs: add navigation and architecture docs for legacy-mech-fees

### DIFF
--- a/subgraphs/legacy-mech-fees/CLAUDE.md
+++ b/subgraphs/legacy-mech-fees/CLAUDE.md
@@ -1,0 +1,32 @@
+# legacy-mech-fees/
+
+Gnosis Chain subgraph tracking fee flows for legacy mechs (LM) and marketplace mechs (LMM).
+
+## Files
+
+| File | What | When to read |
+| --- | --- | --- |
+| `README.md` | Architecture, entities, sample queries, data flow | Understanding subgraph design, writing queries, debugging fee calculations |
+| `schema.graphql` | Entity definitions (LegacyMech, LegacyMechMarketPlace, Global, DailyFees, MechDaily) | Adding/modifying entities, understanding data model |
+| `subgraph.yaml` | Data sources, factory contracts, event/call handlers, templates | Adding contracts, modifying event handlers, debugging indexing |
+| `package.json` | Build scripts (codegen, build, test) | Running builds, adding dependencies |
+| `tsconfig.json` | TypeScript configuration | Modifying TypeScript settings |
+
+## Subdirectories
+
+| Directory | What | When to read |
+| --- | --- | --- |
+| `src/` | Mapping handlers, utilities, known edge cases | Modifying fee tracking logic, debugging data gaps |
+
+## Commands
+
+```bash
+# Generate types from schema and ABIs
+yarn codegen
+
+# Build the subgraph
+yarn build
+
+# Run tests
+yarn test
+```

--- a/subgraphs/legacy-mech-fees/README.md
+++ b/subgraphs/legacy-mech-fees/README.md
@@ -43,7 +43,9 @@ All fee amounts in this subgraph are denominated in:
 - **Marketplace Mechs**: Transactions routed through the legacy marketplace
 
 ### Comprehensive Fee Flow Monitoring
-- **Incoming Fees**: Tracked via `Request` events and marketplace calls
+- **Incoming Fees**:
+  - **LM mechs**: Tracked via direct `Request` events on mech contracts
+  - **LMM mechs**: Tracked via `MarketplaceRequest` events from the marketplace contract
 - **Outgoing Fees**: Tracked via `exec` function calls (excluding burns)
 - **Price Updates**: Dynamic pricing changes tracked in real-time
 

--- a/subgraphs/legacy-mech-fees/src/CLAUDE.md
+++ b/subgraphs/legacy-mech-fees/src/CLAUDE.md
@@ -1,0 +1,12 @@
+# src/
+
+AssemblyScript mapping handlers for legacy mech fee tracking.
+
+## Files
+
+| File | What | When to read |
+| --- | --- | --- |
+| `README.md` | Handler architecture, burn filtering, fee flow, known edge cases | Understanding fee tracking design, debugging calculations, known data gaps |
+| `mapping.ts` | Event/call handlers for mech creation, fee-in, fee-out, price updates | Modifying fee tracking, adding new handlers |
+| `utils.ts` | Global state, daily aggregation, mech-daily tracking helpers | Modifying aggregation logic, adding new utility functions |
+| `constants.ts` | Burn address constant | Changing burn address filtering |

--- a/subgraphs/legacy-mech-fees/src/README.md
+++ b/subgraphs/legacy-mech-fees/src/README.md
@@ -1,0 +1,93 @@
+# Legacy Mech Fees - Source
+
+## Handler Architecture
+
+The subgraph tracks two distinct mech types with separate but parallel handler chains:
+
+**Legacy Mechs (LM)** - Direct user-to-mech interactions:
+- `handleCreateMechLM` → Creates entity, instantiates LegacyMech template
+- `handleRequest` → Tracks fee-in using mech's current price
+- `handleExecLM` → Tracks fee-out (excluding burns)
+- `handlePriceUpdateLM` → Updates mech price
+
+**Legacy Marketplace Mechs (LMM)** - Marketplace-mediated interactions:
+- `handleCreateMechLMM` → Creates entity, instantiates LegacyMechMarketPlace template
+- `handleMarketplaceRequest` → Tracks fee-in via marketplace event
+- `handleExecLMM` → Tracks fee-out (excluding burns)
+- `handlePriceUpdateLMM` → Updates mech price
+
+## Burn Address Filtering
+
+Outgoing transfers to `0x153196110040a0c729227c603db3a6c6d91851b2` are excluded from fee-out totals. This prevents artificial inflation of outgoing fee statistics from burn operations.
+
+Both `handleExecLM` and `handleExecLMM` check destination address and skip if it matches the burn address or amount is zero.
+
+## Fee-In Calculation
+
+Fee-in amount is determined by the mech's current price at the time of request:
+- **LM mechs**: `handleRequest` reads `mech.price` directly from entity
+- **LMM mechs**: `handleMarketplaceRequest` calls `getMechPrice()` which binds to the contract and reads current price
+
+## Aggregation Layers
+
+Each fee event updates three aggregation levels:
+1. **Entity level** - `totalFeesIn`/`totalFeesOut` on individual mech
+2. **Global level** - System-wide totals with type breakdown
+3. **Daily level** - Both global (`DailyFees`) and per-mech (`MechDaily`)
+
+Daily IDs use Unix timestamp truncated to day boundaries (86400 seconds).
+
+## Price Lookup Fallback
+
+`getMechPrice()` tries LMM contract binding first, falls back to LM binding. This handles marketplace requests that could target either mech type, though in practice marketplace requests target LMM mechs.
+
+## Known Behaviors
+
+### Silent Price Lookup Failure
+
+`getMechPrice()` returns `0` when both contract bindings fail (both `try_price()` calls revert). In `handleMarketplaceRequest`, fees ≤ 0 trigger an early return with no logging:
+
+```typescript
+const fee = getMechPrice(mechAddress);
+if (fee.le(BigInt.fromI32(0))) {
+  return;  // Silent exit - no warning logged
+}
+```
+
+**Impact**: If a marketplace request targets an address where price cannot be retrieved (wrong contract type, destroyed contract, RPC failure during sync), the entire request is dropped from indexed data without any trace.
+
+**When this can happen**:
+- Marketplace routes request to non-mech address
+- Contract upgraded or self-destructed between creation and request
+- Temporary RPC issues during subgraph indexing
+
+### Asymmetric Null Mech Handling
+
+The two fee-in handlers behave differently when the mech entity doesn't exist:
+
+**LM handler (`handleRequest`)**:
+```typescript
+if (mech == null) {
+  log.warning('Request received for unknown LegacyMech...');
+  return;  // Early exit - NO global/daily updates
+}
+```
+
+**LMM handler (`handleMarketplaceRequest`)**:
+```typescript
+if (mech != null) {
+  // Update mech...
+} else {
+  log.warning('Marketplace request received for unknown LegacyMechMarketPlace...');
+}
+// CONTINUES regardless - updates Global and DailyFees
+updateGlobalFeesInLegacyMechMarketPlace(fee);
+```
+
+**Impact**: For unknown LMM mechs, fees are counted in `Global.totalFeesInLegacyMechMarketPlace` and `DailyFees.totalFeesInLegacyMechMarketPlace` but not in any individual mech's `totalFeesIn`. This creates "orphaned fees" where:
+
+```
+Sum of all LegacyMechMarketPlace.totalFeesIn ≠ Global.totalFeesInLegacyMechMarketPlace
+```
+
+This asymmetry is intentional - marketplace requests are recorded at the global level even when the specific mech isn't tracked, ensuring fee totals reflect actual blockchain activity.


### PR DESCRIPTION
## Summary

- Add CLAUDE.md navigation indexes for root and src/ directories
- Add src/README.md documenting handler architecture and invisible knowledge
- Clarify LM vs LMM fee tracking mechanisms in README.md
- Document known edge cases and data gap scenarios

## Changes

### New Files
- `subgraphs/legacy-mech-fees/CLAUDE.md` - Navigation index with file descriptions and build commands
- `subgraphs/legacy-mech-fees/src/CLAUDE.md` - Source directory navigation index
- `subgraphs/legacy-mech-fees/src/README.md` - Handler architecture, burn filtering, known behaviors

### Modified Files
- `subgraphs/legacy-mech-fees/README.md` - Clarified fee tracking: LM uses direct Request events, LMM uses MarketplaceRequest events

## Known Behaviors Documented

1. **Silent Price Lookup Failure**: `getMechPrice()` returns 0 on contract call failures, causing marketplace requests to be silently dropped
2. **Asymmetric Null Handling**: LMM handler updates Global/DailyFees even when mech not found, creating "orphaned fees" where individual mech sums may not match global totals

## Test plan

- [ ] Verify documentation renders correctly on GitHub
- [ ] Confirm no changes to subgraph logic (docs only)