### PR TITLE
feat(predict-polymarket): add v2 exchange + collateral-adapter payouts

### DIFF
--- a/abis/CTFExchangeV2.json
+++ b/abis/CTFExchangeV2.json
@@ -1,0 +1,1612 @@
+[
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "admin",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "collateral",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "ctf",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "ctfCollateral",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "outcomeTokenFactory",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "proxyFactory",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "safeFactory",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "feeReceiver",
+            "type": "address"
+          }
+        ],
+        "internalType": "struct ExchangeInitParams",
+        "name": "params",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "AlreadyAdmin",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "AlreadyOperator",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ComplementaryFillExceedsTakerFill",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ExceedsMaxPauseInterval",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "FeeExceedsMaxRate",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "FeeExceedsProceeds",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidSignature",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LastAdmin",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "MakingGtRemaining",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "MaxFeeRateExceedsCeiling",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "MismatchedArrayLengths",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "MismatchedTokenIds",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NoMakerOrders",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotAdmin",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotCrossing",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotOperator",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OrderAlreadyFilled",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "Paused",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "TooLittleTokensReceived",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UserAlreadyPaused",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UserIsPaused",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ZeroMakerAmount",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "FeeCharged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "feeReceiver",
+        "type": "address"
+      }
+    ],
+    "name": "FeeReceiverUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "maxFeeRate",
+        "type": "uint256"
+      }
+    ],
+    "name": "MaxFeeRateUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newAdminAddress",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "admin",
+        "type": "address"
+      }
+    ],
+    "name": "NewAdmin",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOperatorAddress",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "admin",
+        "type": "address"
+      }
+    ],
+    "name": "NewOperator",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "orderHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "maker",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "taker",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "enum Side",
+        "name": "side",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "makerAmountFilled",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "takerAmountFilled",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "fee",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "builder",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "metadata",
+        "type": "bytes32"
+      }
+    ],
+    "name": "OrderFilled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "orderHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "OrderPreapprovalInvalidated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "orderHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "OrderPreapproved",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "takerOrderHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "takerOrderMaker",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "enum Side",
+        "name": "side",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "makerAmountFilled",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "takerAmountFilled",
+        "type": "uint256"
+      }
+    ],
+    "name": "OrdersMatched",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "removedAdmin",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "admin",
+        "type": "address"
+      }
+    ],
+    "name": "RemovedAdmin",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "removedOperator",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "admin",
+        "type": "address"
+      }
+    ],
+    "name": "RemovedOperator",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pauser",
+        "type": "address"
+      }
+    ],
+    "name": "TradingPaused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pauser",
+        "type": "address"
+      }
+    ],
+    "name": "TradingUnpaused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "oldInterval",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newInterval",
+        "type": "uint256"
+      }
+    ],
+    "name": "UserPauseBlockIntervalUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "effectivePauseBlock",
+        "type": "uint256"
+      }
+    ],
+    "name": "UserPaused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      }
+    ],
+    "name": "UserUnpaused",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "PARENT_COLLECTION_ID",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_admin",
+        "type": "address"
+      }
+    ],
+    "name": "addAdmin",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_operator",
+        "type": "address"
+      }
+    ],
+    "name": "addOperator",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "eip712Domain",
+    "outputs": [
+      {
+        "internalType": "bytes1",
+        "name": "fields",
+        "type": "bytes1"
+      },
+      {
+        "internalType": "string",
+        "name": "name",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "version",
+        "type": "string"
+      },
+      {
+        "internalType": "uint256",
+        "name": "chainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "verifyingContract",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "salt",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "extensions",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getCollateral",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getCtf",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getCtfCollateral",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getFeeReceiver",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getMaxFeeRate",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "orderHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getOrderStatus",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "bool",
+            "name": "filled",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint248",
+            "name": "remaining",
+            "type": "uint248"
+          }
+        ],
+        "internalType": "struct OrderStatus",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getOutcomeTokenFactory",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getProxyFactory",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getProxyImplementation",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_addr",
+        "type": "address"
+      }
+    ],
+    "name": "getProxyWalletAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getSafeFactory",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getSafeImplementation",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_addr",
+        "type": "address"
+      }
+    ],
+    "name": "getSafeWalletAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "salt",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "maker",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "tokenId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "makerAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "takerAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "enum Side",
+            "name": "side",
+            "type": "uint8"
+          },
+          {
+            "internalType": "enum SignatureType",
+            "name": "signatureType",
+            "type": "uint8"
+          },
+          {
+            "internalType": "uint256",
+            "name": "timestamp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "metadata",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "builder",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes",
+            "name": "signature",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Order",
+        "name": "order",
+        "type": "tuple"
+      }
+    ],
+    "name": "hashOrder",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "orderHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "invalidatePreapprovedOrder",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_usr",
+        "type": "address"
+      }
+    ],
+    "name": "isAdmin",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_usr",
+        "type": "address"
+      }
+    ],
+    "name": "isOperator",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      }
+    ],
+    "name": "isUserPaused",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "salt",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "maker",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "tokenId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "makerAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "takerAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "enum Side",
+            "name": "side",
+            "type": "uint8"
+          },
+          {
+            "internalType": "enum SignatureType",
+            "name": "signatureType",
+            "type": "uint8"
+          },
+          {
+            "internalType": "uint256",
+            "name": "timestamp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "metadata",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "builder",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes",
+            "name": "signature",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Order",
+        "name": "takerOrder",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "salt",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "maker",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "tokenId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "makerAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "takerAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "enum Side",
+            "name": "side",
+            "type": "uint8"
+          },
+          {
+            "internalType": "enum SignatureType",
+            "name": "signatureType",
+            "type": "uint8"
+          },
+          {
+            "internalType": "uint256",
+            "name": "timestamp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "metadata",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "builder",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes",
+            "name": "signature",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Order[]",
+        "name": "makerOrders",
+        "type": "tuple[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "takerFillAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "makerFillAmounts",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "takerFeeAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "makerFeeAmounts",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "matchOrders",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "name": "onERC1155BatchReceived",
+    "outputs": [
+      {
+        "internalType": "bytes4",
+        "name": "",
+        "type": "bytes4"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "name": "onERC1155Received",
+    "outputs": [
+      {
+        "internalType": "bytes4",
+        "name": "",
+        "type": "bytes4"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "orderStatus",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "filled",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint248",
+        "name": "remaining",
+        "type": "uint248"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pauseTrading",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pauseUser",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "paused",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "salt",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "maker",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "tokenId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "makerAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "takerAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "enum Side",
+            "name": "side",
+            "type": "uint8"
+          },
+          {
+            "internalType": "enum SignatureType",
+            "name": "signatureType",
+            "type": "uint8"
+          },
+          {
+            "internalType": "uint256",
+            "name": "timestamp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "metadata",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "builder",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes",
+            "name": "signature",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Order",
+        "name": "order",
+        "type": "tuple"
+      }
+    ],
+    "name": "preapproveOrder",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_admin",
+        "type": "address"
+      }
+    ],
+    "name": "removeAdmin",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_operator",
+        "type": "address"
+      }
+    ],
+    "name": "removeOperator",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOperatorRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      }
+    ],
+    "name": "setFeeReceiver",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "rate",
+        "type": "uint256"
+      }
+    ],
+    "name": "setMaxFeeRate",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_interval",
+        "type": "uint256"
+      }
+    ],
+    "name": "setUserPauseBlockInterval",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes4",
+        "name": "interfaceId",
+        "type": "bytes4"
+      }
+    ],
+    "name": "supportsInterface",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "unpauseTrading",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "unpauseUser",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "userPauseBlockInterval",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "userPausedBlockAt",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "fee",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "cashValue",
+        "type": "uint256"
+      }
+    ],
+    "name": "validateFee",
+    "outputs": [],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "salt",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "maker",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "tokenId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "makerAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "takerAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "enum Side",
+            "name": "side",
+            "type": "uint8"
+          },
+          {
+            "internalType": "enum SignatureType",
+            "name": "signatureType",
+            "type": "uint8"
+          },
+          {
+            "internalType": "uint256",
+            "name": "timestamp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "metadata",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "builder",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes",
+            "name": "signature",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Order",
+        "name": "order",
+        "type": "tuple"
+      }
+    ],
+    "name": "validateOrder",
+    "outputs": [],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "orderHash",
+        "type": "bytes32"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "salt",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "maker",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "tokenId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "makerAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "takerAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "enum Side",
+            "name": "side",
+            "type": "uint8"
+          },
+          {
+            "internalType": "enum SignatureType",
+            "name": "signatureType",
+            "type": "uint8"
+          },
+          {
+            "internalType": "uint256",
+            "name": "timestamp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "metadata",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "builder",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes",
+            "name": "signature",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Order",
+        "name": "order",
+        "type": "tuple"
+      }
+    ],
+    "name": "validateOrderSignature",
+    "outputs": [],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/abis/CtfCollateralAdapter.json
+++ b/abis/CtfCollateralAdapter.json
@@ -1,0 +1,33 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "initiator",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "payout",
+        "type": "uint256"
+      }
+    ],
+    "name": "PositionsRedeemed",
+    "type": "event"
+  }
+]

