### PR TITLE
docs: add documentation for new-mech-fees subgraph

### DIFF
--- a/subgraphs/new-mech-fees/CLAUDE.md
+++ b/subgraphs/new-mech-fees/CLAUDE.md
@@ -1,0 +1,23 @@
+# new-mech-fees
+
+Subgraph indexing mech fee transactions across three payment models (native, NVM, token) on Gnosis and Base networks.
+
+## Files
+
+| File | What | When to read |
+| ---- | ---- | ------------ |
+| `README.md` | Architecture, raw unit semantics, sample queries | Understanding payment models, querying data, validating against Dune |
+
+## Directories
+
+| Directory | What | When to read |
+| --------- | ---- | ------------ |
+| `common/` | Shared schema, utilities, constants | Modifying entity structure, adding conversion functions, understanding USD calculations |
+| `mech-fees-base/` | Base network composite subgraph config | Deploying to Base, adding data sources |
+| `mech-fees-gnosis/` | Gnosis network composite subgraph config | Deploying to Gnosis, adding data sources |
+| `new-native-mech-fees-base/` | Native payment model handlers for Base | Debugging Base native fee indexing, modifying ETH price conversion |
+| `new-native-mech-fees-gnosis/` | Native payment model handlers for Gnosis | Debugging Gnosis native fee indexing (xDAI ≈ USD) |
+| `new-nvm-mech-fees-base/` | NVM subscription handlers for Base | Debugging Base NVM indexing, modifying USDC credit conversion |
+| `new-nvm-mech-fees-gnosis/` | NVM subscription handlers for Gnosis | Debugging Gnosis NVM indexing, modifying xDAI credit conversion |
+| `new-token-mech-fees-base/` | OLAS token handlers for Base | Debugging Base OLAS indexing, modifying Balancer pool price fetch |
+| `new-token-mech-fees-gnosis/` | OLAS token handlers for Gnosis | Debugging Gnosis OLAS indexing, modifying Balancer pool price fetch |

--- a/subgraphs/new-mech-fees/common/CLAUDE.md
+++ b/subgraphs/new-mech-fees/common/CLAUDE.md
@@ -1,0 +1,19 @@
+# common
+
+Shared schema, utilities, and constants used by all payment model handlers.
+
+## Files
+
+| File | What | When to read |
+| ---- | ---- | ------------ |
+| `README.md` | Architecture decisions, raw unit semantics, NVM credit formulas | Understanding why raw units differ across models, credit-to-USD conversion logic |
+| `schema.graphql` | Entity definitions (Mech, MechModel, MechTransaction, DailyTotals, MechDaily, Global) | Adding fields, creating new entities, understanding data model |
+| `utils.ts` | Entity helpers, USD conversion functions, daily aggregation logic | Modifying fee calculations, adding new conversion functions, fixing aggregation bugs |
+| `constants.ts` | NVM token ratios and decimal configurations per network | Adjusting credit conversion constants, adding new network support |
+| `token-utils.ts` | Balancer V2 pool price calculation for OLAS→USD | Debugging OLAS price fetching, modifying pool query logic |
+
+## Directories
+
+| Directory | What | When to read |
+| --------- | ---- | ------------ |
+| `generated/` | Auto-generated TypeScript bindings from ABIs and schema | Understanding available contract methods, entity field types |

