### PR TITLE
feat(predict): add per-day settled-cost fields to DailyProfitStatistic

### DIFF
--- a/subgraphs/predict/predict-omen/schema.graphql
+++ b/subgraphs/predict/predict-omen/schema.graphql
@@ -135,7 +135,14 @@ type DailyProfitStatistic @entity(immutable: false) {
   totalTraded: BigInt! # total traded today, regardless of market settlement
   totalFees: BigInt! # total fees today, regardless of market settlement
   totalPayout: BigInt! # Payouts received today
-  
+
+  # Cost basis of bets that became settled on this day. Written by handleLogNewAnswer.
+  # Lets ROI for arbitrary windows be computed as profit / dailyTradedSettled without
+  # having to derive `cost = payout - profit`, which is wrong here because totalTraded
+  # lands on bet day, dailyProfit on resolution day, and totalPayout on redemption day.
+  dailyTradedSettled: BigInt!
+  dailyFeesSettled: BigInt!
+
   # Profit
   dailyProfit: BigInt!
   

--- a/subgraphs/predict/predict-omen/src/realitio.ts
+++ b/subgraphs/predict/predict-omen/src/realitio.ts
@@ -132,9 +132,9 @@ export function handleLogNewAnswer(event: LogNewAnswerEvent): void {
         ? dailyStatsCache.get(oldStatId)!
         : getDailyProfitStatistic(participant.traderAgent, oldTimestamp);
       oldDailyStat.dailyProfit = oldDailyStat.dailyProfit.minus(oldProfit);
-      // Reverse the cost that was attributed to old day at first settlement.
-      // At first settlement, `dailyTradedSettled += totalTraded - 0 = totalTraded_at_first_answer`,
-      // which is exactly `participant.totalTradedSettled` now (set then, untouched until re-answer).
+      // Invariant: after every settlement, `participant.totalTradedSettled`/`totalFeesSettled`
+      // equal the cost basis attributed to a daily stat. Subtracting them here always reverses
+      // the exact amount added on the previous settlement, regardless of chain length.
       oldDailyStat.dailyTradedSettled = oldDailyStat.dailyTradedSettled.minus(participant.totalTradedSettled);
       oldDailyStat.dailyFeesSettled = oldDailyStat.dailyFeesSettled.minus(participant.totalFeesSettled);
       removeProfitParticipant(oldDailyStat, fpmm.id);

--- a/subgraphs/predict/predict-omen/src/realitio.ts
+++ b/subgraphs/predict/predict-omen/src/realitio.ts
@@ -132,6 +132,11 @@ export function handleLogNewAnswer(event: LogNewAnswerEvent): void {
         ? dailyStatsCache.get(oldStatId)!
         : getDailyProfitStatistic(participant.traderAgent, oldTimestamp);
       oldDailyStat.dailyProfit = oldDailyStat.dailyProfit.minus(oldProfit);
+      // Reverse the cost that was attributed to old day at first settlement.
+      // At first settlement, `dailyTradedSettled += totalTraded - 0 = totalTraded_at_first_answer`,
+      // which is exactly `participant.totalTradedSettled` now (set then, untouched until re-answer).
+      oldDailyStat.dailyTradedSettled = oldDailyStat.dailyTradedSettled.minus(participant.totalTradedSettled);
+      oldDailyStat.dailyFeesSettled = oldDailyStat.dailyFeesSettled.minus(participant.totalFeesSettled);
       removeProfitParticipant(oldDailyStat, fpmm.id);
       dailyStatsCache.set(oldStatId, oldDailyStat);
 
@@ -141,6 +146,9 @@ export function handleLogNewAnswer(event: LogNewAnswerEvent): void {
         ? dailyStatsCache.get(newStatId)!
         : getDailyProfitStatistic(participant.traderAgent, event.block.timestamp);
       newDailyStat.dailyProfit = newDailyStat.dailyProfit.plus(newProfit);
+      // Mirror newProfit's full-cost basis: attribute the entire current cost to the new day.
+      newDailyStat.dailyTradedSettled = newDailyStat.dailyTradedSettled.plus(participant.totalTraded);
+      newDailyStat.dailyFeesSettled = newDailyStat.dailyFeesSettled.plus(participant.totalFees);
       addProfitParticipant(newDailyStat, fpmm.id);
       dailyStatsCache.set(newStatId, newDailyStat);
 
@@ -228,6 +236,8 @@ export function handleLogNewAnswer(event: LogNewAnswerEvent): void {
       ? dailyStatsCache.get(statId)!
       : getDailyProfitStatistic(participant.traderAgent, event.block.timestamp);
     dailyStat.dailyProfit = dailyStat.dailyProfit.plus(profit);
+    dailyStat.dailyTradedSettled = dailyStat.dailyTradedSettled.plus(amountToSettle);
+    dailyStat.dailyFeesSettled = dailyStat.dailyFeesSettled.plus(feesToSettle);
     addProfitParticipant(dailyStat, fpmm.id);
     dailyStatsCache.set(statId, dailyStat);
 

--- a/subgraphs/predict/predict-omen/src/utils.ts
+++ b/subgraphs/predict/predict-omen/src/utils.ts
@@ -63,6 +63,8 @@ export function getDailyProfitStatistic(agentAddress: Bytes, timestamp: BigInt):
     statistic.totalTraded = BigInt.zero();
     statistic.totalFees = BigInt.zero();
     statistic.totalPayout = BigInt.zero();
+    statistic.dailyTradedSettled = BigInt.zero();
+    statistic.dailyFeesSettled = BigInt.zero();
     statistic.dailyProfit = BigInt.zero();
 
     statistic.profitParticipants = [];

--- a/subgraphs/predict/predict-omen/tests/profit.test.ts
+++ b/subgraphs/predict/predict-omen/tests/profit.test.ts
@@ -621,6 +621,8 @@ describe("Profit Chart Integration", () => {
 
     let day3Id = AGENT.toHexString() + "_" + day3TSNormalized.toString();
     assert.fieldEquals("DailyProfitStatistic", day3Id, "dailyProfit", "900");
+    assert.fieldEquals("DailyProfitStatistic", day3Id, "dailyTradedSettled", "1000");
+    assert.fieldEquals("DailyProfitStatistic", day3Id, "dailyFeesSettled", "100");
     assert.fieldEquals("TraderAgent", AGENT.toHexString(), "totalExpectedPayout", "2000");
 
     // Answer B (outcome 1 — loses): reverses day 3, full profit = 0 - 1000 - 100 = -1100 on day 4
@@ -629,8 +631,12 @@ describe("Profit Chart Integration", () => {
     handleLogNewAnswer(createNewAnswerEvent(MARKET_LOST, ANSWER_1_HEX, day4TS));
 
     assert.fieldEquals("DailyProfitStatistic", day3Id, "dailyProfit", "0"); // reversed
+    assert.fieldEquals("DailyProfitStatistic", day3Id, "dailyTradedSettled", "0"); // cost reversed off old day
+    assert.fieldEquals("DailyProfitStatistic", day3Id, "dailyFeesSettled", "0");
     let day4Id = AGENT.toHexString() + "_" + day4TSNormalized.toString();
     assert.fieldEquals("DailyProfitStatistic", day4Id, "dailyProfit", "-1100"); // full: 0 - 1000 - 100
+    assert.fieldEquals("DailyProfitStatistic", day4Id, "dailyTradedSettled", "1000"); // full cost re-attributed
+    assert.fieldEquals("DailyProfitStatistic", day4Id, "dailyFeesSettled", "100");
     assert.fieldEquals("TraderAgent", AGENT.toHexString(), "totalExpectedPayout", "0");
 
     // Answer C (outcome 0 — wins again): reverses day 4 (-1100), full profit = 900 on day 5
@@ -639,8 +645,12 @@ describe("Profit Chart Integration", () => {
     handleLogNewAnswer(createNewAnswerEvent(MARKET_LOST, ANSWER_0_HEX, day5TS));
 
     assert.fieldEquals("DailyProfitStatistic", day4Id, "dailyProfit", "0"); // -1100 reversed
+    assert.fieldEquals("DailyProfitStatistic", day4Id, "dailyTradedSettled", "0"); // cost reversed off day 4
+    assert.fieldEquals("DailyProfitStatistic", day4Id, "dailyFeesSettled", "0");
     let day5Id = AGENT.toHexString() + "_" + day5TSNormalized.toString();
     assert.fieldEquals("DailyProfitStatistic", day5Id, "dailyProfit", "900"); // full: 2000 - 1000 - 100
+    assert.fieldEquals("DailyProfitStatistic", day5Id, "dailyTradedSettled", "1000"); // full cost re-attributed
+    assert.fieldEquals("DailyProfitStatistic", day5Id, "dailyFeesSettled", "100");
     assert.fieldEquals("TraderAgent", AGENT.toHexString(), "totalExpectedPayout", "2000");
 
     // Participant final state

--- a/subgraphs/predict/predict-polymarket/schema.graphql
+++ b/subgraphs/predict/predict-polymarket/schema.graphql
@@ -145,6 +145,12 @@ type DailyProfitStatistic @entity(immutable: false) {
   totalTraded: BigInt! # total traded today, regardless of market settlement
   totalPayout: BigInt! # Payouts received today
 
+  # Cost basis of bets that became settled on this day. Written by processMarketResolution.
+  # Lets ROI for arbitrary windows be computed as profit / dailyTradedSettled without
+  # having to derive `cost = payout - profit`, which is wrong here because totalTraded
+  # lands on bet day, dailyProfit on resolution day, and totalPayout on redemption day.
+  dailyTradedSettled: BigInt!
+
   # Profit realized on this day (from settlements/payouts)
   dailyProfit: BigInt!
 

--- a/subgraphs/predict/predict-polymarket/src/utils.ts
+++ b/subgraphs/predict/predict-polymarket/src/utils.ts
@@ -69,6 +69,7 @@ export function getDailyProfitStatistic(
     statistic.totalBets = 0;
     statistic.totalTraded = BigInt.zero();
     statistic.totalPayout = BigInt.zero();
+    statistic.dailyTradedSettled = BigInt.zero();
     statistic.dailyProfit = BigInt.zero();
     statistic.profitParticipants = [];
   }
@@ -263,6 +264,7 @@ export function processMarketResolution(
       : getDailyProfitStatistic(participant.traderAgent, event.block.timestamp);
 
     dailyStat.dailyProfit = dailyStat.dailyProfit.plus(profit);
+    dailyStat.dailyTradedSettled = dailyStat.dailyTradedSettled.plus(amountToSettle);
     addProfitParticipant(dailyStat, conditionId);
     dailyStatsCache.set(statId, dailyStat);
 

--- a/subgraphs/predict/predict-polymarket/tests/profit.test.ts
+++ b/subgraphs/predict/predict-polymarket/tests/profit.test.ts
@@ -112,6 +112,7 @@ describe("Profit Chart Integration", () => {
 
     let day3Id = AGENT.toHexString() + "_" + day3TSNormalized.toString();
     assert.fieldEquals("DailyProfitStatistic", day3Id, "dailyProfit", "-1000");
+    assert.fieldEquals("DailyProfitStatistic", day3Id, "dailyTradedSettled", "1000");
     assert.fieldEquals("DailyProfitStatistic", day3Id, "profitParticipants", "[" + CONDITION_LOST.toHexString() + "]");
   });
 
@@ -138,6 +139,7 @@ describe("Profit Chart Integration", () => {
     // Profit recorded on Day 3: expectedPayout(2000) - totalTraded(1000) = 1000
     let day3Id = AGENT.toHexString() + "_" + day3TSNormalized.toString();
     assert.fieldEquals("DailyProfitStatistic", day3Id, "dailyProfit", "1000");
+    assert.fieldEquals("DailyProfitStatistic", day3Id, "dailyTradedSettled", "1000");
     assert.fieldEquals("DailyProfitStatistic", day3Id, "profitParticipants", "[" + CONDITION_WON.toHexString() + "]");
 
     // Verify expectedPayout on participant
@@ -259,6 +261,8 @@ describe("Profit Chart Integration", () => {
 
     // Both bets lost: -1000 - 2000 = -3000
     assert.fieldEquals("DailyProfitStatistic", day3Id, "dailyProfit", "-3000");
+    // Cost settled across both markets on day 3: 1000 + 2000 = 3000
+    assert.fieldEquals("DailyProfitStatistic", day3Id, "dailyTradedSettled", "3000");
   });
 
   /**


### PR DESCRIPTION
## Summary

Adds `dailyTradedSettled` (omen + polymarket) and `dailyFeesSettled` (omen only) on `DailyProfitStatistic`. Written by the resolution handlers at the same time `dailyProfit` is incremented, so per-day cost and per-day profit share a day key.

## Why

Without these fields, windowed-ROI consumers (e.g. the website's 7D/30D/90D distributions) were forced to derive `tradingCosts = totalPayout - dailyProfit`, which is wrong here:

- `totalTraded` lands on **bet day**
- `dailyProfit` lands on **resolution day**
- `totalPayout` lands on **redemption day**

So the equation breaks across any non-lifetime window. The lifetime "All" tab works because it uses `traderAgent.totalTradedSettled` / `totalExpectedPayout`, which are not bound to a day. With the new fields, `ROI = profit / dailyTradedSettled` is computable directly per window and matches the lifetime math.

## Changes

- **omen schema/utils**: init new fields to zero in `getDailyProfitStatistic`.
- **omen `realitio.ts` fresh settlement**: increment by `amountToSettle` / `feesToSettle` (mirrors the agent/global delta).
- **omen `realitio.ts` re-answer path**: subtract `participant.totalTradedSettled` / `totalFeesSettled` from old day, add `participant.totalTraded` / `totalFees` to new day. Mirrors `newProfit`'s full-cost basis; net agent/global delta unchanged.
- **polymarket schema/utils**: init `dailyTradedSettled` to zero; `processMarketResolution` increments by `amountToSettle`.

## Test plan

- [x] `yarn codegen && yarn build` clean in both subgraphs
- [x] `yarn test` — 19/19 omen, 107/107 polymarket
- [ ] Deploy to dev studio and spot-check a settled day matches `dailyProfit / dailyTradedSettled` against the lifetime ratio for the same agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)