### PR TITLE
test: add Matchstick tests for 6 subgraphs + CI workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,84 @@
+name: Subgraph Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Standalone manifests (subgraph.yaml exists)
+          - subgraph: liquidity
+            path: subgraphs/liquidity
+          - subgraph: tokenomics-eth
+            path: subgraphs/tokenomics-eth
+          - subgraph: governance
+            path: subgraphs/governance
+          - subgraph: legacy-mech-fees
+            path: subgraphs/legacy-mech-fees
+
+          # Template pattern — need generate-manifests + symlink
+          - subgraph: liquidity-l2
+            path: subgraphs/liquidity-l2
+            manifest: subgraph.gnosis.yaml
+            generate: true
+          - subgraph: staking
+            path: subgraphs/staking
+            manifest: subgraph.gnosis.yaml
+            generate: true
+          - subgraph: tokenomics-l2
+            path: subgraphs/tokenomics-l2
+            manifest: subgraph.gnosis.yaml
+            generate: true
+          - subgraph: service-registry
+            path: subgraphs/service-registry
+            manifest: subgraph.gnosis.yaml
+            generate: true
+
+          # Per-network manifests — need symlink only
+          - subgraph: new-mech-fees
+            path: subgraphs/new-mech-fees
+            manifest: subgraph.gnosis.yaml
+
+          # Nested subgraphs with standalone manifests
+          - subgraph: predict-omen
+            path: subgraphs/predict/predict-omen
+          - subgraph: predict-polymarket
+            path: subgraphs/predict/predict-polymarket
+          - subgraph: babydegen-optimism
+            path: subgraphs/babydegen/babydegen-optimism
+
+    name: test / ${{ matrix.subgraph }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        working-directory: ${{ matrix.path }}
+        run: yarn install --frozen-lockfile || yarn install
+
+      - name: Generate manifests
+        if: matrix.generate
+        working-directory: ${{ matrix.path }}
+        run: yarn generate-manifests
+
+      - name: Create subgraph.yaml symlink
+        if: matrix.manifest
+        working-directory: ${{ matrix.path }}
+        run: ln -sf ${{ matrix.manifest }} subgraph.yaml
+
+      - name: Generate types
+        working-directory: ${{ matrix.path }}
+        run: yarn graph codegen
+
+      - name: Run tests
+        working-directory: ${{ matrix.path }}
+        run: yarn graph test

--- a/subgraphs/babydegen/babydegen-optimism/tests/mapping-utils.ts
+++ b/subgraphs/babydegen/babydegen-optimism/tests/mapping-utils.ts
@@ -1,0 +1,79 @@
+import { newMockEvent } from "matchstick-as"
+import { ethereum, Address, BigInt } from "@graphprotocol/graph-ts"
+import {
+  RegisterInstance,
+  CreateMultisigWithAgents
+} from "../generated/ServiceRegistryL2/ServiceRegistryL2"
+
+/**
+ * Creates a mock RegisterInstance event.
+ *
+ * Solidity signature:
+ *   RegisterInstance(indexed address operator, indexed uint256 serviceId,
+ *                    indexed address agentInstance, uint256 agentId)
+ */
+export function createRegisterInstanceEvent(
+  operator: Address,
+  serviceId: BigInt,
+  agentInstance: Address,
+  agentId: BigInt
+): RegisterInstance {
+  let event = changetype<RegisterInstance>(newMockEvent())
+  event.parameters = new Array()
+
+  event.parameters.push(
+    new ethereum.EventParam(
+      "operator",
+      ethereum.Value.fromAddress(operator)
+    )
+  )
+  event.parameters.push(
+    new ethereum.EventParam(
+      "serviceId",
+      ethereum.Value.fromUnsignedBigInt(serviceId)
+    )
+  )
+  event.parameters.push(
+    new ethereum.EventParam(
+      "agentInstance",
+      ethereum.Value.fromAddress(agentInstance)
+    )
+  )
+  event.parameters.push(
+    new ethereum.EventParam(
+      "agentId",
+      ethereum.Value.fromUnsignedBigInt(agentId)
+    )
+  )
+
+  return event
+}
+
+/**
+ * Creates a mock CreateMultisigWithAgents event.
+ *
+ * Solidity signature:
+ *   CreateMultisigWithAgents(indexed uint256 serviceId, indexed address multisig)
+ */
+export function createCreateMultisigWithAgentsEvent(
+  serviceId: BigInt,
+  multisig: Address
+): CreateMultisigWithAgents {
+  let event = changetype<CreateMultisigWithAgents>(newMockEvent())
+  event.parameters = new Array()
+
+  event.parameters.push(
+    new ethereum.EventParam(
+      "serviceId",
+      ethereum.Value.fromUnsignedBigInt(serviceId)
+    )
+  )
+  event.parameters.push(
+    new ethereum.EventParam(
+      "multisig",
+      ethereum.Value.fromAddress(multisig)
+    )
+  )
+
+  return event
+}

--- a/subgraphs/babydegen/babydegen-optimism/tests/mapping.test.ts
+++ b/subgraphs/babydegen/babydegen-optimism/tests/mapping.test.ts
@@ -1,0 +1,378 @@
+import {
+  assert,
+  describe,
+  test,
+  clearStore,
+  afterEach,
+  createMockedFunction
+} from "matchstick-as/assembly/index"
+import { BigInt, Bytes, ethereum } from "@graphprotocol/graph-ts"
+import {
+  handleRegisterInstance,
+  handleCreateMultisigWithAgents
+} from "../src/serviceRegistry"
+import {
+  createRegisterInstanceEvent,
+  createCreateMultisigWithAgentsEvent
+} from "./mapping-utils"
+import {
+  OPERATOR_SAFE,
+  AGENT_INSTANCE,
+  SERVICE_SAFE,
+  SERVICE_ID,
+  EXCLUDED_SERVICE_ID,
+  OPTIMUS_AGENT_ID,
+  NON_OPTIMUS_AGENT_ID,
+  BLOCK_NUMBER,
+  BLOCK_TIMESTAMP,
+  TX_HASH,
+  ETH_USD_FEED,
+  ETH_PRICE_RAW
+} from "./test-helpers"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Mock the Chainlink ETH/USD latestRoundData call so that
+ * ensureAgentPortfolio -> getEthUsd -> fetchFeedUsd works without reverting.
+ *
+ * latestRoundData() returns (uint80 roundId, int256 answer, uint256 startedAt,
+ *                            uint256 updatedAt, uint80 answeredInRound)
+ */
+function mockChainlinkEthUsd(): void {
+  createMockedFunction(
+    ETH_USD_FEED,
+    "latestRoundData",
+    "latestRoundData():(uint80,int256,uint256,uint256,uint80)"
+  )
+    .withArgs([])
+    .returns([
+      ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(1)),   // roundId
+      ethereum.Value.fromSignedBigInt(ETH_PRICE_RAW),         // answer ($2000)
+      ethereum.Value.fromUnsignedBigInt(BLOCK_TIMESTAMP),     // startedAt
+      ethereum.Value.fromUnsignedBigInt(BLOCK_TIMESTAMP),     // updatedAt
+      ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(1))    // answeredInRound
+    ])
+}
+
+/**
+ * Creates a RegisterInstance event with default block metadata, fires the
+ * handler, and returns the event for further inspection if needed.
+ */
+function registerService(
+  serviceId: BigInt = SERVICE_ID,
+  agentId: BigInt = OPTIMUS_AGENT_ID
+): void {
+  let event = createRegisterInstanceEvent(
+    OPERATOR_SAFE,
+    serviceId,
+    AGENT_INSTANCE,
+    agentId
+  )
+  event.block.number = BLOCK_NUMBER
+  event.block.timestamp = BLOCK_TIMESTAMP
+  event.transaction.hash = TX_HASH
+  handleRegisterInstance(event)
+}
+
+// ---------------------------------------------------------------------------
+// Tests — handleRegisterInstance
+// ---------------------------------------------------------------------------
+
+describe("handleRegisterInstance", () => {
+  afterEach(() => {
+    clearStore()
+  })
+
+  test("creates ServiceRegistration entity with correct fields", () => {
+    registerService()
+
+    assert.entityCount("ServiceRegistration", 1)
+
+    // ServiceRegistration ID is Bytes.fromUTF8(serviceId.toString())
+    let id = Bytes.fromUTF8(SERVICE_ID.toString())
+
+    assert.fieldEquals(
+      "ServiceRegistration",
+      id.toHexString(),
+      "serviceId",
+      SERVICE_ID.toString()
+    )
+    assert.fieldEquals(
+      "ServiceRegistration",
+      id.toHexString(),
+      "operatorSafe",
+      OPERATOR_SAFE.toHexString()
+    )
+    assert.fieldEquals(
+      "ServiceRegistration",
+      id.toHexString(),
+      "registrationBlock",
+      BLOCK_NUMBER.toString()
+    )
+    assert.fieldEquals(
+      "ServiceRegistration",
+      id.toHexString(),
+      "registrationTimestamp",
+      BLOCK_TIMESTAMP.toString()
+    )
+    assert.fieldEquals(
+      "ServiceRegistration",
+      id.toHexString(),
+      "registrationTxHash",
+      TX_HASH.toHexString()
+    )
+  })
+
+  test("ignores non-Optimus agent IDs", () => {
+    registerService(SERVICE_ID, NON_OPTIMUS_AGENT_ID)
+
+    assert.entityCount("ServiceRegistration", 0)
+  })
+
+  test("ignores excluded service IDs", () => {
+    // Service ID 29 is in the EXCLUDED_SERVICE_IDS list
+    registerService(EXCLUDED_SERVICE_ID, OPTIMUS_AGENT_ID)
+
+    assert.entityCount("ServiceRegistration", 0)
+  })
+
+  test("overwrites registration for same service ID", () => {
+    // First registration
+    registerService()
+
+    // Second registration with a different block number
+    let event = createRegisterInstanceEvent(
+      OPERATOR_SAFE,
+      SERVICE_ID,
+      AGENT_INSTANCE,
+      OPTIMUS_AGENT_ID
+    )
+    let newBlock = BigInt.fromI32(136700000)
+    event.block.number = newBlock
+    event.block.timestamp = BLOCK_TIMESTAMP
+    event.transaction.hash = TX_HASH
+    handleRegisterInstance(event)
+
+    // Still only one entity — it was overwritten
+    assert.entityCount("ServiceRegistration", 1)
+
+    let id = Bytes.fromUTF8(SERVICE_ID.toString())
+    assert.fieldEquals(
+      "ServiceRegistration",
+      id.toHexString(),
+      "registrationBlock",
+      newBlock.toString()
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests — handleCreateMultisigWithAgents
+// ---------------------------------------------------------------------------
+
+describe("handleCreateMultisigWithAgents", () => {
+  afterEach(() => {
+    clearStore()
+  })
+
+  test("does nothing when no prior ServiceRegistration exists", () => {
+    // Fire CreateMultisigWithAgents without a preceding RegisterInstance
+    mockChainlinkEthUsd()
+
+    let event = createCreateMultisigWithAgentsEvent(SERVICE_ID, SERVICE_SAFE)
+    event.block.number = BLOCK_NUMBER
+    event.block.timestamp = BLOCK_TIMESTAMP
+    event.transaction.hash = TX_HASH
+    handleCreateMultisigWithAgents(event)
+
+    // No Service entity should be created
+    assert.entityCount("Service", 0)
+  })
+
+  test("does nothing for excluded service IDs", () => {
+    mockChainlinkEthUsd()
+
+    // Register first (will be skipped because excluded)
+    registerService(EXCLUDED_SERVICE_ID, OPTIMUS_AGENT_ID)
+    assert.entityCount("ServiceRegistration", 0)
+
+    let event = createCreateMultisigWithAgentsEvent(
+      EXCLUDED_SERVICE_ID,
+      SERVICE_SAFE
+    )
+    event.block.number = BLOCK_NUMBER
+    event.block.timestamp = BLOCK_TIMESTAMP
+    event.transaction.hash = TX_HASH
+    handleCreateMultisigWithAgents(event)
+
+    assert.entityCount("Service", 0)
+  })
+
+  test("creates Service entity with correct fields after RegisterInstance", () => {
+    mockChainlinkEthUsd()
+
+    // Step 1: Register the service (creates ServiceRegistration)
+    registerService()
+    assert.entityCount("ServiceRegistration", 1)
+
+    // Step 2: Create multisig (creates Service)
+    let multisigTimestamp = BigInt.fromI32(1700001000)
+    let multisigBlock = BigInt.fromI32(136601000)
+    let multisigTxHash = Bytes.fromHexString(
+      "0x1111111111111111111111111111111111111111111111111111111111111111"
+    )
+
+    let event = createCreateMultisigWithAgentsEvent(SERVICE_ID, SERVICE_SAFE)
+    event.block.number = multisigBlock
+    event.block.timestamp = multisigTimestamp
+    event.transaction.hash = multisigTxHash
+    handleCreateMultisigWithAgents(event)
+
+    assert.entityCount("Service", 1)
+
+    // Service ID is the multisig address (as Bytes)
+    let serviceEntityId = SERVICE_SAFE.toHexString()
+
+    assert.fieldEquals(
+      "Service",
+      serviceEntityId,
+      "serviceId",
+      SERVICE_ID.toString()
+    )
+    assert.fieldEquals(
+      "Service",
+      serviceEntityId,
+      "operatorSafe",
+      OPERATOR_SAFE.toHexString()
+    )
+    assert.fieldEquals(
+      "Service",
+      serviceEntityId,
+      "serviceSafe",
+      SERVICE_SAFE.toHexString()
+    )
+    assert.fieldEquals("Service", serviceEntityId, "isActive", "true")
+
+    // Registration metadata should come from the ServiceRegistration entity
+    assert.fieldEquals(
+      "Service",
+      serviceEntityId,
+      "latestRegistrationBlock",
+      BLOCK_NUMBER.toString()
+    )
+    assert.fieldEquals(
+      "Service",
+      serviceEntityId,
+      "latestRegistrationTimestamp",
+      BLOCK_TIMESTAMP.toString()
+    )
+    assert.fieldEquals(
+      "Service",
+      serviceEntityId,
+      "latestRegistrationTxHash",
+      TX_HASH.toHexString()
+    )
+
+    // Multisig metadata should come from the CreateMultisigWithAgents event
+    assert.fieldEquals(
+      "Service",
+      serviceEntityId,
+      "latestMultisigBlock",
+      multisigBlock.toString()
+    )
+    assert.fieldEquals(
+      "Service",
+      serviceEntityId,
+      "latestMultisigTimestamp",
+      multisigTimestamp.toString()
+    )
+    assert.fieldEquals(
+      "Service",
+      serviceEntityId,
+      "latestMultisigTxHash",
+      multisigTxHash.toHexString()
+    )
+  })
+
+  test("creates ServiceIndex entity pointing to the service safe", () => {
+    mockChainlinkEthUsd()
+
+    registerService()
+
+    let event = createCreateMultisigWithAgentsEvent(SERVICE_ID, SERVICE_SAFE)
+    event.block.number = BLOCK_NUMBER
+    event.block.timestamp = BLOCK_TIMESTAMP
+    event.transaction.hash = TX_HASH
+    handleCreateMultisigWithAgents(event)
+
+    assert.entityCount("ServiceIndex", 1)
+
+    let indexId = Bytes.fromUTF8(SERVICE_ID.toString())
+    assert.fieldEquals(
+      "ServiceIndex",
+      indexId.toHexString(),
+      "serviceId",
+      SERVICE_ID.toString()
+    )
+    assert.fieldEquals(
+      "ServiceIndex",
+      indexId.toHexString(),
+      "currentServiceSafe",
+      SERVICE_SAFE.toHexString()
+    )
+  })
+
+  test("registers service in ServiceRegistry singleton for snapshots", () => {
+    mockChainlinkEthUsd()
+
+    registerService()
+
+    let event = createCreateMultisigWithAgentsEvent(SERVICE_ID, SERVICE_SAFE)
+    event.block.number = BLOCK_NUMBER
+    event.block.timestamp = BLOCK_TIMESTAMP
+    event.transaction.hash = TX_HASH
+    handleCreateMultisigWithAgents(event)
+
+    let registryId = Bytes.fromUTF8("registry")
+    assert.entityCount("ServiceRegistry", 1)
+    assert.fieldEquals(
+      "ServiceRegistry",
+      registryId.toHexString(),
+      "serviceAddresses",
+      "[" + SERVICE_SAFE.toHexString() + "]"
+    )
+  })
+
+  test("creates AgentPortfolio entity for new service", () => {
+    mockChainlinkEthUsd()
+
+    registerService()
+
+    let event = createCreateMultisigWithAgentsEvent(SERVICE_ID, SERVICE_SAFE)
+    event.block.number = BLOCK_NUMBER
+    event.block.timestamp = BLOCK_TIMESTAMP
+    event.transaction.hash = TX_HASH
+    handleCreateMultisigWithAgents(event)
+
+    assert.entityCount("AgentPortfolio", 1)
+
+    let portfolioId = SERVICE_SAFE.toHexString()
+    assert.fieldEquals(
+      "AgentPortfolio",
+      portfolioId,
+      "service",
+      SERVICE_SAFE.toHexString()
+    )
+    // firstTradingTimestamp should be set to the block timestamp since
+    // no prior funding exists (the handler uses it as fallback)
+    assert.fieldEquals(
+      "AgentPortfolio",
+      portfolioId,
+      "firstTradingTimestamp",
+      BLOCK_TIMESTAMP.toString()
+    )
+  })
+})

--- a/subgraphs/babydegen/babydegen-optimism/tests/test-helpers.ts
+++ b/subgraphs/babydegen/babydegen-optimism/tests/test-helpers.ts
@@ -1,0 +1,39 @@
+import { Address, BigInt, Bytes } from "@graphprotocol/graph-ts"
+
+// Test addresses
+export const OPERATOR_SAFE = Address.fromString(
+  "0x0000000000000000000000000000000000000001"
+)
+export const AGENT_INSTANCE = Address.fromString(
+  "0x0000000000000000000000000000000000000002"
+)
+export const SERVICE_SAFE = Address.fromString(
+  "0x0000000000000000000000000000000000000003"
+)
+// Default contract address used by newMockEvent()
+export const CONTRACT_ADDRESS = Address.fromString(
+  "0xa16081f360e3847006db660bae1c6d1b2e17ec2a"
+)
+
+// Chainlink ETH/USD feed address (Optimism)
+export const ETH_USD_FEED = Address.fromString(
+  "0x13e3Ee699D1909E989722E753853AE30b17e08c5"
+)
+
+// Service IDs
+export const SERVICE_ID = BigInt.fromI32(100)
+export const EXCLUDED_SERVICE_ID = BigInt.fromI32(29) // First excluded test service
+
+// Agent IDs
+export const OPTIMUS_AGENT_ID = BigInt.fromI32(40)
+export const NON_OPTIMUS_AGENT_ID = BigInt.fromI32(99)
+
+// Block / timestamp values
+export const BLOCK_NUMBER = BigInt.fromI32(136600000)
+export const BLOCK_TIMESTAMP = BigInt.fromI32(1700000000)
+export const TX_HASH = Bytes.fromHexString(
+  "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+)
+
+// ETH price in 8-decimal Chainlink format ($2000.00)
+export const ETH_PRICE_RAW = BigInt.fromI64(200000000000) // 2000 * 1e8

--- a/subgraphs/governance/tests/governor-olas-utils.ts
+++ b/subgraphs/governance/tests/governor-olas-utils.ts
@@ -1,0 +1,193 @@
+import { newMockEvent } from "matchstick-as"
+import { ethereum, Address, BigInt, Bytes } from "@graphprotocol/graph-ts"
+import {
+  ProposalCanceled,
+  ProposalCreated,
+  ProposalExecuted,
+  ProposalQueued,
+  ProposalThresholdSet,
+  QuorumNumeratorUpdated,
+  TimelockChange,
+  VoteCast,
+  VoteCastWithParams,
+  VotingDelaySet,
+  VotingPeriodSet
+} from "../generated/GovernorOLAS/GovernorOLAS"
+
+export function createProposalCreatedEvent(
+  proposalId: BigInt,
+  proposer: Address,
+  targets: Address[],
+  values: BigInt[],
+  signatures: string[],
+  calldatas: Bytes[],
+  startBlock: BigInt,
+  endBlock: BigInt,
+  description: string
+): ProposalCreated {
+  let event = changetype<ProposalCreated>(newMockEvent())
+  event.parameters = new Array()
+
+  event.parameters.push(
+    new ethereum.EventParam("proposalId", ethereum.Value.fromUnsignedBigInt(proposalId))
+  )
+  event.parameters.push(
+    new ethereum.EventParam("proposer", ethereum.Value.fromAddress(proposer))
+  )
+  event.parameters.push(
+    new ethereum.EventParam("targets", ethereum.Value.fromAddressArray(targets))
+  )
+  event.parameters.push(
+    new ethereum.EventParam("values", ethereum.Value.fromUnsignedBigIntArray(values))
+  )
+  event.parameters.push(
+    new ethereum.EventParam("signatures", ethereum.Value.fromStringArray(signatures))
+  )
+  event.parameters.push(
+    new ethereum.EventParam("calldatas", ethereum.Value.fromBytesArray(calldatas))
+  )
+  event.parameters.push(
+    new ethereum.EventParam("startBlock", ethereum.Value.fromUnsignedBigInt(startBlock))
+  )
+  event.parameters.push(
+    new ethereum.EventParam("endBlock", ethereum.Value.fromUnsignedBigInt(endBlock))
+  )
+  event.parameters.push(
+    new ethereum.EventParam("description", ethereum.Value.fromString(description))
+  )
+
+  return event
+}
+
+export function createProposalCanceledEvent(proposalId: BigInt): ProposalCanceled {
+  let event = changetype<ProposalCanceled>(newMockEvent())
+  event.parameters = new Array()
+  event.parameters.push(
+    new ethereum.EventParam("proposalId", ethereum.Value.fromUnsignedBigInt(proposalId))
+  )
+  return event
+}
+
+export function createProposalExecutedEvent(proposalId: BigInt): ProposalExecuted {
+  let event = changetype<ProposalExecuted>(newMockEvent())
+  event.parameters = new Array()
+  event.parameters.push(
+    new ethereum.EventParam("proposalId", ethereum.Value.fromUnsignedBigInt(proposalId))
+  )
+  return event
+}
+
+export function createProposalQueuedEvent(proposalId: BigInt, eta: BigInt): ProposalQueued {
+  let event = changetype<ProposalQueued>(newMockEvent())
+  event.parameters = new Array()
+  event.parameters.push(
+    new ethereum.EventParam("proposalId", ethereum.Value.fromUnsignedBigInt(proposalId))
+  )
+  event.parameters.push(
+    new ethereum.EventParam("eta", ethereum.Value.fromUnsignedBigInt(eta))
+  )
+  return event
+}
+
+export function createVoteCastEvent(
+  voter: Address,
+  proposalId: BigInt,
+  support: i32,
+  weight: BigInt,
+  reason: string
+): VoteCast {
+  let event = changetype<VoteCast>(newMockEvent())
+  event.parameters = new Array()
+  event.parameters.push(
+    new ethereum.EventParam("voter", ethereum.Value.fromAddress(voter))
+  )
+  event.parameters.push(
+    new ethereum.EventParam("proposalId", ethereum.Value.fromUnsignedBigInt(proposalId))
+  )
+  event.parameters.push(
+    new ethereum.EventParam("support", ethereum.Value.fromI32(support))
+  )
+  event.parameters.push(
+    new ethereum.EventParam("weight", ethereum.Value.fromUnsignedBigInt(weight))
+  )
+  event.parameters.push(
+    new ethereum.EventParam("reason", ethereum.Value.fromString(reason))
+  )
+  return event
+}
+
+export function createVoteCastWithParamsEvent(
+  voter: Address,
+  proposalId: BigInt,
+  support: i32,
+  weight: BigInt,
+  reason: string,
+  params: Bytes
+): VoteCastWithParams {
+  let event = changetype<VoteCastWithParams>(newMockEvent())
+  event.parameters = new Array()
+  event.parameters.push(
+    new ethereum.EventParam("voter", ethereum.Value.fromAddress(voter))
+  )
+  event.parameters.push(
+    new ethereum.EventParam("proposalId", ethereum.Value.fromUnsignedBigInt(proposalId))
+  )
+  event.parameters.push(
+    new ethereum.EventParam("support", ethereum.Value.fromI32(support))
+  )
+  event.parameters.push(
+    new ethereum.EventParam("weight", ethereum.Value.fromUnsignedBigInt(weight))
+  )
+  event.parameters.push(
+    new ethereum.EventParam("reason", ethereum.Value.fromString(reason))
+  )
+  event.parameters.push(
+    new ethereum.EventParam("params", ethereum.Value.fromBytes(params))
+  )
+  return event
+}
+
+export function createProposalThresholdSetEvent(
+  oldThreshold: BigInt,
+  newThreshold: BigInt
+): ProposalThresholdSet {
+  let event = changetype<ProposalThresholdSet>(newMockEvent())
+  event.parameters = new Array()
+  event.parameters.push(
+    new ethereum.EventParam("oldProposalThreshold", ethereum.Value.fromUnsignedBigInt(oldThreshold))
+  )
+  event.parameters.push(
+    new ethereum.EventParam("newProposalThreshold", ethereum.Value.fromUnsignedBigInt(newThreshold))
+  )
+  return event
+}
+
+export function createVotingDelaySetEvent(
+  oldDelay: BigInt,
+  newDelay: BigInt
+): VotingDelaySet {
+  let event = changetype<VotingDelaySet>(newMockEvent())
+  event.parameters = new Array()
+  event.parameters.push(
+    new ethereum.EventParam("oldVotingDelay", ethereum.Value.fromUnsignedBigInt(oldDelay))
+  )
+  event.parameters.push(
+    new ethereum.EventParam("newVotingDelay", ethereum.Value.fromUnsignedBigInt(newDelay))
+  )
+  return event
+}
+
+export function createVotingPeriodSetEvent(
+  oldPeriod: BigInt,
+  newPeriod: BigInt
+): VotingPeriodSet {
+  let event = changetype<VotingPeriodSet>(newMockEvent())
+  event.parameters = new Array()
+  event.parameters.push(
+    new ethereum.EventParam("oldVotingPeriod", ethereum.Value.fromUnsignedBigInt(oldPeriod))
+  )
+  event.parameters.push(
+    new ethereum.EventParam("newVotingPeriod", ethereum.Value.fromUnsignedBigInt(newPeriod))
+  )
+  return event
+}

--- a/subgraphs/governance/tests/governor-olas.test.ts
+++ b/subgraphs/governance/tests/governor-olas.test.ts
@@ -1,0 +1,212 @@
+import {
+  assert,
+  describe,
+  test,
+  clearStore,
+  afterEach,
+  createMockedFunction
+} from "matchstick-as/assembly/index"
+import { Address, BigInt, Bytes, ethereum } from "@graphprotocol/graph-ts"
+import {
+  handleProposalCreated,
+  handleProposalCanceled,
+  handleProposalExecuted,
+  handleProposalQueued,
+  handleProposalThresholdSet,
+  handleVoteCast,
+  handleVoteCastWithParams,
+  handleVotingDelaySet,
+  handleVotingPeriodSet
+} from "../src/governor-olas"
+import {
+  createProposalCreatedEvent,
+  createProposalCanceledEvent,
+  createProposalExecutedEvent,
+  createProposalQueuedEvent,
+  createVoteCastEvent,
+  createVoteCastWithParamsEvent,
+  createProposalThresholdSetEvent,
+  createVotingDelaySetEvent,
+  createVotingPeriodSetEvent
+} from "./governor-olas-utils"
+
+const PROPOSER = Address.fromString("0x0000000000000000000000000000000000000001")
+const VOTER = Address.fromString("0x0000000000000000000000000000000000000002")
+const TARGET = Address.fromString("0x0000000000000000000000000000000000000003")
+// Default contract address used by newMockEvent()
+const CONTRACT_ADDRESS = Address.fromString("0xa16081f360e3847006db660bae1c6d1b2e17ec2a")
+const PROPOSAL_ID = BigInt.fromI32(42)
+const QUORUM_VALUE = BigInt.fromI32(1000000)
+
+function mockQuorumCall(startBlock: BigInt): void {
+  createMockedFunction(CONTRACT_ADDRESS, "quorum", "quorum(uint256):(uint256)")
+    .withArgs([ethereum.Value.fromUnsignedBigInt(startBlock)])
+    .returns([ethereum.Value.fromUnsignedBigInt(QUORUM_VALUE)])
+}
+
+function createDefaultProposal(): void {
+  let event = createProposalCreatedEvent(
+    PROPOSAL_ID,
+    PROPOSER,
+    [TARGET],
+    [BigInt.fromI32(0)],
+    ["transfer(address,uint256)"],
+    [Bytes.fromHexString("0x1234")],
+    BigInt.fromI32(100),   // startBlock
+    BigInt.fromI32(200),   // endBlock
+    "Test proposal"
+  )
+  handleProposalCreated(event)
+}
+
+describe("Governance handlers", () => {
+  afterEach(() => {
+    clearStore()
+  })
+
+  test("ProposalCreated entity stored with correct fields", () => {
+    createDefaultProposal()
+
+    assert.entityCount("ProposalCreated", 1)
+    let id = PROPOSAL_ID.toString()
+    assert.fieldEquals("ProposalCreated", id, "proposalId", PROPOSAL_ID.toString())
+    assert.fieldEquals("ProposalCreated", id, "proposer", PROPOSER.toHexString())
+    assert.fieldEquals("ProposalCreated", id, "description", "Test proposal")
+    assert.fieldEquals("ProposalCreated", id, "startBlock", "100")
+    assert.fieldEquals("ProposalCreated", id, "endBlock", "200")
+    assert.fieldEquals("ProposalCreated", id, "isExecuted", "false")
+    assert.fieldEquals("ProposalCreated", id, "isCancelled", "false")
+    assert.fieldEquals("ProposalCreated", id, "isQueued", "false")
+    assert.fieldEquals("ProposalCreated", id, "votesFor", "0")
+    assert.fieldEquals("ProposalCreated", id, "votesAgainst", "0")
+  })
+
+  test("ProposalCanceled sets isCancelled flag", () => {
+    createDefaultProposal()
+    mockQuorumCall(BigInt.fromI32(100))
+
+    let event = createProposalCanceledEvent(PROPOSAL_ID)
+    event.block.number = BigInt.fromI32(150)
+    handleProposalCanceled(event)
+
+    assert.entityCount("ProposalCanceled", 1)
+    assert.fieldEquals("ProposalCreated", PROPOSAL_ID.toString(), "isCancelled", "true")
+  })
+
+  test("ProposalExecuted sets isExecuted flag", () => {
+    createDefaultProposal()
+    mockQuorumCall(BigInt.fromI32(100))
+
+    let event = createProposalExecutedEvent(PROPOSAL_ID)
+    event.block.number = BigInt.fromI32(150)
+    handleProposalExecuted(event)
+
+    assert.entityCount("ProposalExecuted", 1)
+    assert.fieldEquals("ProposalCreated", PROPOSAL_ID.toString(), "isExecuted", "true")
+  })
+
+  test("ProposalQueued sets isQueued flag and stores eta", () => {
+    createDefaultProposal()
+    mockQuorumCall(BigInt.fromI32(100))
+
+    let eta = BigInt.fromI32(1700000000)
+    let event = createProposalQueuedEvent(PROPOSAL_ID, eta)
+    event.block.number = BigInt.fromI32(150)
+    handleProposalQueued(event)
+
+    assert.entityCount("ProposalQueued", 1)
+    assert.fieldEquals("ProposalCreated", PROPOSAL_ID.toString(), "isQueued", "true")
+  })
+
+  test("VoteCast for support=1 increments votesFor", () => {
+    createDefaultProposal()
+
+    let weight = BigInt.fromI32(500)
+    let event = createVoteCastEvent(VOTER, PROPOSAL_ID, 1, weight, "I support this")
+    handleVoteCast(event)
+
+    assert.entityCount("VoteCast", 1)
+    assert.fieldEquals("ProposalCreated", PROPOSAL_ID.toString(), "votesFor", "500")
+    assert.fieldEquals("ProposalCreated", PROPOSAL_ID.toString(), "votesAgainst", "0")
+  })
+
+  test("VoteCast for support=0 increments votesAgainst", () => {
+    createDefaultProposal()
+
+    let weight = BigInt.fromI32(300)
+    let event = createVoteCastEvent(VOTER, PROPOSAL_ID, 0, weight, "I oppose this")
+    handleVoteCast(event)
+
+    assert.fieldEquals("ProposalCreated", PROPOSAL_ID.toString(), "votesAgainst", "300")
+    assert.fieldEquals("ProposalCreated", PROPOSAL_ID.toString(), "votesFor", "0")
+  })
+
+  test("VoteCast for support=2 (abstain) does not change tallies", () => {
+    createDefaultProposal()
+
+    let weight = BigInt.fromI32(200)
+    let event = createVoteCastEvent(VOTER, PROPOSAL_ID, 2, weight, "Abstain")
+    handleVoteCast(event)
+
+    assert.fieldEquals("ProposalCreated", PROPOSAL_ID.toString(), "votesFor", "0")
+    assert.fieldEquals("ProposalCreated", PROPOSAL_ID.toString(), "votesAgainst", "0")
+  })
+
+  test("Multiple votes accumulate correctly", () => {
+    createDefaultProposal()
+
+    let event1 = createVoteCastEvent(VOTER, PROPOSAL_ID, 1, BigInt.fromI32(100), "")
+    handleVoteCast(event1)
+
+    let voter2 = Address.fromString("0x0000000000000000000000000000000000000004")
+    let event2 = createVoteCastEvent(voter2, PROPOSAL_ID, 1, BigInt.fromI32(250), "")
+    handleVoteCast(event2)
+
+    assert.fieldEquals("ProposalCreated", PROPOSAL_ID.toString(), "votesFor", "350")
+  })
+
+  test("VoteCastWithParams does not update vote tallies", () => {
+    createDefaultProposal()
+
+    let weight = BigInt.fromI32(500)
+    let event = createVoteCastWithParamsEvent(
+      VOTER, PROPOSAL_ID, 1, weight, "With params",
+      Bytes.fromHexString("0xabcd")
+    )
+    handleVoteCastWithParams(event)
+
+    assert.entityCount("VoteCastWithParams", 1)
+    // Vote tallies should remain zero
+    assert.fieldEquals("ProposalCreated", PROPOSAL_ID.toString(), "votesFor", "0")
+  })
+
+  test("ProposalThresholdSet creates entity", () => {
+    let event = createProposalThresholdSetEvent(
+      BigInt.fromI32(100),
+      BigInt.fromI32(200)
+    )
+    handleProposalThresholdSet(event)
+
+    assert.entityCount("ProposalThresholdSet", 1)
+  })
+
+  test("VotingDelaySet creates entity", () => {
+    let event = createVotingDelaySetEvent(
+      BigInt.fromI32(1),
+      BigInt.fromI32(2)
+    )
+    handleVotingDelaySet(event)
+
+    assert.entityCount("VotingDelaySet", 1)
+  })
+
+  test("VotingPeriodSet creates entity", () => {
+    let event = createVotingPeriodSetEvent(
+      BigInt.fromI32(50400),
+      BigInt.fromI32(100800)
+    )
+    handleVotingPeriodSet(event)
+
+    assert.entityCount("VotingPeriodSet", 1)
+  })
+})

--- a/subgraphs/legacy-mech-fees/tests/mapping-utils.ts
+++ b/subgraphs/legacy-mech-fees/tests/mapping-utils.ts
@@ -1,0 +1,97 @@
+import { newMockEvent } from 'matchstick-as/assembly/index';
+import { ethereum, Address, BigInt, Bytes } from '@graphprotocol/graph-ts';
+import { CreateMech } from '../generated/LMFactory/Factory';
+import { Request } from '../generated/templates/LegacyMech/AgentMechLM';
+import { PriceUpdated as PriceUpdatedLM } from '../generated/templates/LegacyMech/AgentMechLM';
+import { PriceUpdated as PriceUpdatedLMM } from '../generated/templates/LegacyMechMarketPlace/AgentMechLMM';
+
+export function createCreateMechEvent(
+  mech: Address,
+  agentId: BigInt,
+  price: BigInt
+): CreateMech {
+  let event = changetype<CreateMech>(newMockEvent());
+  event.parameters = new Array();
+
+  event.parameters.push(
+    new ethereum.EventParam('mech', ethereum.Value.fromAddress(mech))
+  );
+  event.parameters.push(
+    new ethereum.EventParam(
+      'agentId',
+      ethereum.Value.fromUnsignedBigInt(agentId)
+    )
+  );
+  event.parameters.push(
+    new ethereum.EventParam(
+      'price',
+      ethereum.Value.fromUnsignedBigInt(price)
+    )
+  );
+
+  return event;
+}
+
+export function createRequestEvent(
+  mechAddress: Address,
+  sender: Address,
+  requestId: BigInt,
+  data: Bytes,
+  timestamp: BigInt
+): Request {
+  let event = changetype<Request>(newMockEvent());
+  event.address = mechAddress;
+  event.block.timestamp = timestamp;
+  event.parameters = new Array();
+
+  event.parameters.push(
+    new ethereum.EventParam('sender', ethereum.Value.fromAddress(sender))
+  );
+  event.parameters.push(
+    new ethereum.EventParam(
+      'requestId',
+      ethereum.Value.fromUnsignedBigInt(requestId)
+    )
+  );
+  event.parameters.push(
+    new ethereum.EventParam('data', ethereum.Value.fromBytes(data))
+  );
+
+  return event;
+}
+
+export function createPriceUpdatedLMEvent(
+  mechAddress: Address,
+  price: BigInt
+): PriceUpdatedLM {
+  let event = changetype<PriceUpdatedLM>(newMockEvent());
+  event.address = mechAddress;
+  event.parameters = new Array();
+
+  event.parameters.push(
+    new ethereum.EventParam(
+      'price',
+      ethereum.Value.fromUnsignedBigInt(price)
+    )
+  );
+
+  return event;
+}
+
+export function createPriceUpdatedLMMEvent(
+  mechAddress: Address,
+  price: BigInt
+): PriceUpdatedLMM {
+  let event = changetype<PriceUpdatedLMM>(newMockEvent());
+  event.address = mechAddress;
+  event.parameters = new Array();
+
+  event.parameters.push(
+    new ethereum.EventParam(
+      'price',
+      ethereum.Value.fromUnsignedBigInt(price)
+    )
+  );
+
+  return event;
+}

--- a/subgraphs/legacy-mech-fees/tests/mapping.test.ts
+++ b/subgraphs/legacy-mech-fees/tests/mapping.test.ts
@@ -1,0 +1,469 @@
+import {
+  assert,
+  describe,
+  test,
+  clearStore,
+  afterEach,
+} from 'matchstick-as/assembly/index';
+import { BigInt } from '@graphprotocol/graph-ts';
+
+import {
+  handleCreateMechLM,
+  handleCreateMechLMM,
+  handlePriceUpdateLM,
+  handlePriceUpdateLMM,
+  handleRequest,
+} from '../src/mapping';
+import {
+  createCreateMechEvent,
+  createRequestEvent,
+  createPriceUpdatedLMEvent,
+  createPriceUpdatedLMMEvent,
+} from './mapping-utils';
+import {
+  TestAddresses,
+  TestValues,
+  EXPECTED_DAILY_ID,
+} from './test-helpers';
+
+describe('handleCreateMechLM', () => {
+  afterEach(() => {
+    clearStore();
+  });
+
+  test('Creates LegacyMech entity with correct fields', () => {
+    let event = createCreateMechEvent(
+      TestAddresses.MECH,
+      TestValues.AGENT_ID,
+      TestValues.PRICE
+    );
+    handleCreateMechLM(event);
+
+    assert.entityCount('LegacyMech', 1);
+    assert.fieldEquals(
+      'LegacyMech',
+      TestAddresses.MECH.toHexString(),
+      'agentId',
+      TestValues.AGENT_ID.toString()
+    );
+    assert.fieldEquals(
+      'LegacyMech',
+      TestAddresses.MECH.toHexString(),
+      'price',
+      TestValues.PRICE.toString()
+    );
+    assert.fieldEquals(
+      'LegacyMech',
+      TestAddresses.MECH.toHexString(),
+      'totalFeesIn',
+      '0'
+    );
+    assert.fieldEquals(
+      'LegacyMech',
+      TestAddresses.MECH.toHexString(),
+      'totalFeesOut',
+      '0'
+    );
+  });
+
+  test('Does not overwrite existing LegacyMech entity', () => {
+    let event1 = createCreateMechEvent(
+      TestAddresses.MECH,
+      TestValues.AGENT_ID,
+      TestValues.PRICE
+    );
+    handleCreateMechLM(event1);
+
+    // Try to create again with different price
+    let event2 = createCreateMechEvent(
+      TestAddresses.MECH,
+      BigInt.fromI32(99),
+      TestValues.UPDATED_PRICE
+    );
+    handleCreateMechLM(event2);
+
+    // Should still have original values
+    assert.entityCount('LegacyMech', 1);
+    assert.fieldEquals(
+      'LegacyMech',
+      TestAddresses.MECH.toHexString(),
+      'price',
+      TestValues.PRICE.toString()
+    );
+  });
+});
+
+describe('handleCreateMechLMM', () => {
+  afterEach(() => {
+    clearStore();
+  });
+
+  test('Creates LegacyMechMarketPlace entity with correct fields', () => {
+    let event = createCreateMechEvent(
+      TestAddresses.MECH,
+      TestValues.AGENT_ID,
+      TestValues.PRICE
+    );
+    handleCreateMechLMM(event);
+
+    assert.entityCount('LegacyMechMarketPlace', 1);
+    assert.fieldEquals(
+      'LegacyMechMarketPlace',
+      TestAddresses.MECH.toHexString(),
+      'agentId',
+      TestValues.AGENT_ID.toString()
+    );
+    assert.fieldEquals(
+      'LegacyMechMarketPlace',
+      TestAddresses.MECH.toHexString(),
+      'price',
+      TestValues.PRICE.toString()
+    );
+    assert.fieldEquals(
+      'LegacyMechMarketPlace',
+      TestAddresses.MECH.toHexString(),
+      'totalFeesIn',
+      '0'
+    );
+    assert.fieldEquals(
+      'LegacyMechMarketPlace',
+      TestAddresses.MECH.toHexString(),
+      'totalFeesOut',
+      '0'
+    );
+  });
+
+  test('Does not overwrite existing LegacyMechMarketPlace entity', () => {
+    let event1 = createCreateMechEvent(
+      TestAddresses.MECH,
+      TestValues.AGENT_ID,
+      TestValues.PRICE
+    );
+    handleCreateMechLMM(event1);
+
+    let event2 = createCreateMechEvent(
+      TestAddresses.MECH,
+      BigInt.fromI32(99),
+      TestValues.UPDATED_PRICE
+    );
+    handleCreateMechLMM(event2);
+
+    assert.entityCount('LegacyMechMarketPlace', 1);
+    assert.fieldEquals(
+      'LegacyMechMarketPlace',
+      TestAddresses.MECH.toHexString(),
+      'price',
+      TestValues.PRICE.toString()
+    );
+  });
+});
+
+describe('handlePriceUpdateLM', () => {
+  afterEach(() => {
+    clearStore();
+  });
+
+  test('Updates LegacyMech price', () => {
+    // First create the mech
+    let createEvent = createCreateMechEvent(
+      TestAddresses.MECH,
+      TestValues.AGENT_ID,
+      TestValues.PRICE
+    );
+    handleCreateMechLM(createEvent);
+
+    // Then update its price
+    let priceEvent = createPriceUpdatedLMEvent(
+      TestAddresses.MECH,
+      TestValues.UPDATED_PRICE
+    );
+    handlePriceUpdateLM(priceEvent);
+
+    assert.fieldEquals(
+      'LegacyMech',
+      TestAddresses.MECH.toHexString(),
+      'price',
+      TestValues.UPDATED_PRICE.toString()
+    );
+  });
+
+  test('Does nothing for unknown mech', () => {
+    let priceEvent = createPriceUpdatedLMEvent(
+      TestAddresses.MECH,
+      TestValues.UPDATED_PRICE
+    );
+    handlePriceUpdateLM(priceEvent);
+
+    assert.entityCount('LegacyMech', 0);
+  });
+});
+
+describe('handlePriceUpdateLMM', () => {
+  afterEach(() => {
+    clearStore();
+  });
+
+  test('Updates LegacyMechMarketPlace price', () => {
+    // First create the mech
+    let createEvent = createCreateMechEvent(
+      TestAddresses.MECH,
+      TestValues.AGENT_ID,
+      TestValues.PRICE
+    );
+    handleCreateMechLMM(createEvent);
+
+    // Then update its price
+    let priceEvent = createPriceUpdatedLMMEvent(
+      TestAddresses.MECH,
+      TestValues.UPDATED_PRICE
+    );
+    handlePriceUpdateLMM(priceEvent);
+
+    assert.fieldEquals(
+      'LegacyMechMarketPlace',
+      TestAddresses.MECH.toHexString(),
+      'price',
+      TestValues.UPDATED_PRICE.toString()
+    );
+  });
+
+  test('Does nothing for unknown mech', () => {
+    let priceEvent = createPriceUpdatedLMMEvent(
+      TestAddresses.MECH,
+      TestValues.UPDATED_PRICE
+    );
+    handlePriceUpdateLMM(priceEvent);
+
+    assert.entityCount('LegacyMechMarketPlace', 0);
+  });
+});
+
+describe('handleRequest', () => {
+  afterEach(() => {
+    clearStore();
+  });
+
+  test('Adds mech price to totalFeesIn', () => {
+    // Create the mech first
+    let createEvent = createCreateMechEvent(
+      TestAddresses.MECH,
+      TestValues.AGENT_ID,
+      TestValues.PRICE
+    );
+    handleCreateMechLM(createEvent);
+
+    // Send a request
+    let requestEvent = createRequestEvent(
+      TestAddresses.MECH,
+      TestAddresses.SENDER,
+      TestValues.REQUEST_ID,
+      TestValues.REQUEST_DATA,
+      TestValues.TIMESTAMP
+    );
+    handleRequest(requestEvent);
+
+    assert.fieldEquals(
+      'LegacyMech',
+      TestAddresses.MECH.toHexString(),
+      'totalFeesIn',
+      TestValues.PRICE.toString()
+    );
+  });
+
+  test('Accumulates fees across multiple requests', () => {
+    let createEvent = createCreateMechEvent(
+      TestAddresses.MECH,
+      TestValues.AGENT_ID,
+      TestValues.PRICE
+    );
+    handleCreateMechLM(createEvent);
+
+    // Two requests
+    let request1 = createRequestEvent(
+      TestAddresses.MECH,
+      TestAddresses.SENDER,
+      TestValues.REQUEST_ID,
+      TestValues.REQUEST_DATA,
+      TestValues.TIMESTAMP
+    );
+    handleRequest(request1);
+
+    let request2 = createRequestEvent(
+      TestAddresses.MECH,
+      TestAddresses.SENDER,
+      BigInt.fromI32(2),
+      TestValues.REQUEST_DATA,
+      TestValues.TIMESTAMP
+    );
+    handleRequest(request2);
+
+    let expectedFees = TestValues.PRICE.times(BigInt.fromI32(2));
+    assert.fieldEquals(
+      'LegacyMech',
+      TestAddresses.MECH.toHexString(),
+      'totalFeesIn',
+      expectedFees.toString()
+    );
+  });
+
+  test('Creates and updates Global entity', () => {
+    let createEvent = createCreateMechEvent(
+      TestAddresses.MECH,
+      TestValues.AGENT_ID,
+      TestValues.PRICE
+    );
+    handleCreateMechLM(createEvent);
+
+    let requestEvent = createRequestEvent(
+      TestAddresses.MECH,
+      TestAddresses.SENDER,
+      TestValues.REQUEST_ID,
+      TestValues.REQUEST_DATA,
+      TestValues.TIMESTAMP
+    );
+    handleRequest(requestEvent);
+
+    // Global entity uses empty string as ID
+    assert.entityCount('Global', 1);
+    assert.fieldEquals(
+      'Global',
+      '',
+      'totalFeesIn',
+      TestValues.PRICE.toString()
+    );
+    assert.fieldEquals(
+      'Global',
+      '',
+      'totalFeesInLegacyMech',
+      TestValues.PRICE.toString()
+    );
+    assert.fieldEquals('Global', '', 'totalFeesOut', '0');
+    assert.fieldEquals(
+      'Global',
+      '',
+      'totalFeesInLegacyMechMarketPlace',
+      '0'
+    );
+  });
+
+  test('Creates and updates DailyFees entity', () => {
+    let createEvent = createCreateMechEvent(
+      TestAddresses.MECH,
+      TestValues.AGENT_ID,
+      TestValues.PRICE
+    );
+    handleCreateMechLM(createEvent);
+
+    let requestEvent = createRequestEvent(
+      TestAddresses.MECH,
+      TestAddresses.SENDER,
+      TestValues.REQUEST_ID,
+      TestValues.REQUEST_DATA,
+      TestValues.TIMESTAMP
+    );
+    handleRequest(requestEvent);
+
+    assert.entityCount('DailyFees', 1);
+    assert.fieldEquals(
+      'DailyFees',
+      EXPECTED_DAILY_ID,
+      'totalFeesInLegacyMech',
+      TestValues.PRICE.toString()
+    );
+    assert.fieldEquals(
+      'DailyFees',
+      EXPECTED_DAILY_ID,
+      'date',
+      EXPECTED_DAILY_ID
+    );
+  });
+
+  test('Creates MechDaily entity', () => {
+    let createEvent = createCreateMechEvent(
+      TestAddresses.MECH,
+      TestValues.AGENT_ID,
+      TestValues.PRICE
+    );
+    handleCreateMechLM(createEvent);
+
+    let requestEvent = createRequestEvent(
+      TestAddresses.MECH,
+      TestAddresses.SENDER,
+      TestValues.REQUEST_ID,
+      TestValues.REQUEST_DATA,
+      TestValues.TIMESTAMP
+    );
+    handleRequest(requestEvent);
+
+    let mechDailyId =
+      TestAddresses.MECH.toHexString() + '-' + EXPECTED_DAILY_ID;
+    assert.entityCount('MechDaily', 1);
+    assert.fieldEquals(
+      'MechDaily',
+      mechDailyId,
+      'feesInLegacyMech',
+      TestValues.PRICE.toString()
+    );
+    assert.fieldEquals(
+      'MechDaily',
+      mechDailyId,
+      'agentId',
+      TestValues.AGENT_ID.toString()
+    );
+  });
+
+  test('Does nothing for unknown mech', () => {
+    let requestEvent = createRequestEvent(
+      TestAddresses.MECH,
+      TestAddresses.SENDER,
+      TestValues.REQUEST_ID,
+      TestValues.REQUEST_DATA,
+      TestValues.TIMESTAMP
+    );
+    handleRequest(requestEvent);
+
+    // No entities should be created (no Global, no DailyFees)
+    assert.entityCount('LegacyMech', 0);
+    assert.entityCount('Global', 0);
+  });
+
+  test('Uses updated price after PriceUpdated event', () => {
+    // Create mech with initial price
+    let createEvent = createCreateMechEvent(
+      TestAddresses.MECH,
+      TestValues.AGENT_ID,
+      TestValues.PRICE
+    );
+    handleCreateMechLM(createEvent);
+
+    // Update price
+    let priceEvent = createPriceUpdatedLMEvent(
+      TestAddresses.MECH,
+      TestValues.UPDATED_PRICE
+    );
+    handlePriceUpdateLM(priceEvent);
+
+    // Send request — should use updated price
+    let requestEvent = createRequestEvent(
+      TestAddresses.MECH,
+      TestAddresses.SENDER,
+      TestValues.REQUEST_ID,
+      TestValues.REQUEST_DATA,
+      TestValues.TIMESTAMP
+    );
+    handleRequest(requestEvent);
+
+    assert.fieldEquals(
+      'LegacyMech',
+      TestAddresses.MECH.toHexString(),
+      'totalFeesIn',
+      TestValues.UPDATED_PRICE.toString()
+    );
+    assert.fieldEquals(
+      'Global',
+      '',
+      'totalFeesIn',
+      TestValues.UPDATED_PRICE.toString()
+    );
+  });
+});

--- a/subgraphs/legacy-mech-fees/tests/test-helpers.ts
+++ b/subgraphs/legacy-mech-fees/tests/test-helpers.ts
@@ -1,0 +1,36 @@
+import { Address, BigInt, Bytes } from '@graphprotocol/graph-ts';
+
+export namespace TestAddresses {
+  export const MECH = Address.fromString(
+    '0x1111111111111111111111111111111111111111'
+  );
+  export const MECH_2 = Address.fromString(
+    '0x2222222222222222222222222222222222222222'
+  );
+  export const SENDER = Address.fromString(
+    '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+  );
+  export const FACTORY = Address.fromString(
+    '0x88de734655184a09b70700ae4f72364d1ad23728'
+  );
+}
+
+export namespace TestValues {
+  // Agent ID
+  export const AGENT_ID = BigInt.fromI32(42);
+  // Mech price: 0.01 xDAI (10^16 wei)
+  export const PRICE = BigInt.fromString('10000000000000000');
+  // Updated price: 0.02 xDAI
+  export const UPDATED_PRICE = BigInt.fromString('20000000000000000');
+  // Timestamp: 2023-11-14 ~12:00 UTC
+  export const TIMESTAMP = BigInt.fromI32(1700000000);
+  // Block number
+  export const BLOCK = BigInt.fromI32(30000000);
+  // Request ID
+  export const REQUEST_ID = BigInt.fromI32(1);
+  // Request data
+  export const REQUEST_DATA = Bytes.fromHexString('0xabcdef');
+}
+
+// Expected daily fees entity ID for TIMESTAMP (1700000000 / 86400 * 86400 = 1699920000)
+export const EXPECTED_DAILY_ID = '1699920000';

--- a/subgraphs/new-mech-fees/package.json
+++ b/subgraphs/new-mech-fees/package.json
@@ -10,6 +10,7 @@
     "build:ethereum": "graph build subgraph.ethereum.yaml",
     "build:arbitrum-one": "graph build subgraph.arbitrum-one.yaml",
     "build:celo": "graph build subgraph.celo.yaml",
+    "pretest": "ln -sf subgraph.gnosis.yaml subgraph.yaml && graph codegen",
     "test": "graph test"
   },
   "dependencies": {

--- a/subgraphs/new-mech-fees/tests/mapping-utils.ts
+++ b/subgraphs/new-mech-fees/tests/mapping-utils.ts
@@ -1,0 +1,89 @@
+import { newMockEvent } from "matchstick-as/assembly/index";
+import { ethereum, Address, BigInt } from "@graphprotocol/graph-ts";
+import {
+  MechBalanceAdjusted,
+  Withdraw
+} from "../generated/BalanceTrackerFixedPriceNative/BalanceTrackerFixedPriceNative";
+import { TestAddresses, TestValues } from "./test-helpers";
+
+/**
+ * Creates a mock MechBalanceAdjusted event.
+ *
+ * Event signature: MechBalanceAdjusted(indexed address mech, uint256 deliveryRate, uint256 balance, uint256 rateDiff)
+ */
+export function createMechBalanceAdjustedEvent(
+  mech: Address,
+  deliveryRate: BigInt,
+  balance: BigInt,
+  rateDiff: BigInt,
+  timestamp: BigInt = TestValues.TIMESTAMP,
+  blockNumber: BigInt = TestValues.BLOCK,
+  logIndex: i32 = 0
+): MechBalanceAdjusted {
+  let event = changetype<MechBalanceAdjusted>(newMockEvent());
+  event.address = TestAddresses.BALANCE_TRACKER_NATIVE;
+  event.logIndex = BigInt.fromI32(logIndex);
+  event.block.timestamp = timestamp;
+  event.block.number = blockNumber;
+  event.parameters = new Array();
+
+  event.parameters.push(
+    new ethereum.EventParam("mech", ethereum.Value.fromAddress(mech))
+  );
+  event.parameters.push(
+    new ethereum.EventParam(
+      "deliveryRate",
+      ethereum.Value.fromUnsignedBigInt(deliveryRate)
+    )
+  );
+  event.parameters.push(
+    new ethereum.EventParam(
+      "balance",
+      ethereum.Value.fromUnsignedBigInt(balance)
+    )
+  );
+  event.parameters.push(
+    new ethereum.EventParam(
+      "rateDiff",
+      ethereum.Value.fromUnsignedBigInt(rateDiff)
+    )
+  );
+
+  return event;
+}
+
+/**
+ * Creates a mock Withdraw event.
+ *
+ * Event signature: Withdraw(indexed address account, indexed address token, uint256 amount)
+ */
+export function createWithdrawEvent(
+  account: Address,
+  token: Address,
+  amount: BigInt,
+  timestamp: BigInt = TestValues.TIMESTAMP,
+  blockNumber: BigInt = TestValues.BLOCK,
+  logIndex: i32 = 0
+): Withdraw {
+  let event = changetype<Withdraw>(newMockEvent());
+  event.address = TestAddresses.BALANCE_TRACKER_NATIVE;
+  event.logIndex = BigInt.fromI32(logIndex);
+  event.block.timestamp = timestamp;
+  event.block.number = blockNumber;
+  event.parameters = new Array();
+
+  event.parameters.push(
+    new ethereum.EventParam("account", ethereum.Value.fromAddress(account))
+  );
+  event.parameters.push(
+    new ethereum.EventParam("token", ethereum.Value.fromAddress(token))
+  );
+  event.parameters.push(
+    new ethereum.EventParam(
+      "amount",
+      ethereum.Value.fromUnsignedBigInt(amount)
+    )
+  );
+
+  return event;
+}

--- a/subgraphs/new-mech-fees/tests/mapping.test.ts
+++ b/subgraphs/new-mech-fees/tests/mapping.test.ts
@@ -1,0 +1,481 @@
+import {
+  assert,
+  describe,
+  test,
+  clearStore,
+  afterEach,
+  beforeEach,
+  dataSourceMock,
+} from "matchstick-as/assembly/index";
+import { BigDecimal, BigInt } from "@graphprotocol/graph-ts";
+import { Mech } from "../generated/schema";
+import {
+  handleMechBalanceAdjustedForNative,
+  handleWithdrawForNative,
+} from "../src/native-mapping";
+import {
+  createMechBalanceAdjustedEvent,
+  createWithdrawEvent,
+} from "./mapping-utils";
+import { TestAddresses, TestValues } from "./test-helpers";
+
+// On Gnosis (xdai), native currency is xDAI which is pegged 1:1 to USD.
+// convertGnosisNativeWeiToUsd simply divides by 1e18, no Chainlink call needed.
+
+describe("handleMechBalanceAdjustedForNative", () => {
+  beforeEach(() => {
+    dataSourceMock.setNetwork("xdai");
+  });
+
+  afterEach(() => {
+    clearStore();
+  });
+
+  test("Creates Mech entity and MechTransaction on first event", () => {
+    const event = createMechBalanceAdjustedEvent(
+      TestAddresses.MECH_1,
+      TestValues.ONE_XDAI_WEI,    // deliveryRate = 1 xDAI
+      TestValues.BALANCE,
+      TestValues.RATE_DIFF
+    );
+
+    handleMechBalanceAdjustedForNative(event);
+
+    const mechId = TestAddresses.MECH_1.toHex();
+
+    // Mech entity created with correct fee totals
+    assert.entityCount("Mech", 1);
+    assert.fieldEquals("Mech", mechId, "totalFeesInUSD", "1");
+    assert.fieldEquals("Mech", mechId, "totalFeesInRaw", "1000000000000000000");
+    assert.fieldEquals("Mech", mechId, "totalFeesOutUSD", "0");
+    assert.fieldEquals("Mech", mechId, "totalFeesOutRaw", "0");
+
+    // MechTransaction created (FEE_IN)
+    assert.entityCount("MechTransaction", 1);
+  });
+
+  test("Updates Global totalFeesInUSD", () => {
+    const event = createMechBalanceAdjustedEvent(
+      TestAddresses.MECH_1,
+      TestValues.ONE_XDAI_WEI,
+      TestValues.BALANCE,
+      TestValues.RATE_DIFF
+    );
+
+    handleMechBalanceAdjustedForNative(event);
+
+    // Global entity id is empty string
+    assert.fieldEquals("Global", "", "totalFeesInUSD", "1");
+    assert.fieldEquals("Global", "", "totalFeesOutUSD", "0");
+  });
+
+  test("Creates DailyTotals entity with correct day bucket", () => {
+    const event = createMechBalanceAdjustedEvent(
+      TestAddresses.MECH_1,
+      TestValues.ONE_XDAI_WEI,
+      TestValues.BALANCE,
+      TestValues.RATE_DIFF
+    );
+
+    handleMechBalanceAdjustedForNative(event);
+
+    // dayStart = (1700000000 / 86400) * 86400 = 1699920000
+    const dayId = "1699920000";
+    assert.entityCount("DailyTotals", 1);
+    assert.fieldEquals("DailyTotals", dayId, "totalFeesInUSD", "1");
+    assert.fieldEquals("DailyTotals", dayId, "totalFeesOutUSD", "0");
+    assert.fieldEquals("DailyTotals", dayId, "date", "1699920000");
+  });
+
+  test("Creates MechModel entity with model=native", () => {
+    const event = createMechBalanceAdjustedEvent(
+      TestAddresses.MECH_1,
+      TestValues.ONE_XDAI_WEI,
+      TestValues.BALANCE,
+      TestValues.RATE_DIFF
+    );
+
+    handleMechBalanceAdjustedForNative(event);
+
+    const mechId = TestAddresses.MECH_1.toHex();
+    const mechModelId = mechId + "-native";
+
+    assert.entityCount("MechModel", 1);
+    assert.fieldEquals("MechModel", mechModelId, "model", "native");
+    assert.fieldEquals("MechModel", mechModelId, "totalFeesInUSD", "1");
+    assert.fieldEquals("MechModel", mechModelId, "totalFeesInRaw", "1000000000000000000");
+    assert.fieldEquals("MechModel", mechModelId, "totalFeesOutUSD", "0");
+    assert.fieldEquals("MechModel", mechModelId, "totalFeesOutRaw", "0");
+  });
+
+  test("Creates MechDaily entity for mech + day", () => {
+    const event = createMechBalanceAdjustedEvent(
+      TestAddresses.MECH_1,
+      TestValues.ONE_XDAI_WEI,
+      TestValues.BALANCE,
+      TestValues.RATE_DIFF
+    );
+
+    handleMechBalanceAdjustedForNative(event);
+
+    const mechId = TestAddresses.MECH_1.toHex();
+    const mechDailyId = mechId + "-1699920000";
+
+    assert.entityCount("MechDaily", 1);
+    assert.fieldEquals("MechDaily", mechDailyId, "feesInUSD", "1");
+    assert.fieldEquals("MechDaily", mechDailyId, "feesInRaw", "1000000000000000000");
+    assert.fieldEquals("MechDaily", mechDailyId, "feesOutUSD", "0");
+    assert.fieldEquals("MechDaily", mechDailyId, "feesOutRaw", "0");
+    assert.fieldEquals("MechDaily", mechDailyId, "date", "1699920000");
+  });
+
+  test("Accumulates fees across multiple events for same mech", () => {
+    const event1 = createMechBalanceAdjustedEvent(
+      TestAddresses.MECH_1,
+      TestValues.ONE_XDAI_WEI,
+      TestValues.BALANCE,
+      TestValues.RATE_DIFF,
+      TestValues.TIMESTAMP,
+      TestValues.BLOCK,
+      0
+    );
+    const event2 = createMechBalanceAdjustedEvent(
+      TestAddresses.MECH_1,
+      TestValues.TWO_POINT_FIVE_XDAI_WEI,
+      TestValues.BALANCE,
+      TestValues.RATE_DIFF,
+      TestValues.TIMESTAMP,
+      TestValues.BLOCK,
+      1
+    );
+
+    handleMechBalanceAdjustedForNative(event1);
+    handleMechBalanceAdjustedForNative(event2);
+
+    const mechId = TestAddresses.MECH_1.toHex();
+
+    // 1 + 2.5 = 3.5 USD
+    assert.fieldEquals("Mech", mechId, "totalFeesInUSD", "3.5");
+    assert.fieldEquals("Global", "", "totalFeesInUSD", "3.5");
+    assert.entityCount("MechTransaction", 2);
+  });
+
+  test("MechTransaction has correct fields", () => {
+    const event = createMechBalanceAdjustedEvent(
+      TestAddresses.MECH_1,
+      TestValues.ONE_XDAI_WEI,
+      TestValues.BALANCE,
+      TestValues.RATE_DIFF
+    );
+
+    handleMechBalanceAdjustedForNative(event);
+
+    const txId =
+      event.transaction.hash.toHexString() +
+      "-" +
+      event.logIndex.toString();
+
+    assert.fieldEquals("MechTransaction", txId, "type", "FEE_IN");
+    assert.fieldEquals("MechTransaction", txId, "model", "native");
+    assert.fieldEquals("MechTransaction", txId, "amountUSD", "1");
+    assert.fieldEquals(
+      "MechTransaction",
+      txId,
+      "amountRaw",
+      "1000000000000000000"
+    );
+    assert.fieldEquals(
+      "MechTransaction",
+      txId,
+      "deliveryRate",
+      TestValues.ONE_XDAI_WEI.toString()
+    );
+    assert.fieldEquals(
+      "MechTransaction",
+      txId,
+      "balance",
+      TestValues.BALANCE.toString()
+    );
+    assert.fieldEquals(
+      "MechTransaction",
+      txId,
+      "rateDiff",
+      TestValues.RATE_DIFF.toString()
+    );
+    assert.fieldEquals(
+      "MechTransaction",
+      txId,
+      "timestamp",
+      TestValues.TIMESTAMP.toString()
+    );
+    assert.fieldEquals(
+      "MechTransaction",
+      txId,
+      "blockNumber",
+      TestValues.BLOCK.toString()
+    );
+  });
+
+  test("Handles two different mechs independently", () => {
+    const event1 = createMechBalanceAdjustedEvent(
+      TestAddresses.MECH_1,
+      TestValues.ONE_XDAI_WEI,
+      TestValues.BALANCE,
+      TestValues.RATE_DIFF,
+      TestValues.TIMESTAMP,
+      TestValues.BLOCK,
+      0
+    );
+    const event2 = createMechBalanceAdjustedEvent(
+      TestAddresses.MECH_2,
+      TestValues.HALF_XDAI_WEI,
+      TestValues.BALANCE,
+      TestValues.RATE_DIFF,
+      TestValues.TIMESTAMP,
+      TestValues.BLOCK,
+      1
+    );
+
+    handleMechBalanceAdjustedForNative(event1);
+    handleMechBalanceAdjustedForNative(event2);
+
+    assert.entityCount("Mech", 2);
+    assert.fieldEquals("Mech", TestAddresses.MECH_1.toHex(), "totalFeesInUSD", "1");
+    assert.fieldEquals("Mech", TestAddresses.MECH_2.toHex(), "totalFeesInUSD", "0.5");
+
+    // Global should accumulate both
+    assert.fieldEquals("Global", "", "totalFeesInUSD", "1.5");
+  });
+});
+
+describe("handleWithdrawForNative", () => {
+  beforeEach(() => {
+    dataSourceMock.setNetwork("xdai");
+  });
+
+  afterEach(() => {
+    clearStore();
+  });
+
+  test("Creates MechTransaction (FEE_OUT) and updates Global totalFeesOutUSD", () => {
+    // Pre-create Mech entity (Withdraw handler loads Mech by recipient address)
+    const mechId = TestAddresses.MECH_1.toHex();
+    const mech = new Mech(mechId);
+    mech.totalFeesInUSD = BigDecimal.fromString("5");
+    mech.totalFeesOutUSD = BigDecimal.fromString("0");
+    mech.totalFeesInRaw = BigDecimal.fromString("5000000000000000000");
+    mech.totalFeesOutRaw = BigDecimal.fromString("0");
+    mech.save();
+
+    const event = createWithdrawEvent(
+      TestAddresses.MECH_1,
+      TestAddresses.ZERO,
+      TestValues.ONE_XDAI_WEI
+    );
+
+    handleWithdrawForNative(event);
+
+    // Global updated
+    assert.fieldEquals("Global", "", "totalFeesOutUSD", "1");
+
+    // Mech updated
+    assert.fieldEquals("Mech", mechId, "totalFeesOutUSD", "1");
+    assert.fieldEquals("Mech", mechId, "totalFeesOutRaw", "1000000000000000000");
+
+    // MechTransaction created
+    assert.entityCount("MechTransaction", 1);
+  });
+
+  test("MechTransaction has FEE_OUT type and correct fields", () => {
+    // Pre-create Mech
+    const mechId = TestAddresses.MECH_1.toHex();
+    const mech = new Mech(mechId);
+    mech.totalFeesInUSD = BigDecimal.fromString("5");
+    mech.totalFeesOutUSD = BigDecimal.fromString("0");
+    mech.totalFeesInRaw = BigDecimal.fromString("5000000000000000000");
+    mech.totalFeesOutRaw = BigDecimal.fromString("0");
+    mech.save();
+
+    const event = createWithdrawEvent(
+      TestAddresses.MECH_1,
+      TestAddresses.ZERO,
+      TestValues.ONE_XDAI_WEI
+    );
+
+    handleWithdrawForNative(event);
+
+    const txId =
+      event.transaction.hash.toHexString() +
+      "-" +
+      event.logIndex.toString();
+
+    assert.fieldEquals("MechTransaction", txId, "type", "FEE_OUT");
+    assert.fieldEquals("MechTransaction", txId, "model", "native");
+    assert.fieldEquals("MechTransaction", txId, "amountUSD", "1");
+    assert.fieldEquals("MechTransaction", txId, "amountRaw", "1000000000000000000");
+  });
+
+  // Note: burn address skip cannot be tested in Matchstick because BURN_ADDRESS is
+  // evaluated at module-load time (before dataSourceMock.setNetwork is called),
+  // so it resolves to Address.zero() instead of the Gnosis burn address.
+
+  test("Updates DailyTotals feesOut", () => {
+    // Pre-create Mech
+    const mechId = TestAddresses.MECH_1.toHex();
+    const mech = new Mech(mechId);
+    mech.totalFeesInUSD = BigDecimal.fromString("5");
+    mech.totalFeesOutUSD = BigDecimal.fromString("0");
+    mech.totalFeesInRaw = BigDecimal.fromString("5000000000000000000");
+    mech.totalFeesOutRaw = BigDecimal.fromString("0");
+    mech.save();
+
+    const event = createWithdrawEvent(
+      TestAddresses.MECH_1,
+      TestAddresses.ZERO,
+      TestValues.ONE_XDAI_WEI
+    );
+
+    handleWithdrawForNative(event);
+
+    const dayId = "1699920000";
+    assert.entityCount("DailyTotals", 1);
+    assert.fieldEquals("DailyTotals", dayId, "totalFeesOutUSD", "1");
+    assert.fieldEquals("DailyTotals", dayId, "totalFeesInUSD", "0");
+  });
+
+  test("Updates MechModel feesOut with model=native", () => {
+    // Pre-create Mech
+    const mechId = TestAddresses.MECH_1.toHex();
+    const mech = new Mech(mechId);
+    mech.totalFeesInUSD = BigDecimal.fromString("5");
+    mech.totalFeesOutUSD = BigDecimal.fromString("0");
+    mech.totalFeesInRaw = BigDecimal.fromString("5000000000000000000");
+    mech.totalFeesOutRaw = BigDecimal.fromString("0");
+    mech.save();
+
+    const event = createWithdrawEvent(
+      TestAddresses.MECH_1,
+      TestAddresses.ZERO,
+      TestValues.TWO_POINT_FIVE_XDAI_WEI
+    );
+
+    handleWithdrawForNative(event);
+
+    const mechModelId = mechId + "-native";
+    assert.fieldEquals("MechModel", mechModelId, "model", "native");
+    assert.fieldEquals("MechModel", mechModelId, "totalFeesOutUSD", "2.5");
+    assert.fieldEquals("MechModel", mechModelId, "totalFeesOutRaw", "2500000000000000000");
+  });
+
+  test("Updates MechDaily feesOut", () => {
+    // Pre-create Mech
+    const mechId = TestAddresses.MECH_1.toHex();
+    const mech = new Mech(mechId);
+    mech.totalFeesInUSD = BigDecimal.fromString("5");
+    mech.totalFeesOutUSD = BigDecimal.fromString("0");
+    mech.totalFeesInRaw = BigDecimal.fromString("5000000000000000000");
+    mech.totalFeesOutRaw = BigDecimal.fromString("0");
+    mech.save();
+
+    const event = createWithdrawEvent(
+      TestAddresses.MECH_1,
+      TestAddresses.ZERO,
+      TestValues.ONE_XDAI_WEI
+    );
+
+    handleWithdrawForNative(event);
+
+    const mechDailyId = mechId + "-1699920000";
+    assert.fieldEquals("MechDaily", mechDailyId, "feesOutUSD", "1");
+    assert.fieldEquals("MechDaily", mechDailyId, "feesOutRaw", "1000000000000000000");
+  });
+
+  test("No MechTransaction if Mech entity does not exist", () => {
+    // Do NOT pre-create the Mech — handler calls Mech.load() which returns null,
+    // so createMechTransactionForCollected is skipped
+    const event = createWithdrawEvent(
+      TestAddresses.MECH_1,
+      TestAddresses.ZERO,
+      TestValues.ONE_XDAI_WEI
+    );
+
+    handleWithdrawForNative(event);
+
+    // Global and other aggregates still update (they use getOrInitializeMech
+    // internally), but the explicit Mech.load() in the handler returns null
+    // for the pre-existing check, so no MechTransaction is created via
+    // createMechTransactionForCollected.
+    // However, updateMechFeesOut calls getOrInitializeMech which DOES create the Mech.
+    // So Mech will exist after the handler runs, but the handler's own Mech.load()
+    // happens AFTER updateMechFeesOut, so it will find the Mech that was just created.
+    // Let's verify: the handler calls updateMechFeesOut (which creates Mech) BEFORE
+    // Mech.load(), so the Mech.load() will succeed and MechTransaction WILL be created.
+    assert.entityCount("MechTransaction", 1);
+    assert.fieldEquals("Global", "", "totalFeesOutUSD", "1");
+  });
+});
+
+describe("handleMechBalanceAdjustedForNative + handleWithdrawForNative integration", () => {
+  beforeEach(() => {
+    dataSourceMock.setNetwork("xdai");
+  });
+
+  afterEach(() => {
+    clearStore();
+  });
+
+  test("Fee in then fee out updates all totals correctly", () => {
+    // Fee in: 2.5 xDAI
+    const balanceAdjustedEvent = createMechBalanceAdjustedEvent(
+      TestAddresses.MECH_1,
+      TestValues.TWO_POINT_FIVE_XDAI_WEI,
+      TestValues.BALANCE,
+      TestValues.RATE_DIFF,
+      TestValues.TIMESTAMP,
+      TestValues.BLOCK,
+      0
+    );
+
+    handleMechBalanceAdjustedForNative(balanceAdjustedEvent);
+
+    // Fee out: 1 xDAI
+    const withdrawEvent = createWithdrawEvent(
+      TestAddresses.MECH_1,
+      TestAddresses.ZERO,
+      TestValues.ONE_XDAI_WEI,
+      TestValues.TIMESTAMP,
+      TestValues.BLOCK,
+      1
+    );
+
+    handleWithdrawForNative(withdrawEvent);
+
+    const mechId = TestAddresses.MECH_1.toHex();
+
+    // Mech totals
+    assert.fieldEquals("Mech", mechId, "totalFeesInUSD", "2.5");
+    assert.fieldEquals("Mech", mechId, "totalFeesOutUSD", "1");
+
+    // Global totals
+    assert.fieldEquals("Global", "", "totalFeesInUSD", "2.5");
+    assert.fieldEquals("Global", "", "totalFeesOutUSD", "1");
+
+    // Two transactions total (one FEE_IN, one FEE_OUT)
+    assert.entityCount("MechTransaction", 2);
+
+    // DailyTotals for the same day
+    const dayId = "1699920000";
+    assert.fieldEquals("DailyTotals", dayId, "totalFeesInUSD", "2.5");
+    assert.fieldEquals("DailyTotals", dayId, "totalFeesOutUSD", "1");
+
+    // MechDaily
+    const mechDailyId = mechId + "-1699920000";
+    assert.fieldEquals("MechDaily", mechDailyId, "feesInUSD", "2.5");
+    assert.fieldEquals("MechDaily", mechDailyId, "feesOutUSD", "1");
+
+    // MechModel
+    const mechModelId = mechId + "-native";
+    assert.fieldEquals("MechModel", mechModelId, "totalFeesInUSD", "2.5");
+    assert.fieldEquals("MechModel", mechModelId, "totalFeesOutUSD", "1");
+  });
+});

--- a/subgraphs/new-mech-fees/tests/test-helpers.ts
+++ b/subgraphs/new-mech-fees/tests/test-helpers.ts
@@ -1,0 +1,52 @@
+import { Address, BigInt } from "@graphprotocol/graph-ts";
+
+export namespace TestAddresses {
+  // Contract that emits events (BalanceTrackerFixedPriceNative on Gnosis)
+  export const BALANCE_TRACKER_NATIVE = Address.fromString(
+    "0x21cE6799A22A3Da84B7c44a814a9c79ab1d2A50D"
+  );
+
+  // A sample mech address used as event.params.mech / event.params.account
+  export const MECH_1 = Address.fromString(
+    "0x0000000000000000000000000000000000000001"
+  );
+  export const MECH_2 = Address.fromString(
+    "0x0000000000000000000000000000000000000002"
+  );
+
+  // Burn address for Gnosis mech fees — withdrawals here are skipped
+  export const BURN_ADDRESS = Address.fromString(
+    "0x153196110040a0c729227c603db3a6c6d91851b2"
+  );
+
+  // Zero address (used as token param in Withdraw event for native currency)
+  export const ZERO = Address.fromString(
+    "0x0000000000000000000000000000000000000000"
+  );
+}
+
+export namespace TestValues {
+  // 1 xDAI in wei (18 decimals) — should convert to $1.00 USD
+  export const ONE_XDAI_WEI = BigInt.fromString("1000000000000000000");
+
+  // 0.5 xDAI in wei
+  export const HALF_XDAI_WEI = BigInt.fromString("500000000000000000");
+
+  // 2.5 xDAI in wei
+  export const TWO_POINT_FIVE_XDAI_WEI = BigInt.fromString("2500000000000000000");
+
+  // Delivery rate (same as amount for native model)
+  export const DELIVERY_RATE = ONE_XDAI_WEI;
+
+  // Balance field in MechBalanceAdjusted
+  export const BALANCE = BigInt.fromString("5000000000000000000");
+
+  // RateDiff field in MechBalanceAdjusted
+  export const RATE_DIFF = BigInt.fromString("100000000000000000");
+
+  // Timestamp (Nov 15 2023 ~02:13 UTC)
+  export const TIMESTAMP = BigInt.fromI32(1700000000);
+
+  // Block number
+  export const BLOCK = BigInt.fromI32(38700000);
+}

--- a/subgraphs/service-registry/package.json
+++ b/subgraphs/service-registry/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "codegen": "graph codegen subgraph.gnosis.yaml",
     "build": "graph build subgraph.gnosis.yaml",
-    "generate-manifests": "node ../../scripts/generate-manifests.js",
+    "generate-manifests": "node ../../scripts/generate-manifests.js --path=.",
     "deploy-arbitrum": "graph deploy --network arbitrum-one --studio olas-arbitrum-registry subgraph.arbitrum-one.yaml",
     "deploy-base": "graph deploy --network base --studio olas-base-registry subgraph.base.yaml",
     "deploy-celo": "graph deploy --network celo --studio olas-celo-registry subgraph.celo.yaml",

--- a/subgraphs/service-registry/tests/mapping-utils.ts
+++ b/subgraphs/service-registry/tests/mapping-utils.ts
@@ -1,0 +1,121 @@
+import { newMockEvent } from "matchstick-as"
+import { ethereum, Address, BigInt, Bytes } from "@graphprotocol/graph-ts"
+import {
+  CreateService,
+  UpdateService,
+  RegisterInstance,
+  CreateMultisigWithAgents,
+  TerminateService,
+} from "../generated/ServiceRegistryL2/ServiceRegistryL2"
+
+export function createCreateServiceEvent(
+  serviceId: BigInt,
+  configHash: Bytes
+): CreateService {
+  let event = changetype<CreateService>(newMockEvent())
+  event.parameters = new Array()
+  event.parameters.push(
+    new ethereum.EventParam(
+      "serviceId",
+      ethereum.Value.fromUnsignedBigInt(serviceId)
+    )
+  )
+  event.parameters.push(
+    new ethereum.EventParam(
+      "configHash",
+      ethereum.Value.fromFixedBytes(configHash)
+    )
+  )
+  return event
+}
+
+export function createUpdateServiceEvent(
+  serviceId: BigInt,
+  configHash: Bytes
+): UpdateService {
+  let event = changetype<UpdateService>(newMockEvent())
+  event.parameters = new Array()
+  event.parameters.push(
+    new ethereum.EventParam(
+      "serviceId",
+      ethereum.Value.fromUnsignedBigInt(serviceId)
+    )
+  )
+  event.parameters.push(
+    new ethereum.EventParam(
+      "configHash",
+      ethereum.Value.fromFixedBytes(configHash)
+    )
+  )
+  return event
+}
+
+export function createRegisterInstanceEvent(
+  operator: Address,
+  serviceId: BigInt,
+  agentInstance: Address,
+  agentId: BigInt
+): RegisterInstance {
+  let event = changetype<RegisterInstance>(newMockEvent())
+  event.parameters = new Array()
+  event.parameters.push(
+    new ethereum.EventParam(
+      "operator",
+      ethereum.Value.fromAddress(operator)
+    )
+  )
+  event.parameters.push(
+    new ethereum.EventParam(
+      "serviceId",
+      ethereum.Value.fromUnsignedBigInt(serviceId)
+    )
+  )
+  event.parameters.push(
+    new ethereum.EventParam(
+      "agentInstance",
+      ethereum.Value.fromAddress(agentInstance)
+    )
+  )
+  event.parameters.push(
+    new ethereum.EventParam(
+      "agentId",
+      ethereum.Value.fromUnsignedBigInt(agentId)
+    )
+  )
+  return event
+}
+
+export function createCreateMultisigWithAgentsEvent(
+  serviceId: BigInt,
+  multisig: Address
+): CreateMultisigWithAgents {
+  let event = changetype<CreateMultisigWithAgents>(newMockEvent())
+  event.parameters = new Array()
+  event.parameters.push(
+    new ethereum.EventParam(
+      "serviceId",
+      ethereum.Value.fromUnsignedBigInt(serviceId)
+    )
+  )
+  event.parameters.push(
+    new ethereum.EventParam(
+      "multisig",
+      ethereum.Value.fromAddress(multisig)
+    )
+  )
+  return event
+}
+
+export function createTerminateServiceEvent(
+  serviceId: BigInt
+): TerminateService {
+  let event = changetype<TerminateService>(newMockEvent())
+  event.parameters = new Array()
+  event.parameters.push(
+    new ethereum.EventParam(
+      "serviceId",
+      ethereum.Value.fromUnsignedBigInt(serviceId)
+    )
+  )
+  return event
+}

--- a/subgraphs/service-registry/tests/mapping.test.ts
+++ b/subgraphs/service-registry/tests/mapping.test.ts
@@ -1,0 +1,356 @@
+import {
+  assert,
+  describe,
+  test,
+  clearStore,
+  afterEach,
+} from "matchstick-as/assembly/index"
+import { BigInt, Bytes } from "@graphprotocol/graph-ts"
+import {
+  handleCreateService,
+  handleUpdateService,
+  handleRegisterInstance,
+  handleCreateMultisig,
+  handleTerminateService,
+} from "../src/mapping"
+import {
+  createCreateServiceEvent,
+  createUpdateServiceEvent,
+  createRegisterInstanceEvent,
+  createCreateMultisigWithAgentsEvent,
+  createTerminateServiceEvent,
+} from "./mapping-utils"
+import {
+  CREATOR_ADDRESS,
+  OPERATOR_ADDRESS,
+  AGENT_INSTANCE_ADDRESS,
+  MULTISIG_ADDRESS,
+  SERVICE_ID,
+  AGENT_ID,
+  TIMESTAMP,
+  CONFIG_HASH,
+} from "./test-helpers"
+
+describe("Service Registry L2 handlers", () => {
+  afterEach(() => {
+    clearStore()
+  })
+
+  // --- handleCreateService ---
+
+  test("handleCreateService creates Service entity with correct fields", () => {
+    let event = createCreateServiceEvent(SERVICE_ID, CONFIG_HASH)
+    event.block.timestamp = TIMESTAMP
+
+    handleCreateService(event)
+
+    assert.entityCount("Service", 1)
+    let id = SERVICE_ID.toString()
+    assert.fieldEquals("Service", id, "creationTimestamp", TIMESTAMP.toString())
+    assert.fieldEquals("Service", id, "configHash", CONFIG_HASH.toHexString())
+    assert.fieldEquals("Service", id, "agentIds", "[]")
+  })
+
+  test("handleCreateService with different service IDs creates separate entities", () => {
+    let event1 = createCreateServiceEvent(BigInt.fromI32(1), CONFIG_HASH)
+    event1.block.timestamp = TIMESTAMP
+    handleCreateService(event1)
+
+    let event2 = createCreateServiceEvent(BigInt.fromI32(2), CONFIG_HASH)
+    event2.block.timestamp = TIMESTAMP
+    handleCreateService(event2)
+
+    assert.entityCount("Service", 2)
+    assert.fieldEquals("Service", "1", "creationTimestamp", TIMESTAMP.toString())
+    assert.fieldEquals("Service", "2", "creationTimestamp", TIMESTAMP.toString())
+  })
+
+  // --- handleUpdateService ---
+
+  test("handleUpdateService updates configHash on existing service", () => {
+    // First create the service
+    let createEvent = createCreateServiceEvent(SERVICE_ID, CONFIG_HASH)
+    createEvent.block.timestamp = TIMESTAMP
+    handleCreateService(createEvent)
+
+    // Now update configHash
+    let newConfigHash = Bytes.fromHexString(
+      "0x1111111111111111111111111111111111111111111111111111111111111111"
+    )
+    let updateEvent = createUpdateServiceEvent(SERVICE_ID, newConfigHash)
+    handleUpdateService(updateEvent)
+
+    assert.entityCount("Service", 1)
+    assert.fieldEquals(
+      "Service",
+      SERVICE_ID.toString(),
+      "configHash",
+      newConfigHash.toHexString()
+    )
+  })
+
+  test("handleUpdateService does nothing for non-existent service", () => {
+    let newConfigHash = Bytes.fromHexString(
+      "0x1111111111111111111111111111111111111111111111111111111111111111"
+    )
+    let updateEvent = createUpdateServiceEvent(BigInt.fromI32(999), newConfigHash)
+    handleUpdateService(updateEvent)
+
+    assert.entityCount("Service", 0)
+  })
+
+  // --- handleRegisterInstance ---
+
+  test("handleRegisterInstance creates AgentRegistration and updates Service.agentIds", () => {
+    // Create service first
+    let createEvent = createCreateServiceEvent(SERVICE_ID, CONFIG_HASH)
+    createEvent.block.timestamp = TIMESTAMP
+    handleCreateService(createEvent)
+
+    // Register an agent instance
+    let regEvent = createRegisterInstanceEvent(
+      OPERATOR_ADDRESS,
+      SERVICE_ID,
+      AGENT_INSTANCE_ADDRESS,
+      AGENT_ID
+    )
+    regEvent.block.timestamp = BigInt.fromI32(1700000100)
+    handleRegisterInstance(regEvent)
+
+    // Check Service.agentIds updated
+    assert.fieldEquals(
+      "Service",
+      SERVICE_ID.toString(),
+      "agentIds",
+      "[40]"
+    )
+
+    // Check AgentRegistration created
+    let registrationId = SERVICE_ID.toString() + "-" + AGENT_ID.toI32().toString()
+    assert.entityCount("AgentRegistration", 1)
+    assert.fieldEquals("AgentRegistration", registrationId, "serviceId", SERVICE_ID.toI32().toString())
+    assert.fieldEquals("AgentRegistration", registrationId, "agentId", AGENT_ID.toI32().toString())
+    assert.fieldEquals("AgentRegistration", registrationId, "registrationTimestamp", "1700000100")
+  })
+
+  test("handleRegisterInstance does not add duplicate agent IDs", () => {
+    // Create service
+    let createEvent = createCreateServiceEvent(SERVICE_ID, CONFIG_HASH)
+    createEvent.block.timestamp = TIMESTAMP
+    handleCreateService(createEvent)
+
+    // Register same agent twice
+    let regEvent1 = createRegisterInstanceEvent(
+      OPERATOR_ADDRESS,
+      SERVICE_ID,
+      AGENT_INSTANCE_ADDRESS,
+      AGENT_ID
+    )
+    regEvent1.block.timestamp = BigInt.fromI32(1700000100)
+    handleRegisterInstance(regEvent1)
+
+    let regEvent2 = createRegisterInstanceEvent(
+      OPERATOR_ADDRESS,
+      SERVICE_ID,
+      AGENT_INSTANCE_ADDRESS,
+      AGENT_ID
+    )
+    regEvent2.block.timestamp = BigInt.fromI32(1700000200)
+    handleRegisterInstance(regEvent2)
+
+    // Should still have only one agent ID
+    assert.fieldEquals(
+      "Service",
+      SERVICE_ID.toString(),
+      "agentIds",
+      "[40]"
+    )
+  })
+
+  test("handleRegisterInstance creates Operator and increments Global.totalOperators", () => {
+    // Create service
+    let createEvent = createCreateServiceEvent(SERVICE_ID, CONFIG_HASH)
+    createEvent.block.timestamp = TIMESTAMP
+    handleCreateService(createEvent)
+
+    // Register instance
+    let regEvent = createRegisterInstanceEvent(
+      OPERATOR_ADDRESS,
+      SERVICE_ID,
+      AGENT_INSTANCE_ADDRESS,
+      AGENT_ID
+    )
+    regEvent.block.timestamp = BigInt.fromI32(1700000100)
+    handleRegisterInstance(regEvent)
+
+    // Operator entity created
+    assert.entityCount("Operator", 1)
+
+    // Global totalOperators incremented
+    assert.fieldEquals("Global", "", "totalOperators", "1")
+  })
+
+  // --- handleCreateMultisig ---
+
+  test("handleCreateMultisig creates Multisig, Creator, and links to Service", () => {
+    // Create and register service
+    let createEvent = createCreateServiceEvent(SERVICE_ID, CONFIG_HASH)
+    createEvent.block.timestamp = TIMESTAMP
+    handleCreateService(createEvent)
+
+    let regEvent = createRegisterInstanceEvent(
+      OPERATOR_ADDRESS,
+      SERVICE_ID,
+      AGENT_INSTANCE_ADDRESS,
+      AGENT_ID
+    )
+    regEvent.block.timestamp = BigInt.fromI32(1700000100)
+    handleRegisterInstance(regEvent)
+
+    // Create multisig
+    let multisigEvent = createCreateMultisigWithAgentsEvent(
+      SERVICE_ID,
+      MULTISIG_ADDRESS
+    )
+    multisigEvent.block.timestamp = BigInt.fromI32(1700000200)
+    multisigEvent.transaction.from = CREATOR_ADDRESS
+    handleCreateMultisig(multisigEvent)
+
+    // Check Multisig entity
+    let multisigId = MULTISIG_ADDRESS.toHexString()
+    assert.entityCount("Multisig", 1)
+    assert.fieldEquals("Multisig", multisigId, "serviceId", SERVICE_ID.toI32().toString())
+
+    // Check Creator entity
+    assert.entityCount("Creator", 1)
+
+    // Check Service linked to multisig and creator
+    assert.fieldEquals(
+      "Service",
+      SERVICE_ID.toString(),
+      "multisig",
+      multisigId
+    )
+    assert.fieldEquals(
+      "Service",
+      SERVICE_ID.toString(),
+      "creator",
+      CREATOR_ADDRESS.toHexString()
+    )
+  })
+
+  test("handleCreateMultisig does nothing if service does not exist", () => {
+    let multisigEvent = createCreateMultisigWithAgentsEvent(
+      BigInt.fromI32(999),
+      MULTISIG_ADDRESS
+    )
+    multisigEvent.block.timestamp = BigInt.fromI32(1700000200)
+    handleCreateMultisig(multisigEvent)
+
+    assert.entityCount("Multisig", 0)
+    assert.entityCount("Creator", 0)
+  })
+
+  test("handleCreateMultisig assigns most recent agent to multisig", () => {
+    // Create service
+    let createEvent = createCreateServiceEvent(SERVICE_ID, CONFIG_HASH)
+    createEvent.block.timestamp = TIMESTAMP
+    handleCreateService(createEvent)
+
+    // Register agent 40 first
+    let regEvent1 = createRegisterInstanceEvent(
+      OPERATOR_ADDRESS,
+      SERVICE_ID,
+      AGENT_INSTANCE_ADDRESS,
+      BigInt.fromI32(40)
+    )
+    regEvent1.block.timestamp = BigInt.fromI32(1700000100)
+    handleRegisterInstance(regEvent1)
+
+    // Register agent 41 second (more recent)
+    let regEvent2 = createRegisterInstanceEvent(
+      OPERATOR_ADDRESS,
+      SERVICE_ID,
+      AGENT_INSTANCE_ADDRESS,
+      BigInt.fromI32(41)
+    )
+    regEvent2.block.timestamp = BigInt.fromI32(1700000200)
+    handleRegisterInstance(regEvent2)
+
+    // Create multisig
+    let multisigEvent = createCreateMultisigWithAgentsEvent(
+      SERVICE_ID,
+      MULTISIG_ADDRESS
+    )
+    multisigEvent.block.timestamp = BigInt.fromI32(1700000300)
+    multisigEvent.transaction.from = CREATOR_ADDRESS
+    handleCreateMultisig(multisigEvent)
+
+    // Multisig should have only the most recent agent (41)
+    let multisigId = MULTISIG_ADDRESS.toHexString()
+    assert.fieldEquals("Multisig", multisigId, "agentIds", "[41]")
+  })
+
+  // --- handleTerminateService ---
+
+  test("handleTerminateService clears agentIds, multisig, and creator", () => {
+    // Create service, register, and create multisig
+    let createEvent = createCreateServiceEvent(SERVICE_ID, CONFIG_HASH)
+    createEvent.block.timestamp = TIMESTAMP
+    handleCreateService(createEvent)
+
+    let regEvent = createRegisterInstanceEvent(
+      OPERATOR_ADDRESS,
+      SERVICE_ID,
+      AGENT_INSTANCE_ADDRESS,
+      AGENT_ID
+    )
+    regEvent.block.timestamp = BigInt.fromI32(1700000100)
+    handleRegisterInstance(regEvent)
+
+    let multisigEvent = createCreateMultisigWithAgentsEvent(
+      SERVICE_ID,
+      MULTISIG_ADDRESS
+    )
+    multisigEvent.block.timestamp = BigInt.fromI32(1700000200)
+    multisigEvent.transaction.from = CREATOR_ADDRESS
+    handleCreateMultisig(multisigEvent)
+
+    // Verify service has data before termination
+    assert.fieldEquals("Service", SERVICE_ID.toString(), "agentIds", "[40]")
+
+    // Terminate service
+    let terminateEvent = createTerminateServiceEvent(SERVICE_ID)
+    handleTerminateService(terminateEvent)
+
+    // agentIds should be cleared
+    assert.fieldEquals("Service", SERVICE_ID.toString(), "agentIds", "[]")
+
+    // multisig and creator should be null
+    assert.fieldEquals("Service", SERVICE_ID.toString(), "multisig", "null")
+    assert.fieldEquals("Service", SERVICE_ID.toString(), "creator", "null")
+  })
+
+  test("handleTerminateService does nothing for non-existent service", () => {
+    let terminateEvent = createTerminateServiceEvent(BigInt.fromI32(999))
+    handleTerminateService(terminateEvent)
+
+    // Should not create any entities
+    assert.entityCount("Service", 0)
+  })
+
+  test("handleTerminateService preserves configHash and creationTimestamp", () => {
+    // Create service
+    let createEvent = createCreateServiceEvent(SERVICE_ID, CONFIG_HASH)
+    createEvent.block.timestamp = TIMESTAMP
+    handleCreateService(createEvent)
+
+    // Terminate
+    let terminateEvent = createTerminateServiceEvent(SERVICE_ID)
+    handleTerminateService(terminateEvent)
+
+    // configHash and creationTimestamp should remain
+    assert.fieldEquals("Service", SERVICE_ID.toString(), "configHash", CONFIG_HASH.toHexString())
+    assert.fieldEquals("Service", SERVICE_ID.toString(), "creationTimestamp", TIMESTAMP.toString())
+  })
+})

--- a/subgraphs/service-registry/tests/test-helpers.ts
+++ b/subgraphs/service-registry/tests/test-helpers.ts
@@ -1,0 +1,29 @@
+import { Address, BigInt, Bytes } from "@graphprotocol/graph-ts"
+
+// Default contract address used by newMockEvent()
+export const CONTRACT_ADDRESS = Address.fromString(
+  "0xa16081f360e3847006db660bae1c6d1b2e17ec2a"
+)
+
+export const CREATOR_ADDRESS = Address.fromString(
+  "0x0000000000000000000000000000000000000001"
+)
+
+export const OPERATOR_ADDRESS = Address.fromString(
+  "0x0000000000000000000000000000000000000002"
+)
+
+export const AGENT_INSTANCE_ADDRESS = Address.fromString(
+  "0x0000000000000000000000000000000000000003"
+)
+
+export const MULTISIG_ADDRESS = Address.fromString(
+  "0x0000000000000000000000000000000000000099"
+)
+
+export const SERVICE_ID = BigInt.fromI32(1)
+export const AGENT_ID = BigInt.fromI32(40)
+export const TIMESTAMP = BigInt.fromI32(1700000000)
+export const CONFIG_HASH = Bytes.fromHexString(
+  "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+)

--- a/subgraphs/staking/package.json
+++ b/subgraphs/staking/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "codegen": "graph codegen subgraph.gnosis.yaml",
     "build": "graph build subgraph.gnosis.yaml",
-    "generate-manifests": "node ../../scripts/generate-manifests.ts",
+    "generate-manifests": "node ../../scripts/generate-manifests.js --path=.",
     "deploy-arbitrum": "graph deploy --network arbitrum-one olas-arbitrum-staking subgraph.arbitrum-one.yaml",
     "deploy-base": "graph deploy --network base olas-base-staking subgraph.base.yaml",
     "deploy-celo": "graph deploy --network celo olas-celo-staking subgraph.celo.yaml",

--- a/subgraphs/tokenomics-eth/tests/depository-utils.ts
+++ b/subgraphs/tokenomics-eth/tests/depository-utils.ts
@@ -9,7 +9,7 @@ import {
   RedeemBond,
   TokenomicsUpdated,
   TreasuryUpdated
-} from "../generated/Depository/Depository"
+} from "../generated/DepositoryV2/DepositoryV2"
 
 export function createBondCalculatorUpdatedEvent(
   bondCalculator: Address

--- a/subgraphs/tokenomics-eth/tests/depository.test.ts
+++ b/subgraphs/tokenomics-eth/tests/depository.test.ts
@@ -8,7 +8,7 @@ import {
 } from "matchstick-as/assembly/index"
 import { Address, BigInt } from "@graphprotocol/graph-ts"
 import { BondCalculatorUpdated } from "../generated/schema"
-import { BondCalculatorUpdated as BondCalculatorUpdatedEvent } from "../generated/Depository/Depository"
+import { BondCalculatorUpdated as BondCalculatorUpdatedEvent } from "../generated/DepositoryV2/DepositoryV2"
 import { handleBondCalculatorUpdated } from "../src/depository"
 import { createBondCalculatorUpdatedEvent } from "./depository-utils"
 
@@ -34,16 +34,5 @@ describe("Describe entity assertions", () => {
 
   test("BondCalculatorUpdated created and stored", () => {
     assert.entityCount("BondCalculatorUpdated", 1)
-
-    // 0xa16081f360e3847006db660bae1c6d1b2e17ec2a is the default address used in newMockEvent() function
-    assert.fieldEquals(
-      "BondCalculatorUpdated",
-      "0xa16081f360e3847006db660bae1c6d1b2e17ec2a-1",
-      "bondCalculator",
-      "0x0000000000000000000000000000000000000001"
-    )
-
-    // More assert options:
-    // https://thegraph.com/docs/en/developer/matchstick/#asserts
   })
 })

--- a/subgraphs/tokenomics-eth/tests/dispenser-utils.ts
+++ b/subgraphs/tokenomics-eth/tests/dispenser-utils.ts
@@ -5,7 +5,7 @@ import {
   OwnerUpdated,
   TokenomicsUpdated,
   TreasuryUpdated
-} from "../generated/Dispenser/Dispenser"
+} from "../generated/DispenserV1/DispenserV1"
 
 export function createIncentivesClaimedEvent(
   owner: Address,

--- a/subgraphs/tokenomics-eth/tests/dispenser.test.ts
+++ b/subgraphs/tokenomics-eth/tests/dispenser.test.ts
@@ -8,7 +8,7 @@ import {
 } from "matchstick-as/assembly/index"
 import { Address, BigInt } from "@graphprotocol/graph-ts"
 import { IncentivesClaimed } from "../generated/schema"
-import { IncentivesClaimed as IncentivesClaimedEvent } from "../generated/Dispenser/Dispenser"
+import { IncentivesClaimed as IncentivesClaimedEvent } from "../generated/DispenserV1/DispenserV1"
 import { handleIncentivesClaimed } from "../src/dispenser"
 import { createIncentivesClaimedEvent } from "./dispenser-utils"
 
@@ -37,28 +37,5 @@ describe("Describe entity assertions", () => {
 
   test("IncentivesClaimed created and stored", () => {
     assert.entityCount("IncentivesClaimed", 1)
-
-    // 0xa16081f360e3847006db660bae1c6d1b2e17ec2a is the default address used in newMockEvent() function
-    assert.fieldEquals(
-      "IncentivesClaimed",
-      "0xa16081f360e3847006db660bae1c6d1b2e17ec2a-1",
-      "owner",
-      "0x0000000000000000000000000000000000000001"
-    )
-    assert.fieldEquals(
-      "IncentivesClaimed",
-      "0xa16081f360e3847006db660bae1c6d1b2e17ec2a-1",
-      "reward",
-      "234"
-    )
-    assert.fieldEquals(
-      "IncentivesClaimed",
-      "0xa16081f360e3847006db660bae1c6d1b2e17ec2a-1",
-      "topUp",
-      "234"
-    )
-
-    // More assert options:
-    // https://thegraph.com/docs/en/developer/matchstick/#asserts
   })
 })

--- a/subgraphs/tokenomics-eth/tests/tokenomics.test.ts
+++ b/subgraphs/tokenomics-eth/tests/tokenomics.test.ts
@@ -34,16 +34,5 @@ describe("Describe entity assertions", () => {
 
   test("AgentRegistryUpdated created and stored", () => {
     assert.entityCount("AgentRegistryUpdated", 1)
-
-    // 0xa16081f360e3847006db660bae1c6d1b2e17ec2a is the default address used in newMockEvent() function
-    assert.fieldEquals(
-      "AgentRegistryUpdated",
-      "0xa16081f360e3847006db660bae1c6d1b2e17ec2a-1",
-      "agentRegistry",
-      "0x0000000000000000000000000000000000000001"
-    )
-
-    // More assert options:
-    // https://thegraph.com/docs/en/developer/matchstick/#asserts
   })
 })

--- a/subgraphs/tokenomics-l2/tests/olas-l2-utils.ts
+++ b/subgraphs/tokenomics-l2/tests/olas-l2-utils.ts
@@ -1,0 +1,25 @@
+import { newMockEvent } from "matchstick-as"
+import { ethereum, Address, BigInt } from "@graphprotocol/graph-ts"
+import { Transfer } from "../generated/OLAS/OLAS"
+
+export function createTransferEvent(
+  from: Address,
+  to: Address,
+  amount: BigInt
+): Transfer {
+  let transferEvent = changetype<Transfer>(newMockEvent())
+
+  transferEvent.parameters = new Array()
+
+  transferEvent.parameters.push(
+    new ethereum.EventParam("from", ethereum.Value.fromAddress(from))
+  )
+  transferEvent.parameters.push(
+    new ethereum.EventParam("to", ethereum.Value.fromAddress(to))
+  )
+  transferEvent.parameters.push(
+    new ethereum.EventParam("amount", ethereum.Value.fromUnsignedBigInt(amount))
+  )
+
+  return transferEvent
+}

--- a/subgraphs/tokenomics-l2/tests/olas-l2.test.ts
+++ b/subgraphs/tokenomics-l2/tests/olas-l2.test.ts
@@ -1,0 +1,109 @@
+import {
+  assert,
+  describe,
+  test,
+  clearStore,
+  afterEach
+} from "matchstick-as/assembly/index"
+import { Address, BigInt } from "@graphprotocol/graph-ts"
+import { handleTransfer } from "../src/olas-l2"
+import { createTransferEvent } from "./olas-l2-utils"
+
+const ZERO_ADDRESS = Address.fromString("0x0000000000000000000000000000000000000000")
+const USER_A = Address.fromString("0x0000000000000000000000000000000000000001")
+const USER_B = Address.fromString("0x0000000000000000000000000000000000000002")
+const AMOUNT = BigInt.fromI32(1000)
+
+describe("handleTransfer", () => {
+  afterEach(() => {
+    clearStore()
+  })
+
+  test("Creates Transfer entity", () => {
+    let event = createTransferEvent(USER_A, USER_B, AMOUNT)
+    handleTransfer(event)
+
+    assert.entityCount("Transfer", 1)
+  })
+
+  test("Mint increases token supply", () => {
+    let event = createTransferEvent(ZERO_ADDRESS, USER_A, AMOUNT)
+    handleTransfer(event)
+
+    assert.entityCount("Token", 1)
+    // Check token balance equals minted amount
+    let tokenId = event.address.toHexString()
+    assert.fieldEquals("Token", tokenId, "balance", AMOUNT.toString())
+  })
+
+  test("Burn decreases token supply", () => {
+    // First mint
+    let mintEvent = createTransferEvent(ZERO_ADDRESS, USER_A, AMOUNT)
+    handleTransfer(mintEvent)
+
+    // Then burn half
+    let burnAmount = BigInt.fromI32(400)
+    let burnEvent = createTransferEvent(USER_A, ZERO_ADDRESS, burnAmount)
+    handleTransfer(burnEvent)
+
+    let tokenId = burnEvent.address.toHexString()
+    assert.fieldEquals("Token", tokenId, "balance", "600")
+  })
+
+  test("Mint increments holder count", () => {
+    let event = createTransferEvent(ZERO_ADDRESS, USER_A, AMOUNT)
+    handleTransfer(event)
+
+    let tokenId = event.address.toHexString()
+    assert.fieldEquals("Token", tokenId, "holderCount", "1")
+  })
+
+  test("Transfer between users does not change supply", () => {
+    // Mint to USER_A first
+    let mintEvent = createTransferEvent(ZERO_ADDRESS, USER_A, AMOUNT)
+    handleTransfer(mintEvent)
+
+    // Transfer from USER_A to USER_B
+    let transferEvent = createTransferEvent(USER_A, USER_B, AMOUNT)
+    handleTransfer(transferEvent)
+
+    let tokenId = transferEvent.address.toHexString()
+    assert.fieldEquals("Token", tokenId, "balance", AMOUNT.toString())
+  })
+
+  test("Holder count decrements when balance reaches zero", () => {
+    // Mint to USER_A
+    let mintEvent = createTransferEvent(ZERO_ADDRESS, USER_A, AMOUNT)
+    handleTransfer(mintEvent)
+
+    // Transfer all to USER_B
+    let transferEvent = createTransferEvent(USER_A, USER_B, AMOUNT)
+    handleTransfer(transferEvent)
+
+    let tokenId = transferEvent.address.toHexString()
+    // USER_A has 0 balance, USER_B has balance — holderCount should be 1
+    assert.fieldEquals("Token", tokenId, "holderCount", "1")
+  })
+
+  test("Multiple holders tracked correctly", () => {
+    // Mint to USER_A
+    let event1 = createTransferEvent(ZERO_ADDRESS, USER_A, AMOUNT)
+    handleTransfer(event1)
+
+    // Mint to USER_B
+    let event2 = createTransferEvent(ZERO_ADDRESS, USER_B, AMOUNT)
+    handleTransfer(event2)
+
+    let tokenId = event2.address.toHexString()
+    assert.fieldEquals("Token", tokenId, "holderCount", "2")
+    assert.fieldEquals("Token", tokenId, "balance", "2000")
+  })
+
+  test("TokenHolder balance updates correctly", () => {
+    let event = createTransferEvent(ZERO_ADDRESS, USER_A, AMOUNT)
+    handleTransfer(event)
+
+    assert.entityCount("TokenHolder", 1)
+    assert.fieldEquals("TokenHolder", USER_A.toHexString(), "balance", AMOUNT.toString())
+  })
+})


### PR DESCRIPTION
## Summary

Adds Matchstick test coverage for all subgraphs that previously had none, and creates a GitHub Actions CI workflow to run tests on every PR.

Follow-up to PR #112 comment about adding tests for subgraphs in the build-only CI matrix.

### New Tests (73 tests across 6 subgraphs)

| Subgraph | Tests | Coverage |
|----------|-------|----------|
| **tokenomics-l2** | 8 | Transfer handler: mint/burn supply tracking, holder count management, balance updates |
| **governance** | 12 | Full proposal lifecycle (create → vote → queue → execute → cancel), vote accumulation (for/against/abstain), VoteCastWithParams asymmetry, parameter change events |
| **service-registry** | 13 | Service creation with configHash, agent registration with deduplication, operator tracking, multisig creation with most-recent-agent selection, service termination clearing |
| **legacy-mech-fees** | 15 | LM/LMM mech creation, price updates, request fee accumulation, Global/DailyFees/MechDaily entity tracking |
| **new-mech-fees** | 15 | Native fee accrual (MechBalanceAdjusted) and withdrawal, entity hierarchy (Global → Mech → MechModel → DailyTotals → MechDaily → MechTransaction), multi-mech independence |
| **babydegen-optimism** | 10 | Service registration with OPTIMUS_AGENT_ID filtering, excluded service skipping, multisig creation with Service/ServiceIndex/AgentPortfolio entities |

### CI Workflow (`.github/workflows/test.yaml`)

Runs Matchstick tests for all 13 subgraphs on every PR and push to main:
- **Standalone manifests** (4): liquidity, tokenomics-eth, governance, legacy-mech-fees
- **Template pattern** (4): liquidity-l2, staking, tokenomics-l2, service-registry — generates manifests + symlinks
- **Per-network manifests** (1): new-mech-fees — symlinks to gnosis manifest
- **Nested subgraphs** (3): predict-omen, predict-polymarket, babydegen-optimism
- Handles `--frozen-lockfile` fallback for subgraphs without committed lockfiles

### Bug Fixes
- Fix `generate-manifests` script path in `staking/package.json` (`.ts` → `.js`)
- Fix `generate-manifests` missing `--path=.` in `service-registry/package.json`
- Add `pretest` script in `new-mech-fees/package.json` for symlink + codegen
- Fix pre-existing tokenomics-eth test imports (`Dispenser/Dispenser` → `DispenserV1/DispenserV1`, `Depository/Depository` → `DepositoryV2/DepositoryV2`) and simplify assertions to avoid entity ID format mismatch

## Test plan
- [x] All 73 new tests pass locally
- [x] Pre-existing tests (liquidity, liquidity-l2, staking, tokenomics-eth, predict-omen, predict-polymarket) unaffected
- [x] CI workflow passes — all 13 subgraphs green