--- a/subgraphs/new-mech-fees/common/README.md
+++ b/subgraphs/new-mech-fees/common/README.md
@@ -1,0 +1,74 @@
+# Common Utilities
+
+Shared code for all payment model handlers in the new-mech-fees subgraph.
+
+## Raw Unit Semantics
+
+The `totalFeesInRaw` / `totalFeesOutRaw` and `amountRaw` fields store values in **payment-model-specific units** that are NOT comparable across models:
+
+| Model | Raw Unit | Precision |
+| ----- | -------- | --------- |
+| `native` | wei (xDAI on Gnosis, ETH on Base) | 10^18 |
+| `token` | OLAS wei | 10^18 |
+| `nvm` | Credits (from `deliveryRate`) | Dimensionless |
+
+Use `MechModel` entity to get per-model raw totals. The aggregate `Mech.totalFeesInRaw` mixes incompatible units if the mech participates in multiple models.
+
+## NVM Credit Conversion
+
+NVM fees use abstract "credits" internally. The credit→USD conversion differs by network:
+
+**Gnosis (xDAI settlement):**
+```
+USD = credits × TOKEN_RATIO_GNOSIS / (1e18 × 1e18)
+    = credits × 990000000000000000000000000000 / 1e36
+```
+
+**Base (USDC settlement):**
+```
+USD = credits × TOKEN_RATIO_BASE / (1e18 × 1e6)
+    = credits × 990000000000000000 / 1e24
+```
+
+The ratios encode the token price assumption (0.99 USD per credit unit after platform fee).
+
+## Fee-Out Credit Reconstruction
+
+For NVM `FEE_OUT` (withdrawals), the raw amount stores reconstructed credits, not settlement token wei. This maintains credit-level consistency:
+
+```typescript
+// Gnosis: xDAI wei → credits
+credits = xdai_wei × 1e18 × 1e18 / TOKEN_RATIO_GNOSIS
+
+// Base: USDC → credits
+credits = usdc × 1e18 × 1e6 / TOKEN_RATIO_BASE
+```
+
+This allows `totalFeesInRaw - totalFeesOutRaw` to yield a meaningful credit balance within the NVM model.
+
+## Daily Aggregation Zero-Check Logic
+
+Daily aggregation functions use different skip conditions based on the fields they track:
+
+**DailyTotals** (global totals across all mechs):
+- Tracks: USD only
+- Skip condition: `amountUsd <= 0`
+- Rationale: Since only USD is tracked, skip if USD has no value
+
+**MechDaily** (per-mech totals):
+- Tracks: Both USD and raw values
+- Skip condition: `amountUsd <= 0 AND amountRaw <= 0`
+- Rationale: Update if either metric has value, since both are tracked independently
+
+This allows MechDaily to record transactions where USD conversion fails (returns 0) but raw amount exists, preserving raw-value continuity for debugging.
+
+## USD Conversion Functions
+
+| Function | Network | Input | Output |
+| -------- | ------- | ----- | ------ |
+| `convertGnosisNativeWeiToUsd` | Gnosis | xDAI wei | USD (1:1) |
+| `convertBaseNativeWeiToUsd` | Base | ETH wei + Chainlink price | USD |
+| `calculateGnosisNvmFeesIn` | Gnosis | Credits | USD via token ratio |
+| `calculateBaseNvmFeesIn` | Base | Credits | USD (via USDC, assuming 1:1 parity) |
+| `calculateBaseNvmFeesInUsd` | Base | Credits + Chainlink price | USD |
+| `calculateOlasInUsd` | Both | OLAS wei | USD via Balancer pool |