--- a/subgraphs/predict/predict-polymarket/POLYMARKET_V2_MIGRATION_PLAN.md
+++ b/subgraphs/predict/predict-polymarket/POLYMARKET_V2_MIGRATION_PLAN.md
@@ -1,0 +1,77 @@
+# Polymarket v2 Migration
+
+Status: **Re-indexing from scratch** (graft attempt failed; see "History")
+v2 cutover: 2026-04-28 ~11:00 UTC
+
+## What changed at cutover
+
+| Concern               | v1                                             | v2                                                    |
+| --------------------- | ---------------------------------------------- | ----------------------------------------------------- |
+| Standard CTF Exchange | `0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982e`   | `0xE111180000d2663C0091e4f400237545B87B996B`          |
+| NegRisk CTF Exchange  | `0xC5d563A36AE78145C45a50134d48A1215220f80a`   | `0xe2222d279d744050d28e00520010520000310F59`          |
+| ConditionalTokens     | `0x4D97DCd97eC945f40cF65F87097ACe5EA0476045`   | unchanged                                             |
+| NegRiskAdapter        | `0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296`   | unchanged                                             |
+| Collateral (UI)       | USDC.e                                         | pUSD (6-dec, 1:1 USDC-backed; `ctfCollateral` is still USDC.e under the hood, so position IDs survive) |
+| `OrderFilled` ABI     | `makerAssetId/takerAssetId`                    | `side` (uint8) + `tokenId` + new `builder`/`metadata` |
+| `TokenRegistered`     | emitted                                        | **removed** — derive tokenIds via eth_call (see below) |
+
+## Implementation
+
+- **`src/ctf-exchange-v2.ts`** — `handleOrderFilledV2`. Reads `side` (0=BUY/1=SELL) and `tokenId` directly; normalizes to `processTradeActivity`.
+- **`src/conditional-tokens.ts`** — `handleConditionPreparation` derives both outcome tokenIds via eth_call:
+  ```
+  collectionId_i = ConditionalTokens.getCollectionId(0x0, conditionId, indexSet_i)
+  tokenId_i      = ConditionalTokens.getPositionId(collateral, collectionId_i)
+  ```
+  Branches on `oracle`: NegRiskAdapter → collateral = NegRiskAdapter; otherwise USDC.e. Writes `TokenRegistry` rows the same way `handleTokenRegistered` did. ~2 eth_calls per new binary market — negligible.
+- **`src/collateral-adapter.ts`** — `handlePositionsRedeemed` for both `CtfCollateralAdapter` and `NegRiskCtfCollateralAdapter`. Post-cutover, redemptions are routed through these adapters so the Safe receives pUSD directly. The legacy CTF / NegRiskAdapter `PayoutRedemption` events still fire post-cutover but with `redeemer = adapter` — those fall through `TraderAgent.load == null` in the existing handlers, so no double-counting.
+- **v1 handlers (`ctf-exchange.ts`, `neg-risk-mapping.ts`)** — unchanged.
+
+## Manifest layout (see `subgraph.yaml` for source of truth)
+
+- v1 exchanges: `endBlock: 86750000` (~cutover + 2 weeks safety buffer; bump if v1 stays live longer).
+- v2 exchanges: `startBlock: 85952819` (a few days before cutover; no v2 events fire until cutover, so the extra range is cheap).
+- Collateral adapters, two address pairs (Polymarket directed redemptions through one set for a short window, then switched to a different set):
+  - **Current** (live from 2026-05-01 15:00 UTC onward — the relayer cutoff for the old adapters), `startBlock: 86263778`:
+    - `CtfCollateralAdapter`: `0xAdA100Db00Ca00073811820692005400218FcE1f`
+    - `NegRiskCtfCollateralAdapter`: `0xadA2005600Dec949baf300f4C6120000bDB6eAab`
+  - **Old** (live ~2026-04-30 → 2026-05-01), pinned to `[86219367, 86263778]` so coverage is contiguous with the current pair:
+    - `CtfCollateralAdapterOld`: `0xADa100874d00e3331d00f2007a9c336a65009718`
+    - `NegRiskCtfCollateralAdapterOld`: `0xAdA200001000ef00D07553cEE7006808F895c6F1`
+
+## History
+
+### Initial plan: graft-on-top
+
+The first plan was to graft the v2 deployment on top of the paused production base
+(`QmZXBjgbyCNCrrB51kEPtNHtzzwwNHy8GnSGmLFHFGDc5Z` @ 85952819) to avoid a full
+re-index. That deploy went through and ran for several days post-cutover.
+
+### Adapter backfill graft (failed)
+
+When the collateral adapters were added (this branch), we tried a second graft on top
+of the v2-grafted deployment (`QmUMaqgrL8tTJmrSTbajqG6TFhdL2etFYJQ4EjmdjuaN6T` @ 86397457).
+graph-node refused to start with:
+
+```
+Failed to start subgraph, code: SubgraphStartFailure,
+error: store error: Unexpected null for non-null column,
+runner_index: 31, sgd: 51
+```
+
+Schema was identical to the base, so this wasn't a missing-column issue. We didn't
+chase the root cause further; the manifest was already structured to handle a clean
+re-index (current + `*Old` adapter pairs cover `[86219367, ∞)` contiguously), so we
+dropped grafting and committed to indexing from scratch.
+
+### Decision
+
+Drop `features: grafting` and the `graft:` block. Re-index from scratch. The
+`*Old` adapter dataSources backfill the historical `[86219367, 86263778]` window
+that the original graft-only deploy silently dropped.
+
+## Open
+
+- v2 `startBlock` (`85952819`) could be bumped to the actual v2 cutover block
+  (~`86145578`) to shave a few days of empty scanning off the re-index. Not
+  blocking.

--- a/subgraphs/predict/predict-polymarket/claude.md
+++ b/subgraphs/predict/predict-polymarket/claude.md
@@ -23,10 +23,12 @@ subgraphs/predict/predict-polymarket/
 ├── subgraph.yaml                    # Subgraph configuration & event mappings
 ├── src/
 │   ├── service-registry-l-2.ts      # Agent registration
-│   ├── conditional-tokens.ts        # Condition preparation and payout handling
-│   ├── ctf-exchange.ts              # Order tracking from CTF Exchange (agents as makers)
+│   ├── conditional-tokens.ts        # Condition preparation and legacy CTF payout handling
+│   ├── ctf-exchange.ts              # Order tracking from CTF Exchange v1 (agents as makers)
+│   ├── ctf-exchange-v2.ts           # Order tracking from CTF Exchange v2 (post-cutover)
 │   ├── uma-mapping.ts               # Market metadata extraction from UMA events
 │   ├── neg-risk-mapping.ts          # NegRisk market handling
+│   ├── collateral-adapter.ts        # Post-cutover payout handling (CtfCollateralAdapter / NegRiskCtfCollateralAdapter)
 │   ├── constants.ts                 # Constants
 │   └── utils.ts                     # Utility functions (settlement, payout, trade activity)
 ├── tests/                           # Test files