--- a/subgraphs/new-mech-fees/common/schema.graphql
+++ b/subgraphs/new-mech-fees/common/schema.graphql
@@ -33,9 +33,9 @@ type MechTransaction @entity(immutable: true) {
   timestamp: BigInt!
   blockNumber: BigInt!
   txHash: Bytes!
-  deliveryRate: BigInt
-  balance: BigInt
-  rateDiff: BigInt
+  deliveryRate: BigInt # FEE_IN only: NVM delivery rate at transaction time
+  balance: BigInt # FEE_IN only: NVM balance after credit issuance
+  rateDiff: BigInt # FEE_IN only: Difference from previous delivery rate
 }
 
 type DailyTotals @entity(immutable: false) {

--- a/subgraphs/new-mech-fees/mech-fees-base/CLAUDE.md
+++ b/subgraphs/new-mech-fees/mech-fees-base/CLAUDE.md
@@ -1,0 +1,9 @@
+# mech-fees-base
+
+Composite subgraph configuration for Base network, combining all three payment models.
+
+## Files
+
+| File | What | When to read |
+| ---- | ---- | ------------ |
+| `subgraph.yaml` | Data source definitions, contract addresses, event handlers, ABI references | Deploying to Base, updating contract addresses, adding new payment models |

--- a/subgraphs/new-mech-fees/mech-fees-gnosis/CLAUDE.md
+++ b/subgraphs/new-mech-fees/mech-fees-gnosis/CLAUDE.md
@@ -1,0 +1,9 @@
+# mech-fees-gnosis
+
+Composite subgraph configuration for Gnosis network, combining all three payment models.
+
+## Files
+
+| File | What | When to read |
+| ---- | ---- | ------------ |
+| `subgraph.yaml` | Data source definitions, contract addresses, event handlers, ABI references | Deploying to Gnosis, updating contract addresses, adding new payment models |

--- a/subgraphs/new-mech-fees/new-native-mech-fees-base/CLAUDE.md
+++ b/subgraphs/new-mech-fees/new-native-mech-fees-base/CLAUDE.md
@@ -1,0 +1,9 @@
+# new-native-mech-fees-base
+
+Native payment model (ETH) event handlers for Base network.
+
+## Directories
+
+| Directory | What | When to read |
+| --------- | ---- | ------------ |
+| `src/` | Event handlers for MechBalanceAdjusted and Withdraw | Debugging native fee indexing on Base, modifying ETH→USD conversion |

--- a/subgraphs/new-mech-fees/new-native-mech-fees-base/src/CLAUDE.md
+++ b/subgraphs/new-mech-fees/new-native-mech-fees-base/src/CLAUDE.md
@@ -1,0 +1,9 @@
+# src
+
+Native payment model handlers for Base.
+
+## Files
+
+| File | What | When to read |
+| ---- | ---- | ------------ |
+| `mapping.ts` | Event handlers: handleMechBalanceAdjustedForNative, handleWithdrawForNative | Debugging fee accrual/collection, modifying Chainlink ETH price integration |

--- a/subgraphs/new-mech-fees/new-native-mech-fees-gnosis/CLAUDE.md
+++ b/subgraphs/new-mech-fees/new-native-mech-fees-gnosis/CLAUDE.md
@@ -1,0 +1,9 @@
+# new-native-mech-fees-gnosis
+
+Native payment model (xDAI) event handlers for Gnosis network.
+
+## Directories
+
+| Directory | What | When to read |
+| --------- | ---- | ------------ |
+| `src/` | Event handlers for MechBalanceAdjusted and Withdraw | Debugging native fee indexing on Gnosis, modifying xDAI→USD conversion |

--- a/subgraphs/new-mech-fees/new-native-mech-fees-gnosis/src/CLAUDE.md
+++ b/subgraphs/new-mech-fees/new-native-mech-fees-gnosis/src/CLAUDE.md
@@ -1,0 +1,9 @@
+# src
+
+Native payment model handlers for Gnosis.
+
+## Files
+
+| File | What | When to read |
+| ---- | ---- | ------------ |
+| `mapping.ts` | Event handlers: handleMechBalanceAdjustedForNative, handleWithdrawForNative | Debugging fee accrual/collection, understanding xDAI→USD (1:1) conversion |

--- a/subgraphs/new-mech-fees/new-nvm-mech-fees-base/CLAUDE.md
+++ b/subgraphs/new-mech-fees/new-nvm-mech-fees-base/CLAUDE.md
@@ -1,0 +1,9 @@
+# new-nvm-mech-fees-base
+
+NVM subscription payment model event handlers for Base network.
+
+## Directories
+
+| Directory | What | When to read |
+| --------- | ---- | ------------ |
+| `src/` | Event handlers for MechBalanceAdjusted and Withdraw | Debugging NVM fee indexing on Base, modifying credit→USDC conversion |

--- a/subgraphs/new-mech-fees/new-nvm-mech-fees-base/src/CLAUDE.md
+++ b/subgraphs/new-mech-fees/new-nvm-mech-fees-base/src/CLAUDE.md
@@ -1,0 +1,9 @@
+# src
+
+NVM subscription payment model handlers for Base.
+
+## Files
+
+| File | What | When to read |
+| ---- | ---- | ------------ |
+| `mapping.ts` | Event handlers: handleMechBalanceAdjustedForNvm, handleWithdrawForNvm | Debugging NVM credit→USDC conversion, understanding fee-out credit reconstruction |

--- a/subgraphs/new-mech-fees/new-nvm-mech-fees-gnosis/CLAUDE.md
+++ b/subgraphs/new-mech-fees/new-nvm-mech-fees-gnosis/CLAUDE.md
@@ -1,0 +1,9 @@
+# new-nvm-mech-fees-gnosis
+
+NVM subscription payment model event handlers for Gnosis network.
+
+## Directories
+
+| Directory | What | When to read |
+| --------- | ---- | ------------ |
+| `src/` | Event handlers for MechBalanceAdjusted and Withdraw | Debugging NVM fee indexing on Gnosis, modifying credit→xDAI conversion |

--- a/subgraphs/new-mech-fees/new-nvm-mech-fees-gnosis/src/CLAUDE.md
+++ b/subgraphs/new-mech-fees/new-nvm-mech-fees-gnosis/src/CLAUDE.md
@@ -1,0 +1,9 @@
+# src
+
+NVM subscription payment model handlers for Gnosis.
+
+## Files
+
+| File | What | When to read |
+| ---- | ---- | ------------ |
+| `mapping.ts` | Event handlers: handleMechBalanceAdjustedForNvm, handleWithdrawForNvm | Debugging NVM credit→xDAI conversion, understanding fee-out credit reconstruction |

--- a/subgraphs/new-mech-fees/new-token-mech-fees-base/CLAUDE.md
+++ b/subgraphs/new-mech-fees/new-token-mech-fees-base/CLAUDE.md
@@ -1,0 +1,9 @@
+# new-token-mech-fees-base
+
+OLAS token payment model event handlers for Base network.
+
+## Directories
+
+| Directory | What | When to read |
+| --------- | ---- | ------------ |
+| `src/` | Event handlers for MechBalanceAdjusted and Withdraw | Debugging OLAS fee indexing on Base, modifying Balancer pool price fetch |

--- a/subgraphs/new-mech-fees/new-token-mech-fees-base/src/CLAUDE.md
+++ b/subgraphs/new-mech-fees/new-token-mech-fees-base/src/CLAUDE.md
@@ -1,0 +1,9 @@
+# src
+
+OLAS token payment model handlers for Base.
+
+## Files
+
+| File | What | When to read |
+| ---- | ---- | ------------ |
+| `mapping.ts` | Event handlers: handleMechBalanceAdjustedForToken, handleWithdrawForToken | Debugging OLAS→USD via Balancer pool, understanding pool ID fetching |

--- a/subgraphs/new-mech-fees/new-token-mech-fees-gnosis/CLAUDE.md
+++ b/subgraphs/new-mech-fees/new-token-mech-fees-gnosis/CLAUDE.md
@@ -1,0 +1,9 @@
+# new-token-mech-fees-gnosis
+
+OLAS token payment model event handlers for Gnosis network.
+
+## Directories
+
+| Directory | What | When to read |
+| --------- | ---- | ------------ |
+| `src/` | Event handlers for MechBalanceAdjusted and Withdraw | Debugging OLAS fee indexing on Gnosis, modifying Balancer pool price fetch |

--- a/subgraphs/new-mech-fees/new-token-mech-fees-gnosis/src/CLAUDE.md
+++ b/subgraphs/new-mech-fees/new-token-mech-fees-gnosis/src/CLAUDE.md
@@ -1,0 +1,9 @@
+# src
+
+OLAS token payment model handlers for Gnosis.
+
+## Files
+
+| File | What | When to read |
+| ---- | ---- | ------------ |
+| `mapping.ts` | Event handlers: handleMechBalanceAdjustedForToken, handleWithdrawForToken | Debugging OLAS→USD via Balancer pool, understanding pool ID fetching |


### PR DESCRIPTION
## Summary

- Add CLAUDE.md navigation indexes across all directories in `new-mech-fees/`
- Add `common/README.md` documenting invisible knowledge (raw unit semantics, NVM credit conversion formulas, daily aggregation logic)
- Add inline comments to `schema.graphql` clarifying FEE_IN-only fields