@@ -613,13 +615,27 @@ export function handleQuestionResolved(event: QuestionResolvedEvent): void {
 
 ---
 
-### 7. Payout Handling (conditional-tokens.ts)
+### 7. Payout Handling (conditional-tokens.ts, neg-risk-mapping.ts, collateral-adapter.ts)
 
-**Event**: `PayoutRedemption(redeemer, collateralToken, parentCollectionId, conditionId, indexSets, payout)`
+Two redemption paths exist post-v2-cutover:
 
-**Handler**: `handlePayoutRedemption`
+**Path A — Pre-cutover (legacy direct CTF / NegRiskAdapter calls)**
+- Events: `ConditionalTokens.PayoutRedemption(redeemer, collateralToken, parentCollectionId, conditionId, indexSets, payout)` and `NegRiskAdapter.PayoutRedemption(redeemer, conditionId, amounts, payout)`.
+- Handlers: `handlePayoutRedemption` / `handleNegRiskPayoutRedemption`.
+- Pre-cutover, `redeemer = agent Safe`, so `processRedemption` runs normally.
+- Post-cutover the agent no longer calls these contracts directly — calls go via the collateral adapters — so `redeemer = adapter address`. `processRedemption` early-returns at `TraderAgent.load(redeemer) == null` (the adapter isn't a registered TraderAgent), which keeps these handlers harmless and prevents double-counting against Path B.
 
-Delegates to `processRedemption()` in utils.ts:
+**Path B — Post-cutover (CtfCollateralAdapter / NegRiskCtfCollateralAdapter)**
+- Trigger: trader [PR #929](https://github.com/valory-xyz/trader/pull/929) routed redemptions through `CtfCollateralAdapter` (standard) and `NegRiskCtfCollateralAdapter` (neg-risk) so the Safe receives **pUSD directly** (the adapters wrap USDC.e → pUSD inside the redeem tx). [PR #935](https://github.com/valory-xyz/trader/pull/935) bumped both adapter addresses on 2026-05-01.
+- Event (both adapters share this signature): `PositionsRedeemed(indexed address initiator, indexed bytes32 conditionId, uint256[] amounts, uint256 payout)` — `initiator` is the agent Safe, `payout` is the pUSD amount paid out.
+- Handler: `handlePositionsRedeemed` in `src/collateral-adapter.ts` — same `processRedemption` delegation as Path A.
+- Tracked addresses (4 dataSources, all using `abis/CtfCollateralAdapter.json`):
+  - `CtfCollateralAdapter` (current): `0xAdA100Db00Ca00073811820692005400218FcE1f`
+  - `NegRiskCtfCollateralAdapter` (current): `0xadA2005600Dec949baf300f4C6120000bDB6eAab`
+  - `CtfCollateralAdapter` (old, PR #929 deploy → PR #935 swap): `0xADa100874d00e3331d00f2007a9c336a65009718`
+  - `NegRiskCtfCollateralAdapter` (old): `0xAdA200001000ef00D07553cEE7006808F895c6F1`
+
+`processRedemption` (utils.ts), shared by both paths:
 - Validates agent, question, and participant exist
 - Creates immutable `PayoutRedemption` entity (audit trail)
 - Updates payout totals only: `agent.totalPayout`, `participant.totalPayout`, `global.totalPayout`

--- a/subgraphs/predict/predict-polymarket/schema.graphql
+++ b/subgraphs/predict/predict-polymarket/schema.graphql
@@ -61,6 +61,10 @@ type Bet @entity (immutable: false) {
   countedInProfit: Boolean!
   question: Question
   dailyStatistic: DailyProfitStatistic
+  # v2-only: builder-program attribution + 32-byte metadata slot from OrderFilled.
+  # Null for v1 bets (v1 event does not emit these fields).
+  builder: Bytes
+  metadata: Bytes
   blockTimestamp: BigInt!
   transactionHash: Bytes!
 }

--- a/subgraphs/predict/predict-polymarket/src/collateral-adapter.ts
+++ b/subgraphs/predict/predict-polymarket/src/collateral-adapter.ts
@@ -1,0 +1,26 @@
+import { PositionsRedeemed as PositionsRedeemedEvent } from "../generated/CtfCollateralAdapter/CtfCollateralAdapter";
+import { processRedemption } from "./utils";
+
+// Post-v2 cutover, agents redeem via CtfCollateralAdapter (standard markets) or
+// NegRiskCtfCollateralAdapter (neg-risk markets). Both wrap USDC.e → pUSD inside
+// the redeem tx, so the legacy `PayoutRedemption` events from CTF / NegRiskAdapter
+// fire with `redeemer = adapter`, not the agent — and our existing handlers
+// silently early-return at the `TraderAgent.load(redeemer) == null` check.
+//
+// `PositionsRedeemed` is the adapter-side event whose `initiator` is the Safe and
+// whose `payout` is the actual pUSD paid out. Both adapters emit the same event
+// signature, so all four dataSources (old/new × standard/neg-risk) share this
+// handler.
+export function handlePositionsRedeemed(
+  event: PositionsRedeemedEvent,
+): void {
+  processRedemption(
+    event.params.initiator,
+    event.params.conditionId,
+    event.params.payout,
+    event.block.timestamp,
+    event.block.number,
+    event.transaction.hash,
+    event.logIndex.toI32(),
+  );
+}

--- a/subgraphs/predict/predict-polymarket/src/conditional-tokens.ts
+++ b/subgraphs/predict/predict-polymarket/src/conditional-tokens.ts
@@ -1,10 +1,65 @@
 import {
   ConditionPreparation as ConditionPreparationEvent,
   PayoutRedemption as PayoutRedemptionEvent,
+  ConditionalTokens,
 } from "../generated/ConditionalTokens/ConditionalTokens";
-import { QuestionIdToConditionId } from "../generated/schema";
-import { log } from "@graphprotocol/graph-ts";
+import {
+  QuestionIdToConditionId,
+  TokenRegistry,
+} from "../generated/schema";
+import { Address, BigInt, Bytes, log } from "@graphprotocol/graph-ts";
 import { processRedemption } from "./utils";
+import {
+  NEG_RISK_ADAPTER_ADDRESS,
+  USDC_E_ADDRESS,
+  ZERO_BYTES32,
+} from "./constants";
+
+function registerOutcomeToken(
+  ctf: ConditionalTokens,
+  conditionId: Bytes,
+  collateral: Address,
+  indexSet: i32,
+  outcomeIndex: i32,
+  txHash: Bytes,
+): void {
+  let collectionIdCall = ctf.try_getCollectionId(
+    ZERO_BYTES32,
+    conditionId,
+    BigInt.fromI32(indexSet),
+  );
+  if (collectionIdCall.reverted) {
+    log.warning(
+      "getCollectionId reverted for condition {} indexSet {}",
+      [conditionId.toHexString(), indexSet.toString()],
+    );
+    return;
+  }
+
+  let positionIdCall = ctf.try_getPositionId(
+    collateral,
+    collectionIdCall.value,
+  );
+  if (positionIdCall.reverted) {
+    log.warning(
+      "getPositionId reverted for condition {} indexSet {}",
+      [conditionId.toHexString(), indexSet.toString()],
+    );
+    return;
+  }
+
+  let tokenId = positionIdCall.value;
+  let tokenIdBytes = Bytes.fromByteArray(Bytes.fromBigInt(tokenId));
+
+  if (TokenRegistry.load(tokenIdBytes) != null) return;
+
+  let registry = new TokenRegistry(tokenIdBytes);
+  registry.tokenId = tokenId;
+  registry.conditionId = conditionId;
+  registry.outcomeIndex = BigInt.fromI32(outcomeIndex);
+  registry.transactionHash = txHash;
+  registry.save();
+}
 
 export function handleConditionPreparation(
   event: ConditionPreparationEvent,
@@ -17,6 +72,11 @@ export function handleConditionPreparation(
   let bridge = QuestionIdToConditionId.load(event.params.questionId);
 
   if (bridge !== null) {
+    // NOTE: this early-return also gates the v2 TokenRegistry derivation below.
+    // For v2-exclusive markets with questionId reuse, the second conditionId's
+    // tokens won't be derived and handleOrderFilledV2 will drop trades via the
+    // TokenRegistry.load === null warning path. v1-era repeats are covered by
+    // handleTokenRegistered.
     log.warning(
       "REPETITIVE_QUESTION_ID detected: {} | Existing ConditionId: {} | New ConditionId: {} | Txn Hash: {}",
       [
@@ -35,6 +95,30 @@ export function handleConditionPreparation(
   entity.oracle = event.params.oracle;
   entity.transactionHash = event.transaction.hash;
   entity.save();
+
+  // v2 exchanges do not emit TokenRegistered — derive outcome tokenIds here
+  // so MarketParticipant lookups work for post-cutover markets. Idempotent:
+  // if TokenRegistry row already exists (v1 handler path), we skip.
+  let isNegRisk = event.params.oracle.equals(NEG_RISK_ADAPTER_ADDRESS);
+  let collateral = isNegRisk ? NEG_RISK_ADAPTER_ADDRESS : USDC_E_ADDRESS;
+
+  let ctf = ConditionalTokens.bind(event.address);
+  registerOutcomeToken(
+    ctf,
+    event.params.conditionId,
+    collateral,
+    1,
+    0,
+    event.transaction.hash,
+  );
+  registerOutcomeToken(
+    ctf,
+    event.params.conditionId,
+    collateral,
+    2,
+    1,
+    event.transaction.hash,
+  );
 }
 
 export function handlePayoutRedemption(event: PayoutRedemptionEvent): void {

--- a/subgraphs/predict/predict-polymarket/src/constants.ts
+++ b/subgraphs/predict/predict-polymarket/src/constants.ts
@@ -1,5 +1,20 @@
-import { BigInt } from "@graphprotocol/graph-ts";
+import { Address, BigInt, Bytes } from "@graphprotocol/graph-ts";
 
 export const PREDICT_AGENT_ID = 86;
 
 export const ONE_DAY = BigInt.fromI32(86400);
+
+// v2 migration: collateral used for ConditionalTokens positionId derivation.
+// Regular markets pin positions against USDC.e; negrisk markets against the
+// NegRiskAdapter wrapper. v2 exchanges keep ctfCollateral = USDC.e, so
+// tokenIds for all pre-cutover markets stay valid.
+export const USDC_E_ADDRESS = Address.fromString(
+  "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+);
+export const NEG_RISK_ADAPTER_ADDRESS = Address.fromString(
+  "0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296",
+);
+
+export const ZERO_BYTES32 = Bytes.fromHexString(
+  "0x0000000000000000000000000000000000000000000000000000000000000000",
+) as Bytes;

--- a/subgraphs/predict/predict-polymarket/src/ctf-exchange-v2.ts
+++ b/subgraphs/predict/predict-polymarket/src/ctf-exchange-v2.ts
@@ -1,0 +1,82 @@
+import { BigInt, Bytes, log } from "@graphprotocol/graph-ts";
+import { OrderFilled as OrderFilledV2Event } from "../generated/CTFExchangeV2/CTFExchangeV2";
+import { Bet, Question, TokenRegistry, TraderAgent } from "../generated/schema";
+import { getDailyProfitStatistic, processTradeActivity } from "./utils";
+
+export function handleOrderFilledV2(event: OrderFilledV2Event): void {
+  // 1. Identify if the maker is one of our TraderAgents
+  let agent = TraderAgent.load(event.params.maker);
+  if (agent === null) return;
+
+  // 2. Direction: side 0 = BUY, 1 = SELL (v2 is explicit)
+  //    BUY  — maker pays collateral (makerAmountFilled), receives shares (takerAmountFilled)
+  //    SELL — maker gives shares (makerAmountFilled), receives collateral (takerAmountFilled)
+  //
+  //    Sells use NEGATIVE amounts/shares (omen convention, matches v1 handler).
+  let isBuying = event.params.side == 0;
+
+  let usdcAmount = isBuying
+    ? event.params.makerAmountFilled
+    : BigInt.zero().minus(event.params.takerAmountFilled);
+
+  let sharesAmount = isBuying
+    ? event.params.takerAmountFilled
+    : BigInt.zero().minus(event.params.makerAmountFilled);
+
+  // 3. Lookup the outcome index from TokenRegistry (populated at
+  //    ConditionPreparation time for v2, or via v1 TokenRegistered for v1-era).
+  let tokenIdBytes = Bytes.fromByteArray(
+    Bytes.fromBigInt(event.params.tokenId),
+  );
+  let tokenRegistry = TokenRegistry.load(tokenIdBytes);
+  if (tokenRegistry === null) {
+    log.warning("TokenRegistry missing for token {} in tx {}", [
+      event.params.tokenId.toString(),
+      event.transaction.hash.toHexString(),
+    ]);
+    return;
+  }
+
+  // 4. Update Daily Stats
+  let dailyStat = getDailyProfitStatistic(agent.id, event.block.timestamp);
+  dailyStat.totalBets += 1;
+  dailyStat.totalTraded = dailyStat.totalTraded.plus(usdcAmount);
+  dailyStat.save();
+
+  // 5. Create Bet
+  let betId = event.transaction.hash.concat(
+    Bytes.fromI32(event.logIndex.toI32()),
+  );
+  let bet = new Bet(betId);
+  bet.bettor = agent.id;
+  bet.outcomeIndex = tokenRegistry.outcomeIndex;
+  bet.amount = usdcAmount;
+  bet.shares = sharesAmount;
+  bet.isBuy = isBuying;
+  bet.blockTimestamp = event.block.timestamp;
+  bet.transactionHash = event.transaction.hash;
+  bet.dailyStatistic = dailyStat.id;
+  bet.countedInTotal = false;
+  bet.countedInProfit = false;
+  bet.builder = event.params.builder;
+  bet.metadata = event.params.metadata;
+
+  let question = Question.load(tokenRegistry.conditionId);
+  if (question !== null) {
+    bet.question = question.id;
+  }
+  bet.save();
+
+  // 6. Process Agent, Participant, and Global atomically
+  processTradeActivity(
+    agent,
+    tokenRegistry.conditionId,
+    betId,
+    usdcAmount,
+    event.block.timestamp,
+    event.block.number,
+    event.transaction.hash,
+    tokenRegistry.outcomeIndex,
+    sharesAmount,
+  );
+}

--- a/subgraphs/predict/predict-polymarket/subgraph.yaml
+++ b/subgraphs/predict/predict-polymarket/subgraph.yaml
@@ -47,6 +47,7 @@ dataSources:
         - Bet
         - Global
         - DailyProfitStatistic
+        - TokenRegistry
       abis:
         - name: ConditionalTokens
           file: ../../../abis/ConditionalTokens.json
@@ -141,6 +142,10 @@ dataSources:
           handler: handleOutcomeReported
         - event: PayoutRedemption(indexed address,indexed bytes32,uint256[],uint256)
           handler: handleNegRiskPayoutRedemption
+  # v1 CTF Exchange — retired at Polymarket v2 cutover 2026-04-28 11:00 UTC.
+  # endBlock 86750000 ≈ May 12 2026 (cutover + ~2 weeks) as a safety buffer
+  # for any tail trades on v1 post-cutover. If the migration slips or v1
+  # remains active past then, extend this endBlock.
   - kind: ethereum/contract
     name: CTFExchange
     network: matic
@@ -148,6 +153,7 @@ dataSources:
       address: "0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982e"
       abi: CTFExchange
       startBlock: 78425180
+      endBlock: 86750000
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -176,6 +182,7 @@ dataSources:
       address: "0xC5d563A36AE78145C45a50134d48A1215220f80a"
       abi: CTFExchange
       startBlock: 78425180
+      endBlock: 86750000
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -197,3 +204,179 @@ dataSources:
           handler: handleOrderFilled
         - event: TokenRegistered(indexed uint256,indexed uint256,indexed bytes32)
           handler: handleTokenRegistered
+  # v2 CTF Exchange (Polymarket CLOB v2, cutover 2026-04-28 ~11:00 UTC).
+  # OrderFilled signature changed: side + tokenId replace makerAssetId/takerAssetId,
+  # and the exchange no longer emits TokenRegistered (handled via eth_call at
+  # ConditionPreparation time instead — see src/conditional-tokens.ts).
+  - kind: ethereum/contract
+    name: CTFExchangeV2
+    network: matic
+    source:
+      address: "0xE111180000d2663C0091e4f400237545B87B996B"
+      abi: CTFExchangeV2
+      startBlock: 85952819 # before v2 cutover (2026-04-28); no events fire until cutover
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      file: ./src/ctf-exchange-v2.ts
+      entities:
+        - Bet
+        - Question
+        - TokenRegistry
+        - TraderAgent
+        - Global
+        - MarketParticipant
+        - DailyProfitStatistic
+      abis:
+        - name: CTFExchangeV2
+          file: ../../../abis/CTFExchangeV2.json
+      eventHandlers:
+        - event: OrderFilled(indexed bytes32,indexed address,indexed address,uint8,uint256,uint256,uint256,uint256,bytes32,bytes32)
+          handler: handleOrderFilledV2
+  - kind: ethereum/contract
+    name: NegRiskCTFExchangeV2
+    network: matic
+    source:
+      address: "0xe2222d279d744050d28e00520010520000310F59"
+      abi: CTFExchangeV2
+      startBlock: 85952819 # before v2 cutover (2026-04-28); no events fire until cutover
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      file: ./src/ctf-exchange-v2.ts
+      entities:
+        - Bet
+        - Question
+        - TokenRegistry
+        - TraderAgent
+        - Global
+        - MarketParticipant
+        - DailyProfitStatistic
+      abis:
+        - name: CTFExchangeV2
+          file: ../../../abis/CTFExchangeV2.json
+      eventHandlers:
+        - event: OrderFilled(indexed bytes32,indexed address,indexed address,uint8,uint256,uint256,uint256,uint256,bytes32,bytes32)
+          handler: handleOrderFilledV2
+  # Polymarket v2 collateral adapters. Post-cutover, redemptions are routed
+  # through these adapters so the Safe receives pUSD directly. The legacy
+  # CTF / NegRiskAdapter PayoutRedemption events still fire but with
+  # `redeemer = adapter` — those fall through TraderAgent.load == null in our
+  # existing handlers, so no double-counting. Actual Safe payout is in the
+  # adapter-side PositionsRedeemed event (`initiator` = Safe, `payout` in pUSD).
+  #
+  # Two address pairs (same ABI, same handler) because Polymarket directed
+  # redemptions through one set of adapter contracts for a short window, then
+  # switched to a different set:
+  #   • Current addresses, live from 2026-05-01 15:00 UTC onward,
+  #     startBlock 86263778.
+  #   • *Old addresses, live ~2026-04-30 → 2026-05-01, pinned to
+  #     [86219367, 86263778] so coverage is contiguous with the current pair.
+  - kind: ethereum/contract
+    name: CtfCollateralAdapter
+    network: matic
+    source:
+      address: "0xAdA100Db00Ca00073811820692005400218FcE1f"
+      abi: CtfCollateralAdapter
+      startBlock: 86263778
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      file: ./src/collateral-adapter.ts
+      entities:
+        - TraderAgent
+        - MarketParticipant
+        - Question
+        - Global
+        - DailyProfitStatistic
+        - PayoutRedemption
+      abis:
+        - name: CtfCollateralAdapter
+          file: ../../../abis/CtfCollateralAdapter.json
+      eventHandlers:
+        - event: PositionsRedeemed(indexed address,indexed bytes32,uint256[],uint256)
+          handler: handlePositionsRedeemed
+  - kind: ethereum/contract
+    name: NegRiskCtfCollateralAdapter
+    network: matic
+    source:
+      address: "0xadA2005600Dec949baf300f4C6120000bDB6eAab"
+      abi: CtfCollateralAdapter
+      startBlock: 86263778
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      file: ./src/collateral-adapter.ts
+      entities:
+        - TraderAgent
+        - MarketParticipant
+        - Question
+        - Global
+        - DailyProfitStatistic
+        - PayoutRedemption
+      abis:
+        - name: CtfCollateralAdapter
+          file: ../../../abis/CtfCollateralAdapter.json
+      eventHandlers:
+        - event: PositionsRedeemed(indexed address,indexed bytes32,uint256[],uint256)
+          handler: handlePositionsRedeemed
+  # *Old adapters: the initial set Polymarket directed redemptions through,
+  # live ~2026-04-30 (block 86219367) → 2026-05-01 15:00 UTC. Pinned to
+  # [86219367, 86263778] so coverage is contiguous with the current adapter
+  # dataSources from 86263778 forward.
+  - kind: ethereum/contract
+    name: CtfCollateralAdapterOld
+    network: matic
+    source:
+      address: "0xADa100874d00e3331d00f2007a9c336a65009718"
+      abi: CtfCollateralAdapter
+      startBlock: 86219367
+      endBlock: 86263778
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      file: ./src/collateral-adapter.ts
+      entities:
+        - TraderAgent
+        - MarketParticipant
+        - Question
+        - Global
+        - DailyProfitStatistic
+        - PayoutRedemption
+      abis:
+        - name: CtfCollateralAdapter
+          file: ../../../abis/CtfCollateralAdapter.json
+      eventHandlers:
+        - event: PositionsRedeemed(indexed address,indexed bytes32,uint256[],uint256)
+          handler: handlePositionsRedeemed
+  - kind: ethereum/contract
+    name: NegRiskCtfCollateralAdapterOld
+    network: matic
+    source:
+      address: "0xAdA200001000ef00D07553cEE7006808F895c6F1"
+      abi: CtfCollateralAdapter
+      startBlock: 86219367
+      endBlock: 86263778
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      file: ./src/collateral-adapter.ts
+      entities:
+        - TraderAgent
+        - MarketParticipant
+        - Question
+        - Global
+        - DailyProfitStatistic
+        - PayoutRedemption
+      abis:
+        - name: CtfCollateralAdapter
+          file: ../../../abis/CtfCollateralAdapter.json
+      eventHandlers:
+        - event: PositionsRedeemed(indexed address,indexed bytes32,uint256[],uint256)
+          handler: handlePositionsRedeemed

--- a/subgraphs/predict/predict-polymarket/tests/conditional-tokens.test.ts
+++ b/subgraphs/predict/predict-polymarket/tests/conditional-tokens.test.ts
@@ -2,7 +2,8 @@ import { assert, describe, test, clearStore, beforeEach, newMockEvent } from "ma
 import { Address, BigInt, Bytes, ethereum } from "@graphprotocol/graph-ts";
 import { handleConditionPreparation, handlePayoutRedemption } from "../src/conditional-tokens";
 import { ConditionPreparation as ConditionPreparationEvent, PayoutRedemption as PayoutRedemptionEvent } from "../generated/ConditionalTokens/ConditionalTokens";
-import { QuestionIdToConditionId } from "../generated/schema";
+import { QuestionIdToConditionId, TokenRegistry } from "../generated/schema";
+import { mockConditionalTokensCalls, NEG_RISK_ADAPTER, USDC_E } from "./test-helpers";
 
 const ORACLE = Address.fromString("0x1234567890123456789012345678901234567890");
 const QUESTION_ID = Bytes.fromHexString("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890");
@@ -53,6 +54,7 @@ describe("ConditionalTokens - ConditionPreparation Handler", () => {
   });
 
   test("Should create QuestionIdToConditionId bridge for binary outcome (2 outcomes)", () => {
+    mockConditionalTokensCalls(CONDITION_ID, USDC_E);
     let event = createConditionPreparationEvent(CONDITION_ID, ORACLE, QUESTION_ID, 2);
 
     handleConditionPreparation(event);
@@ -87,6 +89,9 @@ describe("ConditionalTokens - ConditionPreparation Handler", () => {
     let conditionId1 = Bytes.fromHexString("0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc");
     let conditionId2 = Bytes.fromHexString("0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd");
 
+    mockConditionalTokensCalls(conditionId1, USDC_E);
+    mockConditionalTokensCalls(conditionId2, USDC_E);
+
     let event1 = createConditionPreparationEvent(conditionId1, ORACLE, questionId1, 2);
     let event2 = createConditionPreparationEvent(conditionId2, ORACLE, questionId2, 2);
 
@@ -99,6 +104,7 @@ describe("ConditionalTokens - ConditionPreparation Handler", () => {
   });
 
   test("Bridge should link questionId to correct conditionId", () => {
+    mockConditionalTokensCalls(CONDITION_ID, USDC_E);
     let event = createConditionPreparationEvent(CONDITION_ID, ORACLE, QUESTION_ID, 2);
 
     handleConditionPreparation(event);
@@ -108,6 +114,7 @@ describe("ConditionalTokens - ConditionPreparation Handler", () => {
   });
 
   test("Should create bridge entity with any oracle address", () => {
+    mockConditionalTokensCalls(CONDITION_ID, USDC_E);
     let event = createConditionPreparationEvent(CONDITION_ID, Address.zero(), QUESTION_ID, 2);
 
     handleConditionPreparation(event);
@@ -152,6 +159,7 @@ describe("ConditionalTokens - Edge Cases", () => {
   });
 
   test("Should use questionId correctly as unique identifier for bridge", () => {
+    mockConditionalTokensCalls(CONDITION_ID, USDC_E);
     let event = createConditionPreparationEvent(CONDITION_ID, ORACLE, QUESTION_ID, 2);
 
     handleConditionPreparation(event);
@@ -169,10 +177,79 @@ describe("ConditionalTokens - Edge Cases", () => {
     let questionId = Bytes.fromHexString("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
     let conditionId = Bytes.fromHexString("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
 
+    mockConditionalTokensCalls(conditionId, USDC_E);
     let event = createConditionPreparationEvent(conditionId, ORACLE, questionId, 2);
     handleConditionPreparation(event);
 
     assert.fieldEquals("QuestionIdToConditionId", questionId.toHexString(), "id", questionId.toHexString());
     assert.fieldEquals("QuestionIdToConditionId", questionId.toHexString(), "conditionId", conditionId.toHexString());
+  });
+});
+
+describe("ConditionalTokens - v2 TokenRegistry derivation", () => {
+  beforeEach(() => {
+    clearStore();
+  });
+
+  test("Should derive both outcome tokenIds via eth_calls for a regular binary market", () => {
+    let tokenIdBytes = mockConditionalTokensCalls(CONDITION_ID, USDC_E);
+
+    let event = createConditionPreparationEvent(CONDITION_ID, ORACLE, QUESTION_ID, 2);
+    handleConditionPreparation(event);
+
+    let id0 = tokenIdBytes[0].toHexString();
+    assert.fieldEquals("TokenRegistry", id0, "conditionId", CONDITION_ID.toHexString());
+    assert.fieldEquals("TokenRegistry", id0, "outcomeIndex", "0");
+
+    let id1 = tokenIdBytes[1].toHexString();
+    assert.fieldEquals("TokenRegistry", id1, "conditionId", CONDITION_ID.toHexString());
+    assert.fieldEquals("TokenRegistry", id1, "outcomeIndex", "1");
+  });
+
+  test("Should use NegRiskAdapter as collateral when oracle is NegRiskAdapter", () => {
+    // NegRisk branch — collateral for positionId derivation switches
+    let tokenIdBytes = mockConditionalTokensCalls(CONDITION_ID, NEG_RISK_ADAPTER);
+
+    let event = createConditionPreparationEvent(
+      CONDITION_ID,
+      NEG_RISK_ADAPTER,
+      QUESTION_ID,
+      2,
+    );
+    handleConditionPreparation(event);
+
+    let id0 = tokenIdBytes[0].toHexString();
+    assert.fieldEquals("TokenRegistry", id0, "conditionId", CONDITION_ID.toHexString());
+    assert.fieldEquals("TokenRegistry", id0, "outcomeIndex", "0");
+  });
+
+  test("Should skip TokenRegistry derivation for non-binary markets", () => {
+    // Mock the eth_calls so that, if the outcomeSlotCount guard were removed,
+    // registerOutcomeToken would succeed and create rows. This proves the
+    // guard is what gates creation — not unmocked-call auto-reverts.
+    mockConditionalTokensCalls(CONDITION_ID, USDC_E);
+
+    let event = createConditionPreparationEvent(CONDITION_ID, ORACLE, QUESTION_ID, 3);
+    handleConditionPreparation(event);
+
+    assert.entityCount("TokenRegistry", 0);
+  });
+
+  test("Should not overwrite existing TokenRegistry entries (idempotent)", () => {
+    let tokenIdBytes = mockConditionalTokensCalls(CONDITION_ID, USDC_E);
+
+    // Pre-seed a TokenRegistry row (simulating v1 TokenRegistered handler having run)
+    let existing = new TokenRegistry(tokenIdBytes[0]);
+    existing.tokenId = BigInt.fromI32(12345);
+    existing.conditionId = Bytes.fromHexString("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    existing.outcomeIndex = BigInt.fromI32(99);
+    existing.transactionHash = Bytes.fromHexString("0x" + "de".repeat(32));
+    existing.save();
+
+    let event = createConditionPreparationEvent(CONDITION_ID, ORACLE, QUESTION_ID, 2);
+    handleConditionPreparation(event);
+
+    // Pre-existing row must be unchanged
+    assert.fieldEquals("TokenRegistry", tokenIdBytes[0].toHexString(), "outcomeIndex", "99");
   });
 });

--- a/subgraphs/predict/predict-polymarket/tests/ctf-exchange-v2.test.ts
+++ b/subgraphs/predict/predict-polymarket/tests/ctf-exchange-v2.test.ts
@@ -1,0 +1,356 @@
+import {
+  assert,
+  describe,
+  test,
+  clearStore,
+  beforeEach,
+  newMockEvent,
+} from "matchstick-as/assembly/index";
+import { Address, BigInt, Bytes, ethereum } from "@graphprotocol/graph-ts";
+import { handleOrderFilledV2 } from "../src/ctf-exchange-v2";
+import { OrderFilled } from "../generated/CTFExchangeV2/CTFExchangeV2";
+import {
+  TraderAgent,
+  Question,
+  MarketMetadata,
+  TokenRegistry,
+} from "../generated/schema";
+
+const CONDITION_ID = Bytes.fromHexString(
+  "0x1111111111111111111111111111111111111111111111111111111111111111",
+);
+const TOKEN_ID_0 = BigInt.fromI32(100);
+const TOKEN_ID_1 = BigInt.fromI32(101);
+const TAKER = Address.fromString("0x1234567890123456789012345678901234567890");
+const MAKER = Address.fromString("0x2234567890123456789012345678901234567890");
+const ORDER_HASH = Bytes.fromHexString(
+  "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+);
+const BUILDER = Bytes.fromHexString(
+  "0x0000000000000000000000000000000000000000000000000000000000000000",
+);
+const METADATA = Bytes.fromHexString(
+  "0x0000000000000000000000000000000000000000000000000000000000000000",
+);
+
+function createOrderFilledV2Event(
+  orderHash: Bytes,
+  maker: Address,
+  taker: Address,
+  side: i32,
+  tokenId: BigInt,
+  makerAmountFilled: BigInt,
+  takerAmountFilled: BigInt,
+  fee: BigInt,
+  builder: Bytes,
+  metadata: Bytes,
+): OrderFilled {
+  let event = changetype<OrderFilled>(newMockEvent());
+  event.parameters = new Array();
+
+  event.parameters.push(new ethereum.EventParam("orderHash", ethereum.Value.fromFixedBytes(orderHash)));
+  event.parameters.push(new ethereum.EventParam("maker", ethereum.Value.fromAddress(maker)));
+  event.parameters.push(new ethereum.EventParam("taker", ethereum.Value.fromAddress(taker)));
+  event.parameters.push(new ethereum.EventParam("side", ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(side))));
+  event.parameters.push(new ethereum.EventParam("tokenId", ethereum.Value.fromUnsignedBigInt(tokenId)));
+  event.parameters.push(new ethereum.EventParam("makerAmountFilled", ethereum.Value.fromUnsignedBigInt(makerAmountFilled)));
+  event.parameters.push(new ethereum.EventParam("takerAmountFilled", ethereum.Value.fromUnsignedBigInt(takerAmountFilled)));
+  event.parameters.push(new ethereum.EventParam("fee", ethereum.Value.fromUnsignedBigInt(fee)));
+  event.parameters.push(new ethereum.EventParam("builder", ethereum.Value.fromFixedBytes(builder)));
+  event.parameters.push(new ethereum.EventParam("metadata", ethereum.Value.fromFixedBytes(metadata)));
+
+  return event;
+}
+
+function setupTraderAgent(address: Address, serviceId: BigInt): void {
+  let agent = new TraderAgent(address);
+  agent.serviceId = serviceId;
+  agent.totalBets = 0;
+  agent.totalTraded = BigInt.zero();
+  agent.totalTradedSettled = BigInt.zero();
+  agent.totalPayout = BigInt.zero();
+  agent.totalExpectedPayout = BigInt.zero();
+  agent.blockNumber = BigInt.fromI32(1);
+  agent.blockTimestamp = BigInt.fromI32(1);
+  agent.transactionHash = Bytes.fromHexString(
+    "0x1234567890123456789012345678901234567890123456789012345678901234",
+  );
+  agent.save();
+}
+
+function setupQuestion(conditionId: Bytes, questionId: Bytes): void {
+  let metadata = new MarketMetadata(questionId);
+  metadata.title = "Test Question";
+  metadata.outcomes = ["Yes", "No"];
+  metadata.rawAncillaryData = "test";
+  metadata.save();
+
+  let question = new Question(conditionId);
+  question.questionId = questionId;
+  question.metadata = metadata.id;
+  question.isNegRisk = false;
+  question.blockNumber = BigInt.fromI32(1);
+  question.blockTimestamp = BigInt.fromI32(1);
+  question.transactionHash = Bytes.fromHexString(
+    "0x1234567890123456789012345678901234567890123456789012345678901234",
+  );
+  question.save();
+}
+
+function setupTokenRegistry(tokenId: BigInt, conditionId: Bytes, outcomeIndex: i32): void {
+  let tokenIdBytes = Bytes.fromByteArray(Bytes.fromBigInt(tokenId));
+  let registry = new TokenRegistry(tokenIdBytes);
+  registry.tokenId = tokenId;
+  registry.conditionId = conditionId;
+  registry.outcomeIndex = BigInt.fromI32(outcomeIndex);
+  registry.transactionHash = Bytes.fromHexString(
+    "0x1234567890123456789012345678901234567890123456789012345678901234",
+  );
+  registry.save();
+}
+
+describe("CTFExchangeV2 - OrderFilled Handler", () => {
+  beforeEach(() => {
+    clearStore();
+  });
+
+  test("Should create Bet when maker is a TraderAgent buying (side=0)", () => {
+    setupTraderAgent(MAKER, BigInt.fromI32(1));
+    setupQuestion(
+      CONDITION_ID,
+      Bytes.fromHexString(
+        "0x1234567890123456789012345678901234567890123456789012345678901234",
+      ),
+    );
+    setupTokenRegistry(TOKEN_ID_1, CONDITION_ID, 1);
+
+    // BUY: maker pays collateral (makerAmountFilled), receives shares (takerAmountFilled)
+    let event = createOrderFilledV2Event(
+      ORDER_HASH,
+      MAKER,
+      TAKER,
+      0, // side = BUY
+      TOKEN_ID_1,
+      BigInt.fromI32(500000), // makerAmountFilled (USDC paid)
+      BigInt.fromI32(1000000), // takerAmountFilled (shares received)
+      BigInt.fromI32(1000),
+      BUILDER,
+      METADATA,
+    );
+
+    handleOrderFilledV2(event);
+
+    let betId = event.transaction.hash
+      .concat(Bytes.fromI32(event.logIndex.toI32()))
+      .toHexString();
+    assert.fieldEquals("Bet", betId, "bettor", MAKER.toHexString());
+    assert.fieldEquals("Bet", betId, "outcomeIndex", "1");
+    assert.fieldEquals("Bet", betId, "amount", "500000");
+    assert.fieldEquals("Bet", betId, "shares", "1000000");
+    assert.fieldEquals("Bet", betId, "isBuy", "true");
+    assert.fieldEquals("Bet", betId, "countedInTotal", "false");
+    assert.fieldEquals("Bet", betId, "countedInProfit", "false");
+  });
+
+  test("Should create Bet with NEGATIVE amounts when maker is selling (side=1)", () => {
+    setupTraderAgent(MAKER, BigInt.fromI32(1));
+    setupQuestion(
+      CONDITION_ID,
+      Bytes.fromHexString(
+        "0x1234567890123456789012345678901234567890123456789012345678901234",
+      ),
+    );
+    setupTokenRegistry(TOKEN_ID_0, CONDITION_ID, 0);
+
+    // SELL: maker gives shares (makerAmountFilled), receives collateral (takerAmountFilled)
+    let event = createOrderFilledV2Event(
+      ORDER_HASH,
+      MAKER,
+      TAKER,
+      1, // side = SELL
+      TOKEN_ID_0,
+      BigInt.fromI32(600000), // makerAmountFilled (shares given)
+      BigInt.fromI32(300000), // takerAmountFilled (USDC received)
+      BigInt.fromI32(500),
+      BUILDER,
+      METADATA,
+    );
+
+    handleOrderFilledV2(event);
+
+    let betId = event.transaction.hash
+      .concat(Bytes.fromI32(event.logIndex.toI32()))
+      .toHexString();
+    assert.fieldEquals("Bet", betId, "bettor", MAKER.toHexString());
+    assert.fieldEquals("Bet", betId, "outcomeIndex", "0");
+    assert.fieldEquals("Bet", betId, "amount", "-300000");
+    assert.fieldEquals("Bet", betId, "shares", "-600000");
+    assert.fieldEquals("Bet", betId, "isBuy", "false");
+  });
+
+  test("Should not create Bet when maker is not a TraderAgent", () => {
+    setupQuestion(
+      CONDITION_ID,
+      Bytes.fromHexString(
+        "0x1234567890123456789012345678901234567890123456789012345678901234",
+      ),
+    );
+    setupTokenRegistry(TOKEN_ID_1, CONDITION_ID, 1);
+
+    let event = createOrderFilledV2Event(
+      ORDER_HASH,
+      MAKER,
+      TAKER,
+      0,
+      TOKEN_ID_1,
+      BigInt.fromI32(500000),
+      BigInt.fromI32(1000000),
+      BigInt.fromI32(1000),
+      BUILDER,
+      METADATA,
+    );
+
+    handleOrderFilledV2(event);
+
+    let betId = event.transaction.hash
+      .concat(Bytes.fromI32(event.logIndex.toI32()))
+      .toHexString();
+    assert.notInStore("Bet", betId);
+  });
+
+  test("Should skip bet creation when TokenRegistry is missing", () => {
+    setupTraderAgent(MAKER, BigInt.fromI32(1));
+    setupQuestion(
+      CONDITION_ID,
+      Bytes.fromHexString(
+        "0x1234567890123456789012345678901234567890123456789012345678901234",
+      ),
+    );
+    // No TokenRegistry setup — handler should bail.
+
+    let event = createOrderFilledV2Event(
+      ORDER_HASH,
+      MAKER,
+      TAKER,
+      0,
+      TOKEN_ID_1,
+      BigInt.fromI32(500000),
+      BigInt.fromI32(1000000),
+      BigInt.fromI32(1000),
+      BUILDER,
+      METADATA,
+    );
+
+    handleOrderFilledV2(event);
+
+    let betId = event.transaction.hash
+      .concat(Bytes.fromI32(event.logIndex.toI32()))
+      .toHexString();
+    assert.notInStore("Bet", betId);
+    assert.fieldEquals("TraderAgent", MAKER.toHexString(), "totalBets", "0");
+  });
+
+  test("Should update TraderAgent and Global statistics for a buy", () => {
+    setupTraderAgent(MAKER, BigInt.fromI32(1));
+    setupQuestion(
+      CONDITION_ID,
+      Bytes.fromHexString(
+        "0x1234567890123456789012345678901234567890123456789012345678901234",
+      ),
+    );
+    setupTokenRegistry(TOKEN_ID_1, CONDITION_ID, 1);
+
+    let event = createOrderFilledV2Event(
+      ORDER_HASH,
+      MAKER,
+      TAKER,
+      0,
+      TOKEN_ID_1,
+      BigInt.fromI32(500000),
+      BigInt.fromI32(1000000),
+      BigInt.fromI32(1000),
+      BUILDER,
+      METADATA,
+    );
+
+    handleOrderFilledV2(event);
+
+    assert.fieldEquals("TraderAgent", MAKER.toHexString(), "totalBets", "1");
+    assert.fieldEquals("TraderAgent", MAKER.toHexString(), "totalTraded", "500000");
+    assert.fieldEquals("Global", "", "totalBets", "1");
+    assert.fieldEquals("Global", "", "totalTraded", "500000");
+  });
+
+  test("Should create MarketParticipant with outcome share tracking", () => {
+    setupTraderAgent(MAKER, BigInt.fromI32(1));
+    setupQuestion(
+      CONDITION_ID,
+      Bytes.fromHexString(
+        "0x1234567890123456789012345678901234567890123456789012345678901234",
+      ),
+    );
+    setupTokenRegistry(TOKEN_ID_1, CONDITION_ID, 1);
+
+    let event = createOrderFilledV2Event(
+      ORDER_HASH,
+      MAKER,
+      TAKER,
+      0,
+      TOKEN_ID_1,
+      BigInt.fromI32(500000),
+      BigInt.fromI32(1000000),
+      BigInt.fromI32(1000),
+      BUILDER,
+      METADATA,
+    );
+
+    handleOrderFilledV2(event);
+
+    let participantId =
+      MAKER.toHexString() + "_" + CONDITION_ID.toHexString();
+    assert.fieldEquals("MarketParticipant", participantId, "totalBets", "1");
+    assert.fieldEquals("MarketParticipant", participantId, "totalTraded", "500000");
+    // Outcome 1 buy adds to outcomeShares1
+    assert.fieldEquals("MarketParticipant", participantId, "outcomeShares0", "0");
+    assert.fieldEquals("MarketParticipant", participantId, "outcomeShares1", "1000000");
+  });
+
+  test("Should persist builder and metadata from v2 event on Bet", () => {
+    setupTraderAgent(MAKER, BigInt.fromI32(1));
+    setupQuestion(
+      CONDITION_ID,
+      Bytes.fromHexString(
+        "0x1234567890123456789012345678901234567890123456789012345678901234",
+      ),
+    );
+    setupTokenRegistry(TOKEN_ID_1, CONDITION_ID, 1);
+
+    let customBuilder = Bytes.fromHexString(
+      "0x00000000000000000000000000000000000000000000000000000000deadbeef",
+    );
+    let customMetadata = Bytes.fromHexString(
+      "0x00000000000000000000000000000000000000000000000000000000cafebabe",
+    );
+
+    let event = createOrderFilledV2Event(
+      ORDER_HASH,
+      MAKER,
+      TAKER,
+      0,
+      TOKEN_ID_1,
+      BigInt.fromI32(500000),
+      BigInt.fromI32(1000000),
+      BigInt.fromI32(1000),
+      customBuilder,
+      customMetadata,
+    );
+
+    handleOrderFilledV2(event);
+
+    let betId = event.transaction.hash
+      .concat(Bytes.fromI32(event.logIndex.toI32()))
+      .toHexString();
+    assert.fieldEquals("Bet", betId, "builder", customBuilder.toHexString());
+    assert.fieldEquals("Bet", betId, "metadata", customMetadata.toHexString());
+  });
+});

--- a/subgraphs/predict/predict-polymarket/tests/test-helpers.ts
+++ b/subgraphs/predict/predict-polymarket/tests/test-helpers.ts
@@ -1,5 +1,100 @@
-import { Address, BigInt, Bytes } from "@graphprotocol/graph-ts";
+import { Address, BigInt, Bytes, ethereum } from "@graphprotocol/graph-ts";
+import { createMockedFunction } from "matchstick-as/assembly/index";
 import { QuestionIdToConditionId } from "../generated/schema";
+
+// Default contract address used by matchstick's newMockEvent() — handlers bind
+// the ConditionalTokens contract to event.address, so mocks must target this.
+export const DEFAULT_MOCK_CONTRACT = Address.fromString(
+  "0xa16081f360e3847006db660bae1c6d1b2e17ec2a",
+);
+
+export const USDC_E = Address.fromString(
+  "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+);
+export const NEG_RISK_ADAPTER = Address.fromString(
+  "0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296",
+);
+const ZERO_BYTES32 = Bytes.fromHexString(
+  "0x0000000000000000000000000000000000000000000000000000000000000000",
+);
+
+/**
+ * Mock the ConditionalTokens.getCollectionId + getPositionId eth_calls that
+ * handleConditionPreparation makes to derive outcome tokenIds for v2 markets.
+ *
+ * Returns the 32-byte `tokenIdBytes` values that the handler will use as the
+ * TokenRegistry entity IDs (outcome 0 at index 0, outcome 1 at index 1). These
+ * are the Bytes.fromBigInt round-trip of the mocked positionId values; tests
+ * should use them directly for `assert.fieldEquals("TokenRegistry", ..)`.
+ */
+export function mockConditionalTokensCalls(
+  conditionId: Bytes,
+  collateral: Address,
+): Bytes[] {
+  // Derive distinct-per-condition bytes32 values for collectionIds so repeated
+  // calls across conditions don't collide in the mock registry. Highest byte
+  // kept at 0x11..0xdd (top bit unset) so fromBigInt round-trips cleanly to
+  // 32 bytes without an unsigned-padding byte.
+  let mockCollection1 = Bytes.fromHexString(
+    "0x01" + conditionId.toHexString().slice(4),
+  ) as Bytes;
+  let mockCollection2 = Bytes.fromHexString(
+    "0x02" + conditionId.toHexString().slice(4),
+  ) as Bytes;
+  let mockTokenId1 = BigInt.fromUnsignedBytes(mockCollection1);
+  let mockTokenId2 = BigInt.fromUnsignedBytes(mockCollection2);
+
+  createMockedFunction(
+    DEFAULT_MOCK_CONTRACT,
+    "getCollectionId",
+    "getCollectionId(bytes32,bytes32,uint256):(bytes32)",
+  )
+    .withArgs([
+      ethereum.Value.fromFixedBytes(ZERO_BYTES32 as Bytes),
+      ethereum.Value.fromFixedBytes(conditionId),
+      ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(1)),
+    ])
+    .returns([ethereum.Value.fromFixedBytes(mockCollection1)]);
+
+  createMockedFunction(
+    DEFAULT_MOCK_CONTRACT,
+    "getCollectionId",
+    "getCollectionId(bytes32,bytes32,uint256):(bytes32)",
+  )
+    .withArgs([
+      ethereum.Value.fromFixedBytes(ZERO_BYTES32 as Bytes),
+      ethereum.Value.fromFixedBytes(conditionId),
+      ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(2)),
+    ])
+    .returns([ethereum.Value.fromFixedBytes(mockCollection2)]);
+
+  createMockedFunction(
+    DEFAULT_MOCK_CONTRACT,
+    "getPositionId",
+    "getPositionId(address,bytes32):(uint256)",
+  )
+    .withArgs([
+      ethereum.Value.fromAddress(collateral),
+      ethereum.Value.fromFixedBytes(mockCollection1),
+    ])
+    .returns([ethereum.Value.fromUnsignedBigInt(mockTokenId1)]);
+
+  createMockedFunction(
+    DEFAULT_MOCK_CONTRACT,
+    "getPositionId",
+    "getPositionId(address,bytes32):(uint256)",
+  )
+    .withArgs([
+      ethereum.Value.fromAddress(collateral),
+      ethereum.Value.fromFixedBytes(mockCollection2),
+    ])
+    .returns([ethereum.Value.fromUnsignedBigInt(mockTokenId2)]);
+
+  // Stored TokenRegistry ID = Bytes.fromByteArray(Bytes.fromBigInt(positionId)).
+  // After the Matchstick BigInt round-trip the unsigned-padding byte is dropped,
+  // so the stored 32-byte ID equals the mockCollection bytes (same LE layout).
+  return [mockCollection1, mockCollection2];
+}
 
 /**
  * Common test addresses for consistency across tests


### PR DESCRIPTION
Migrates upstream PRs #90, #91, #92 from autonolas-subgraph into the studio monorepo at subgraphs/predict/predict-polymarket.

- v2 CTF Exchange dataSources (CTFExchangeV2 / NegRiskCTFExchangeV2) with handleOrderFilledV2; v1 exchanges get endBlock 86750000 as a cutover safety buffer.
- handleConditionPreparation derives outcome tokenIds via ConditionalTokens.getCollectionId + getPositionId eth_calls (v2 no longer emits TokenRegistered).
- Collateral adapter dataSources (current + *Old pair) covering [86219367, ∞) contiguously so adapter-routed PositionsRedeemed payouts are tracked end-to-end without grafting.
- ABI paths adapted to studio's ../../../abis/ convention; new ABIs (CTFExchangeV2.json, CtfCollateralAdapter.json) added under root abis/.
- Tests, schema, constants, helpers, claude.md, and migration-plan doc updated in lockstep.

All 107 Matchstick tests pass.