### PR TITLE
phase-1b(pearl-transactions): StakingFactory + StakingProxy + reward/unstake/evict rows + DailyServiceFunds

### DIFF
--- a/subgraphs/pearl-transactions/networks.json
+++ b/subgraphs/pearl-transactions/networks.json
@@ -7,6 +7,10 @@
     "ServiceRegistryTokenUtility": {
       "address": "0xa45E64d13A30a51b91ae0eb182e88a40e9b18eD8",
       "startBlock": 30095874
+    },
+    "StakingFactory": {
+      "address": "0xb0228CA253A88Bc8eb4ca70BCAC8f87b381f4700",
+      "startBlock": 35206806
     }
   },
   "matic": {
@@ -17,6 +21,10 @@
     "ServiceRegistryTokenUtility": {
       "address": "0xa45E64d13A30a51b91ae0eb182e88a40e9b18eD8",
       "startBlock": 52737296
+    },
+    "StakingFactory": {
+      "address": "0x46C0D07F55d4F9B5Eed2Fc9680B5953e5fd7b461",
+      "startBlock": 62213142
     }
   },
   "optimism": {
@@ -27,6 +35,10 @@
     "ServiceRegistryTokenUtility": {
       "address": "0xBb7e1D6Cb6F243D6bdE81CE92a9f2aFF7Fbe7eac",
       "startBlock": 116423237
+    },
+    "StakingFactory": {
+      "address": "0xa45E64d13A30a51b91ae0eb182e88a40e9b18eD8",
+      "startBlock": 124618633
     }
   },
   "base": {
@@ -37,6 +49,10 @@
     "ServiceRegistryTokenUtility": {
       "address": "0x34C895f302D0b5cf52ec0Edd3945321EB0f83dd5",
       "startBlock": 10827475
+    },
+    "StakingFactory": {
+      "address": "0x1cEe30D08943EB58EFF84DD1AB44a6ee6FEff63a",
+      "startBlock": 17310019
     }
   }
 }

--- a/subgraphs/pearl-transactions/schema.graphql
+++ b/subgraphs/pearl-transactions/schema.graphql
@@ -1,19 +1,8 @@
-# pearl-transactions schema — Phase 1a.
+# pearl-transactions schema — Phase 1a + 1b.
 #
-# Matches IMPLEMENTATION-PLAN.md §5.1 (semantic ledger). Entities and
-# fields that only become populated in later phases are noted in inline
-# comments and added with placeholder cardinality so the schema does not
-# need to be rewritten for Phase 1b / 2 (additive evolution).
-#
-# Phase 1a deliberately omits the following from §5.1 / §6.5; they
-# arrive in their own PRs:
-#   - StakingContract entity + Service.currentStakingContract field
-#     (Phase 1b — StakingFactory + StakingProxy)
-#   - Service.totalOlasRewardsClaimed (Phase 1b)
-#   - DailyServiceFunds (Phase 1b)
-#   - AgentFundingEvent + FundsMovement.agentFundingEvent backref
-#     (Phase 2a)
-#   - Token / TrackedSafe / TrackedEOA / TokenBalance (Phase 2)
+# Matches IMPLEMENTATION-PLAN.md §5.1 (semantic ledger). Phase 2
+# entities (AgentFundingEvent, Token, TrackedSafe, TrackedEOA,
+# TokenBalance) arrive in their own PRs.
 
 # --- Structural -------------------------------------------------------
 
@@ -47,10 +36,25 @@ type Service @entity(immutable: false) {
   operators: [Bytes!]!                # deduplicated; sub-cohort filter
   masterSafe: MasterSafe
   agentSafe: AgentSafe
-  state: String!                      # REGISTERED|DEPLOYED|TERMINATED (STAKED|UNSTAKED added in Phase 1b)
+  state: String!                      # REGISTERED|DEPLOYED|STAKED|UNSTAKED|TERMINATED
   nftCustodian: Bytes                 # current ERC-721 owner
+  currentStakingContract: StakingContract  # set on stake, cleared on unstake
+  totalOlasRewardsClaimed: BigInt!    # cumulative across stake-cycles
   registeredTimestamp: BigInt!
   updatedTimestamp: BigInt!
+}
+
+# Staking proxy / "staking contract" — created on
+# StakingFactory.InstanceCreated for any allowed implementation. Config
+# snapshot is captured via contract calls at creation time; nothing
+# updates afterward.
+type StakingContract @entity(immutable: false) {
+  id: Bytes!                          # staking proxy address
+  implementation: Bytes!
+  minStakingDeposit: BigInt!
+  numAgentInstances: BigInt!
+  createdBlock: BigInt!
+  createdTimestamp: BigInt!
 }
 
 # --- Ledger -----------------------------------------------------------
@@ -61,9 +65,9 @@ enum FundsCategory {
   SERVICE_BOND_DEPOSIT                # SRTU.TokenDeposit; fires twice per stake-cycle (activate + register)
   SERVICE_BOND_REFUND                 # SRTU.TokenRefund; fires twice per unstake-cycle (terminate + unbond)
   # Phase 1b — staking
-  STAKING_REWARD_CLAIM                # RewardClaimed → Agent Safe
-  UNSTAKE_REWARD                      # (Force)Unstaked reward → Agent Safe
-  SERVICE_EVICTED                     # ServicesEvicted (informational)
+  STAKING_REWARD_CLAIM                # StakingProxy.RewardClaimed → Agent Safe
+  UNSTAKE_REWARD                      # StakingProxy.ServiceUnstaked / ServiceForceUnstaked → Agent Safe
+  SERVICE_EVICTED                     # StakingProxy.ServicesEvicted (informational; amount=0)
   # Phase 2 adds: SAFE_SETUP_TRANSFER, MASTER_FUNDING_IN, MASTER_TO_AGENT,
   # AGENT_TO_MASTER, MASTER_WITHDRAWAL, AGENT_TO_APP, APP_TO_AGENT, OTHER.
 }
@@ -94,16 +98,30 @@ type FundsMovement @entity(immutable: false) {
   service: Service
   masterSafe: MasterSafe
   agentSafe: AgentSafe
+  stakingContract: StakingContract    # set for STAKING_REWARD_CLAIM / UNSTAKE_REWARD / SERVICE_EVICTED rows
+  epoch: BigInt                       # staking-side row only; from the StakingProxy event
   category: FundsCategory!
   source: FundsSource!
   bondType: ServiceBondType           # nullable; populated for SERVICE_BOND_DEPOSIT/REFUND when attribution succeeds
-  token: Bytes                        # token address (null for SAFE_DEPLOYED)
-  amount: BigInt!                     # 0 for SAFE_DEPLOYED informational rows
+  token: Bytes                        # token address (null for SAFE_DEPLOYED / SERVICE_EVICTED)
+  amount: BigInt!                     # 0 for SAFE_DEPLOYED / SERVICE_EVICTED informational rows
   from: Bytes!
   to: Bytes!
   blockNumber: BigInt!
   blockTimestamp: BigInt!
   transactionHash: Bytes!
+}
+
+# Daily roll-up of OLAS rewards per service (UTC midnight bucket).
+# Updated on each StakingProxy.RewardClaimed and the
+# unstake-reward path. Phase 2 adds per-token / per-safe daily
+# roll-ups under a separate entity if needed.
+type DailyServiceFunds @entity(immutable: false) {
+  id: ID!                             # serviceId-dayTimestamp
+  service: Service!
+  dayTimestamp: BigInt!               # UTC midnight (timestamp / 86400 * 86400)
+  olasRewardsClaimed: BigInt!         # that day
+  cumulativeOlasRewardsClaimed: BigInt!
 }
 
 # --- Service-NFT custody trail ---------------------------------------

--- a/subgraphs/pearl-transactions/src/constants.ts
+++ b/subgraphs/pearl-transactions/src/constants.ts
@@ -1,21 +1,22 @@
 // Per-network constants. Mirrors the shared/constants.ts pattern of a
-// dataSource.network() switch resolver. Phase 1a only needs OLAS for
-// the SAFE_DEPLOYED row's metadata (currently null) — the resolver is
-// here so later phases (raw OLAS Transfer handling) reuse it without
-// touching constants.
+// dataSource.network() switch resolver.
 
-import { Address, log } from "@graphprotocol/graph-ts";
+import { Address, Bytes, dataSource, log } from "@graphprotocol/graph-ts";
 
 // Service state strings (matches plan §5.1).
 export const SERVICE_STATE_REGISTERED = "REGISTERED";
 export const SERVICE_STATE_DEPLOYED = "DEPLOYED";
+export const SERVICE_STATE_STAKED = "STAKED";
+export const SERVICE_STATE_UNSTAKED = "UNSTAKED";
 export const SERVICE_STATE_TERMINATED = "TERMINATED";
-// Phase 1b will add STAKED / UNSTAKED.
 
 // FundsCategory string values (the schema enum surfaces in AS as strings).
 export const CATEGORY_SAFE_DEPLOYED = "SAFE_DEPLOYED";
 export const CATEGORY_SERVICE_BOND_DEPOSIT = "SERVICE_BOND_DEPOSIT";
 export const CATEGORY_SERVICE_BOND_REFUND = "SERVICE_BOND_REFUND";
+export const CATEGORY_STAKING_REWARD_CLAIM = "STAKING_REWARD_CLAIM";
+export const CATEGORY_UNSTAKE_REWARD = "UNSTAKE_REWARD";
+export const CATEGORY_SERVICE_EVICTED = "SERVICE_EVICTED";
 
 // ServiceBondType string values.
 export const BOND_TYPE_SECURITY_DEPOSIT = "SECURITY_DEPOSIT";
@@ -48,4 +49,41 @@ export function getOlasAddress(network: string): Address {
   }
   log.critical("Unsupported network in getOlasAddress: {}", [network]);
   return Address.zero();
+}
+
+// isAllowedImplementation — the Olas staking ecosystem allows multiple
+// StakingProxy implementations but pearl-transactions only indexes
+// proxies whose implementation appears on this per-network allow-list.
+// Sourced from `subgraphs/staking/src/utils.ts` (the staking subgraph's
+// canonical allow-list). Phase 1b includes only the 4 v1 networks; the
+// staking subgraph carries arbitrum / celo / mainnet entries that
+// aren't in this subgraph's network set.
+export function isAllowedImplementation(implementation: Bytes): boolean {
+  const network = dataSource.network();
+  let allowed: Bytes[] = [];
+
+  if (network == "gnosis" || network == "xdai") {
+    allowed = [
+      Bytes.fromHexString("0xEa00be6690a871827fAfD705440D20dd75e67AB1"),
+    ];
+  } else if (network == "matic" || network == "polygon") {
+    allowed = [
+      Bytes.fromHexString("0x4aba1Cf7a39a51D75cBa789f5f21cf4882162519"),
+    ];
+  } else if (network == "optimism") {
+    allowed = [
+      Bytes.fromHexString("0x63C2c53c09dE534Dd3bc0b7771bf976070936bAC"),
+    ];
+  } else if (network == "base") {
+    allowed = [
+      Bytes.fromHexString("0xEB5638eefE289691EcE01943f768EDBF96258a80"),
+    ];
+  }
+
+  for (let i = 0; i < allowed.length; i++) {
+    if (implementation.equals(allowed[i])) {
+      return true;
+    }
+  }
+  return false;
 }

--- a/subgraphs/pearl-transactions/src/service-registry.ts
+++ b/subgraphs/pearl-transactions/src/service-registry.ts
@@ -24,6 +24,7 @@ import {
   getOrCreateAgentSafe,
   getOrCreateMasterSafe,
   getOrCreateService,
+  isStakingContract,
   setServiceIndex,
 } from "./utils";
 
@@ -100,16 +101,15 @@ export function handleCreateMultisigWithAgents(
 
 // handleServiceNftTransfer — ERC-721 Transfer on the ServiceRegistryL2
 // contract (the service NFT). Records every custody change, then tries
-// to resolve the recipient to a Master Safe.
-//
-// Master Safe discovery is gated on getOrCreateMasterSafe succeeding
-// (i.e. the recipient answers getOwners() — a real Safe). The recipient
-// is NOT always a Master Safe: at mint it's the creator's Safe (the
-// Master Safe), but when a service is staked the NFT moves to a staking
-// proxy, and on burn it goes to the zero address. Only the Safe case
-// links service.masterSafe; non-Safe recipients are skipped so the real
-// Master Safe link (established at mint) is preserved. Phase 1b replaces
-// the getOwners() probe with an explicit StakingContract allowlist.
+// to resolve the recipient to a Master Safe. Skips two cases:
+//   - the zero address (mint / burn);
+//   - known staking proxies (StakingFactory-tracked) — on stake the NFT
+//     moves Master Safe → staking proxy, and getOwners() on a proxy
+//     reverts, so the explicit check (Phase 1b) avoids the eth_call/log.
+// For any other recipient, getOrCreateMasterSafe probes getOwners() and
+// returns null for non-Safes (defence-in-depth for untracked proxies /
+// EOAs); we only link when it resolves, so a stake hop never clobbers
+// the real Master Safe link established at mint.
 export function handleServiceNftTransfer(event: TransferEvent): void {
   const serviceId = event.params.id;
   const from = event.params.from;
@@ -129,16 +129,17 @@ export function handleServiceNftTransfer(event: TransferEvent): void {
   change.transactionHash = event.transaction.hash;
   change.save();
 
-  // Resolve the recipient to a Master Safe. Skip the zero address
-  // (burn). getOrCreateMasterSafe returns null when `to` isn't a Safe
-  // (staking proxy, EOA, …); only link when it resolves, so a stake hop
-  // (Master Safe → staking proxy) doesn't clobber the real link.
-  if (!to.equals(Address.zero())) {
-    const masterSafe = getOrCreateMasterSafe(to, event);
-    if (masterSafe != null) {
-      service.masterSafe = masterSafe.id;
-      service.save();
-    }
+  // Skip the zero address (mint / burn) and known staking proxies.
+  if (to.equals(Address.zero())) return;
+  if (isStakingContract(to)) return;
+
+  // getOrCreateMasterSafe returns null when `to` isn't a Safe (untracked
+  // proxy, EOA, …); only link when it resolves, so a stake hop never
+  // clobbers the real Master Safe link.
+  const masterSafe = getOrCreateMasterSafe(to, event);
+  if (masterSafe != null) {
+    service.masterSafe = masterSafe.id;
+    service.save();
   }
 }
 

--- a/subgraphs/pearl-transactions/src/staking-factory.ts
+++ b/subgraphs/pearl-transactions/src/staking-factory.ts
@@ -1,0 +1,55 @@
+import { log } from "@graphprotocol/graph-ts";
+import { InstanceCreated as InstanceCreatedEvent } from "../generated/StakingFactory/StakingFactory";
+import { StakingProxy as StakingProxyTemplate } from "../generated/templates";
+import { StakingProxy as StakingProxyContract } from "../generated/templates/StakingProxy/StakingProxy";
+import { isAllowedImplementation } from "./constants";
+import { getOrCreateStakingContract } from "./utils";
+
+// handleInstanceCreated — fires on every StakingFactory.InstanceCreated.
+//
+// We only spawn the StakingProxy template (and create a StakingContract
+// entity) for proxies whose implementation appears on the per-network
+// allow-list (see constants.ts isAllowedImplementation). Unknown
+// implementations are skipped silently — they may have incompatible
+// event ABIs that would crash the indexer.
+//
+// Config snapshot (minStakingDeposit, numAgentInstances) is captured
+// via eth_call at creation time. The values are immutable post-deploy
+// per the Olas staking-contract pattern, so we don't need to track
+// updates.
+export function handleInstanceCreated(event: InstanceCreatedEvent): void {
+  const implementation = event.params.implementation;
+  if (!isAllowedImplementation(implementation)) {
+    return;
+  }
+
+  const proxyAddress = event.params.instance;
+
+  // Bind to the proxy and read the snapshot config. The fields are
+  // delegated to the implementation, so we call on the proxy address.
+  const proxy = StakingProxyContract.bind(proxyAddress);
+  const minStakingDepositResult = proxy.try_minStakingDeposit();
+  const numAgentInstancesResult = proxy.try_numAgentInstances();
+
+  if (minStakingDepositResult.reverted || numAgentInstancesResult.reverted) {
+    log.warning(
+      "StakingProxy {} config call reverted (impl={}, tx={}); skipping",
+      [
+        proxyAddress.toHexString(),
+        implementation.toHexString(),
+        event.transaction.hash.toHexString(),
+      ]
+    );
+    return;
+  }
+
+  getOrCreateStakingContract(
+    proxyAddress,
+    implementation,
+    minStakingDepositResult.value,
+    numAgentInstancesResult.value,
+    event
+  );
+
+  StakingProxyTemplate.create(proxyAddress);
+}

--- a/subgraphs/pearl-transactions/src/staking-proxy.ts
+++ b/subgraphs/pearl-transactions/src/staking-proxy.ts
@@ -41,8 +41,14 @@ export function handleServiceStaked(event: ServiceStakedEvent): void {
   service.updatedTimestamp = event.block.timestamp;
   service.save();
 
+  // `owner` is the Master Safe (ServiceStaked carries it explicitly), so
+  // this is the canonical discovery path. getOrCreateMasterSafe returns
+  // null only if `owner` isn't a Safe (non-Pearl service / EOA owner) —
+  // skip the link in that case rather than crash.
   const masterSafe = getOrCreateMasterSafe(owner, event);
-  service.masterSafe = masterSafe.id;
+  if (masterSafe != null) {
+    service.masterSafe = masterSafe.id;
+  }
 
   const agentSafe = getOrCreateAgentSafe(multisig, service, event);
   service.agentSafe = agentSafe.id;

--- a/subgraphs/pearl-transactions/src/staking-proxy.ts
+++ b/subgraphs/pearl-transactions/src/staking-proxy.ts
@@ -1,0 +1,208 @@
+import { Address, BigInt, ethereum, log } from "@graphprotocol/graph-ts";
+import {
+  RewardClaimed as RewardClaimedEvent,
+  ServiceForceUnstaked as ServiceForceUnstakedEvent,
+  ServiceStaked as ServiceStakedEvent,
+  ServiceUnstaked as ServiceUnstakedEvent,
+  ServicesEvicted as ServicesEvictedEvent,
+} from "../generated/templates/StakingProxy/StakingProxy";
+import { FundsMovement, Service } from "../generated/schema";
+import {
+  CATEGORY_SERVICE_EVICTED,
+  CATEGORY_STAKING_REWARD_CLAIM,
+  CATEGORY_UNSTAKE_REWARD,
+  SERVICE_STATE_STAKED,
+  SERVICE_STATE_UNSTAKED,
+  SOURCE_SEMANTIC,
+  getOlasAddress,
+} from "./constants";
+import {
+  addDailyOlasReward,
+  currentNetwork,
+  fundsMovementId,
+  getOrCreateAgentSafe,
+  getOrCreateMasterSafe,
+  getOrCreateService,
+} from "./utils";
+
+// handleServiceStaked — service NFT moved into the staking proxy.
+// Both owner (Master Safe) and multisig (Agent Safe) are first-class
+// event params, so this is the canonical Master Safe + Agent Safe
+// discovery path (the NFT-Transfer path is secondary).
+export function handleServiceStaked(event: ServiceStakedEvent): void {
+  const serviceId = event.params.serviceId;
+  const owner = event.params.owner;
+  const multisig = event.params.multisig;
+  const epoch = event.params.epoch;
+
+  const service = getOrCreateService(serviceId, event);
+  service.state = SERVICE_STATE_STAKED;
+  service.currentStakingContract = event.address;
+  service.updatedTimestamp = event.block.timestamp;
+  service.save();
+
+  const masterSafe = getOrCreateMasterSafe(owner, event);
+  service.masterSafe = masterSafe.id;
+
+  const agentSafe = getOrCreateAgentSafe(multisig, service, event);
+  service.agentSafe = agentSafe.id;
+  service.save();
+}
+
+// handleRewardClaimed — OLAS reward transferred from the staking proxy
+// to the Agent Safe. Records a FundsMovement(STAKING_REWARD_CLAIM)
+// and bumps both the per-service cumulative and the daily-bucket
+// rollup.
+export function handleRewardClaimed(event: RewardClaimedEvent): void {
+  const serviceId = event.params.serviceId;
+  const owner = event.params.owner; // Master Safe
+  const multisig = event.params.multisig; // Agent Safe
+  const reward = event.params.reward;
+  const epoch = event.params.epoch;
+
+  const service = getOrCreateService(serviceId, event);
+
+  const row = new FundsMovement(fundsMovementId(event));
+  row.service = service.id;
+  if (service.masterSafe !== null) {
+    row.masterSafe = service.masterSafe;
+  } else {
+    row.masterSafe = owner;
+  }
+  if (service.agentSafe !== null) {
+    row.agentSafe = service.agentSafe;
+  } else {
+    row.agentSafe = multisig;
+  }
+  row.stakingContract = event.address;
+  row.epoch = epoch;
+  row.category = CATEGORY_STAKING_REWARD_CLAIM;
+  row.source = SOURCE_SEMANTIC;
+  row.token = getOlasAddress(currentNetwork());
+  row.amount = reward;
+  row.from = event.address; // staking proxy
+  row.to = multisig;
+  row.blockNumber = event.block.number;
+  row.blockTimestamp = event.block.timestamp;
+  row.transactionHash = event.transaction.hash;
+  row.save();
+
+  addDailyOlasReward(service, reward, event.block.timestamp);
+  service.updatedTimestamp = event.block.timestamp;
+  service.save();
+}
+
+function handleAnyUnstake(
+  serviceId: BigInt,
+  owner: Address,
+  multisig: Address,
+  reward: BigInt,
+  epoch: BigInt,
+  event: ethereum.Event
+): void {
+  const service = getOrCreateService(serviceId, event);
+
+  const row = new FundsMovement(fundsMovementId(event));
+  row.service = service.id;
+  if (service.masterSafe !== null) {
+    row.masterSafe = service.masterSafe;
+  } else {
+    row.masterSafe = owner;
+  }
+  if (service.agentSafe !== null) {
+    row.agentSafe = service.agentSafe;
+  } else {
+    row.agentSafe = multisig;
+  }
+  row.stakingContract = event.address;
+  row.epoch = epoch;
+  row.category = CATEGORY_UNSTAKE_REWARD;
+  row.source = SOURCE_SEMANTIC;
+  row.token = getOlasAddress(currentNetwork());
+  row.amount = reward;
+  row.from = event.address;
+  row.to = multisig;
+  row.blockNumber = event.block.number;
+  row.blockTimestamp = event.block.timestamp;
+  row.transactionHash = event.transaction.hash;
+  row.save();
+
+  if (reward.gt(BigInt.zero())) {
+    addDailyOlasReward(service, reward, event.block.timestamp);
+  }
+  service.state = SERVICE_STATE_UNSTAKED;
+  service.currentStakingContract = null;
+  service.updatedTimestamp = event.block.timestamp;
+  service.save();
+}
+
+export function handleServiceUnstaked(event: ServiceUnstakedEvent): void {
+  handleAnyUnstake(
+    event.params.serviceId,
+    event.params.owner,
+    event.params.multisig,
+    event.params.reward,
+    event.params.epoch,
+    event
+  );
+}
+
+export function handleServiceForceUnstaked(
+  event: ServiceForceUnstakedEvent
+): void {
+  handleAnyUnstake(
+    event.params.serviceId,
+    event.params.owner,
+    event.params.multisig,
+    event.params.reward,
+    event.params.epoch,
+    event
+  );
+}
+
+// handleServicesEvicted — informational. Eviction itself does not
+// move funds; we record one zero-amount FundsMovement(SERVICE_EVICTED)
+// per affected service so the consumer wallet UI can render an
+// "Evicted from staking" history row. The follow-up reward/refund
+// transfers (if any) fire as their own typed events.
+export function handleServicesEvicted(event: ServicesEvictedEvent): void {
+  const serviceIds = event.params.serviceIds;
+  const owners = event.params.owners;
+  const multisigs = event.params.multisigs;
+  const epoch = event.params.epoch;
+
+  for (let i = 0; i < serviceIds.length; i++) {
+    const serviceId = serviceIds[i];
+    const owner = i < owners.length ? owners[i] : Address.zero();
+    const multisig = i < multisigs.length ? multisigs[i] : Address.zero();
+
+    const service = getOrCreateService(serviceId, event);
+
+    // Unique-id per (tx, logIndex, serviceId-slot) since ServicesEvicted
+    // is one event affecting many services. Use logIndex + i.
+    const id = event.transaction.hash.concatI32(event.logIndex.toI32() + i);
+    const row = new FundsMovement(id);
+    row.service = service.id;
+    if (service.masterSafe !== null) {
+      row.masterSafe = service.masterSafe;
+    } else {
+      row.masterSafe = owner;
+    }
+    if (service.agentSafe !== null) {
+      row.agentSafe = service.agentSafe;
+    } else {
+      row.agentSafe = multisig;
+    }
+    row.stakingContract = event.address;
+    row.epoch = epoch;
+    row.category = CATEGORY_SERVICE_EVICTED;
+    row.source = SOURCE_SEMANTIC;
+    row.amount = BigInt.zero();
+    row.from = event.address;
+    row.to = multisig;
+    row.blockNumber = event.block.number;
+    row.blockTimestamp = event.block.timestamp;
+    row.transactionHash = event.transaction.hash;
+    row.save();
+  }
+}

--- a/subgraphs/pearl-transactions/src/utils.ts
+++ b/subgraphs/pearl-transactions/src/utils.ts
@@ -9,6 +9,7 @@ import {
 import {
   AgentBondAttributionGuard,
   AgentSafe,
+  DailyServiceFunds,
   FundsMovement,
   MasterSafe,
   PendingBondCounter,
@@ -16,6 +17,7 @@ import {
   PendingRegistration,
   Service,
   ServiceIndex,
+  StakingContract,
 } from "../generated/schema";
 import { GnosisSafe } from "../generated/ServiceRegistryL2/GnosisSafe";
 import {
@@ -150,6 +152,14 @@ function emitSafeDeployedRow(
   row.save();
 }
 
+// isStakingContract — true if `addr` corresponds to an indexed
+// StakingContract entity. Used by handleServiceNftTransfer in Phase 1b
+// to skip Master Safe derivation on the NFT → staking-proxy hop
+// (avoids the getOwners() revert + warning log for proxy addresses).
+export function isStakingContract(addr: Address): boolean {
+  return StakingContract.load(addr) != null;
+}
+
 // --- AgentSafe -------------------------------------------------------
 
 export function getOrCreateAgentSafe(
@@ -187,6 +197,7 @@ export function getOrCreateService(
   service.agentIds = [];
   service.operators = [];
   service.state = SERVICE_STATE_REGISTERED;
+  service.totalOlasRewardsClaimed = BigInt.zero();
   service.registeredTimestamp = event.block.timestamp;
   service.updatedTimestamp = event.block.timestamp;
   service.save();
@@ -417,4 +428,65 @@ export function attributeAgentBondOncePerService(
   const guard = new AgentBondAttributionGuard(guardId);
   guard.save();
   dequeueAndAttribute(txHash, serviceId, bondType);
+}
+
+// --- DailyServiceFunds (Phase 1b) ------------------------------------
+
+const ONE_DAY: i64 = 86400;
+
+export function dayTimestamp(timestamp: BigInt): BigInt {
+  const t = timestamp.toI64();
+  const day = (t / ONE_DAY) * ONE_DAY;
+  return BigInt.fromI64(day);
+}
+
+// addDailyOlasReward — bump both the daily-bucket counter and the
+// per-service cumulative counter for an OLAS reward outflow
+// (RewardClaimed or *Unstaked reward). Idempotent on entity-creation;
+// just adds the amount.
+export function addDailyOlasReward(
+  service: Service,
+  amount: BigInt,
+  blockTimestamp: BigInt
+): void {
+  const day = dayTimestamp(blockTimestamp);
+  const id = service.id + "-" + day.toString();
+  let daily = DailyServiceFunds.load(id);
+  if (daily == null) {
+    daily = new DailyServiceFunds(id);
+    daily.service = service.id;
+    daily.dayTimestamp = day;
+    daily.olasRewardsClaimed = BigInt.zero();
+    daily.cumulativeOlasRewardsClaimed = service.totalOlasRewardsClaimed;
+  }
+  daily.olasRewardsClaimed = daily.olasRewardsClaimed.plus(amount);
+  daily.cumulativeOlasRewardsClaimed = service.totalOlasRewardsClaimed.plus(
+    amount
+  );
+  daily.save();
+
+  service.totalOlasRewardsClaimed = service.totalOlasRewardsClaimed.plus(
+    amount
+  );
+}
+
+// --- StakingContract -------------------------------------------------
+
+export function getOrCreateStakingContract(
+  proxyAddress: Address,
+  implementation: Bytes,
+  minStakingDeposit: BigInt,
+  numAgentInstances: BigInt,
+  event: ethereum.Event
+): StakingContract {
+  let sc = StakingContract.load(proxyAddress);
+  if (sc != null) return sc;
+  sc = new StakingContract(proxyAddress);
+  sc.implementation = implementation;
+  sc.minStakingDeposit = minStakingDeposit;
+  sc.numAgentInstances = numAgentInstances;
+  sc.createdBlock = event.block.number;
+  sc.createdTimestamp = event.block.timestamp;
+  sc.save();
+  return sc;
 }

--- a/subgraphs/pearl-transactions/subgraph.base.yaml
+++ b/subgraphs/pearl-transactions/subgraph.base.yaml
@@ -69,3 +69,60 @@ dataSources:
         - event: TokenRefund(indexed address,indexed address,uint256)
           handler: handleTokenRefund
       file: ./src/service-registry-token-utility.ts
+  - kind: ethereum
+    name: StakingFactory
+    network: base
+    source:
+      address: "0x1cEe30D08943EB58EFF84DD1AB44a6ee6FEff63a"
+      abi: StakingFactory
+      startBlock: 17310019
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - StakingContract
+      abis:
+        - name: StakingFactory
+          file: ../../abis/StakingFactory.json
+        - name: StakingProxy
+          file: ../../abis/StakingProxy.json
+      eventHandlers:
+        - event: InstanceCreated(indexed address,indexed address,indexed address)
+          handler: handleInstanceCreated
+      file: ./src/staking-factory.ts
+templates:
+  - name: StakingProxy
+    kind: ethereum/contract
+    network: base
+    source:
+      abi: StakingProxy
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - Service
+        - MasterSafe
+        - FundsMovement
+        - DailyServiceFunds
+      abis:
+        - name: StakingProxy
+          file: ../../abis/StakingProxy.json
+        - name: GnosisSafe
+          file: ../../abis/GnosisSafe.json
+      eventHandlers:
+        - event: ServiceStaked(uint256,indexed uint256,indexed address,indexed address,uint256[])
+          handler: handleServiceStaked
+        - event: RewardClaimed(uint256,indexed uint256,indexed address,indexed
+            address,uint256[],uint256)
+          handler: handleRewardClaimed
+        - event: ServiceUnstaked(uint256,indexed uint256,indexed address,indexed
+            address,uint256[],uint256,uint256)
+          handler: handleServiceUnstaked
+        - event: ServiceForceUnstaked(uint256,indexed uint256,indexed address,indexed
+            address,uint256[],uint256,uint256)
+          handler: handleServiceForceUnstaked
+        - event: ServicesEvicted(indexed uint256,uint256[],address[],address[],uint256[])
+          handler: handleServicesEvicted
+      file: ./src/staking-proxy.ts

--- a/subgraphs/pearl-transactions/subgraph.gnosis.yaml
+++ b/subgraphs/pearl-transactions/subgraph.gnosis.yaml
@@ -69,3 +69,60 @@ dataSources:
         - event: TokenRefund(indexed address,indexed address,uint256)
           handler: handleTokenRefund
       file: ./src/service-registry-token-utility.ts
+  - kind: ethereum
+    name: StakingFactory
+    network: gnosis
+    source:
+      address: "0xb0228CA253A88Bc8eb4ca70BCAC8f87b381f4700"
+      abi: StakingFactory
+      startBlock: 35206806
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - StakingContract
+      abis:
+        - name: StakingFactory
+          file: ../../abis/StakingFactory.json
+        - name: StakingProxy
+          file: ../../abis/StakingProxy.json
+      eventHandlers:
+        - event: InstanceCreated(indexed address,indexed address,indexed address)
+          handler: handleInstanceCreated
+      file: ./src/staking-factory.ts
+templates:
+  - name: StakingProxy
+    kind: ethereum/contract
+    network: gnosis
+    source:
+      abi: StakingProxy
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - Service
+        - MasterSafe
+        - FundsMovement
+        - DailyServiceFunds
+      abis:
+        - name: StakingProxy
+          file: ../../abis/StakingProxy.json
+        - name: GnosisSafe
+          file: ../../abis/GnosisSafe.json
+      eventHandlers:
+        - event: ServiceStaked(uint256,indexed uint256,indexed address,indexed address,uint256[])
+          handler: handleServiceStaked
+        - event: RewardClaimed(uint256,indexed uint256,indexed address,indexed
+            address,uint256[],uint256)
+          handler: handleRewardClaimed
+        - event: ServiceUnstaked(uint256,indexed uint256,indexed address,indexed
+            address,uint256[],uint256,uint256)
+          handler: handleServiceUnstaked
+        - event: ServiceForceUnstaked(uint256,indexed uint256,indexed address,indexed
+            address,uint256[],uint256,uint256)
+          handler: handleServiceForceUnstaked
+        - event: ServicesEvicted(indexed uint256,uint256[],address[],address[],uint256[])
+          handler: handleServicesEvicted
+      file: ./src/staking-proxy.ts

--- a/subgraphs/pearl-transactions/subgraph.matic.yaml
+++ b/subgraphs/pearl-transactions/subgraph.matic.yaml
@@ -69,3 +69,60 @@ dataSources:
         - event: TokenRefund(indexed address,indexed address,uint256)
           handler: handleTokenRefund
       file: ./src/service-registry-token-utility.ts
+  - kind: ethereum
+    name: StakingFactory
+    network: matic
+    source:
+      address: "0x46C0D07F55d4F9B5Eed2Fc9680B5953e5fd7b461"
+      abi: StakingFactory
+      startBlock: 62213142
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - StakingContract
+      abis:
+        - name: StakingFactory
+          file: ../../abis/StakingFactory.json
+        - name: StakingProxy
+          file: ../../abis/StakingProxy.json
+      eventHandlers:
+        - event: InstanceCreated(indexed address,indexed address,indexed address)
+          handler: handleInstanceCreated
+      file: ./src/staking-factory.ts
+templates:
+  - name: StakingProxy
+    kind: ethereum/contract
+    network: matic
+    source:
+      abi: StakingProxy
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - Service
+        - MasterSafe
+        - FundsMovement
+        - DailyServiceFunds
+      abis:
+        - name: StakingProxy
+          file: ../../abis/StakingProxy.json
+        - name: GnosisSafe
+          file: ../../abis/GnosisSafe.json
+      eventHandlers:
+        - event: ServiceStaked(uint256,indexed uint256,indexed address,indexed address,uint256[])
+          handler: handleServiceStaked
+        - event: RewardClaimed(uint256,indexed uint256,indexed address,indexed
+            address,uint256[],uint256)
+          handler: handleRewardClaimed
+        - event: ServiceUnstaked(uint256,indexed uint256,indexed address,indexed
+            address,uint256[],uint256,uint256)
+          handler: handleServiceUnstaked
+        - event: ServiceForceUnstaked(uint256,indexed uint256,indexed address,indexed
+            address,uint256[],uint256,uint256)
+          handler: handleServiceForceUnstaked
+        - event: ServicesEvicted(indexed uint256,uint256[],address[],address[],uint256[])
+          handler: handleServicesEvicted
+      file: ./src/staking-proxy.ts

--- a/subgraphs/pearl-transactions/subgraph.optimism.yaml
+++ b/subgraphs/pearl-transactions/subgraph.optimism.yaml
@@ -69,3 +69,60 @@ dataSources:
         - event: TokenRefund(indexed address,indexed address,uint256)
           handler: handleTokenRefund
       file: ./src/service-registry-token-utility.ts
+  - kind: ethereum
+    name: StakingFactory
+    network: optimism
+    source:
+      address: "0xa45E64d13A30a51b91ae0eb182e88a40e9b18eD8"
+      abi: StakingFactory
+      startBlock: 124618633
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - StakingContract
+      abis:
+        - name: StakingFactory
+          file: ../../abis/StakingFactory.json
+        - name: StakingProxy
+          file: ../../abis/StakingProxy.json
+      eventHandlers:
+        - event: InstanceCreated(indexed address,indexed address,indexed address)
+          handler: handleInstanceCreated
+      file: ./src/staking-factory.ts
+templates:
+  - name: StakingProxy
+    kind: ethereum/contract
+    network: optimism
+    source:
+      abi: StakingProxy
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - Service
+        - MasterSafe
+        - FundsMovement
+        - DailyServiceFunds
+      abis:
+        - name: StakingProxy
+          file: ../../abis/StakingProxy.json
+        - name: GnosisSafe
+          file: ../../abis/GnosisSafe.json
+      eventHandlers:
+        - event: ServiceStaked(uint256,indexed uint256,indexed address,indexed address,uint256[])
+          handler: handleServiceStaked
+        - event: RewardClaimed(uint256,indexed uint256,indexed address,indexed
+            address,uint256[],uint256)
+          handler: handleRewardClaimed
+        - event: ServiceUnstaked(uint256,indexed uint256,indexed address,indexed
+            address,uint256[],uint256,uint256)
+          handler: handleServiceUnstaked
+        - event: ServiceForceUnstaked(uint256,indexed uint256,indexed address,indexed
+            address,uint256[],uint256,uint256)
+          handler: handleServiceForceUnstaked
+        - event: ServicesEvicted(indexed uint256,uint256[],address[],address[],uint256[])
+          handler: handleServicesEvicted
+      file: ./src/staking-proxy.ts

--- a/subgraphs/pearl-transactions/subgraph.template.yaml
+++ b/subgraphs/pearl-transactions/subgraph.template.yaml
@@ -69,3 +69,60 @@ dataSources:
         - event: TokenRefund(indexed address,indexed address,uint256)
           handler: handleTokenRefund
       file: ./src/service-registry-token-utility.ts
+  - kind: ethereum
+    name: StakingFactory
+    network: {{ network }}
+    source:
+      address: "{{ StakingFactory.address }}"
+      abi: StakingFactory
+      startBlock: {{ StakingFactory.startBlock }}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - StakingContract
+      abis:
+        - name: StakingFactory
+          file: ../../abis/StakingFactory.json
+        - name: StakingProxy
+          file: ../../abis/StakingProxy.json
+      eventHandlers:
+        - event: InstanceCreated(indexed address,indexed address,indexed address)
+          handler: handleInstanceCreated
+      file: ./src/staking-factory.ts
+templates:
+  - name: StakingProxy
+    kind: ethereum/contract
+    network: {{ network }}
+    source:
+      abi: StakingProxy
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - Service
+        - MasterSafe
+        - FundsMovement
+        - DailyServiceFunds
+      abis:
+        - name: StakingProxy
+          file: ../../abis/StakingProxy.json
+        - name: GnosisSafe
+          file: ../../abis/GnosisSafe.json
+      eventHandlers:
+        - event: ServiceStaked(uint256,indexed uint256,indexed address,indexed address,uint256[])
+          handler: handleServiceStaked
+        - event: RewardClaimed(uint256,indexed uint256,indexed address,indexed
+            address,uint256[],uint256)
+          handler: handleRewardClaimed
+        - event: ServiceUnstaked(uint256,indexed uint256,indexed address,indexed
+            address,uint256[],uint256,uint256)
+          handler: handleServiceUnstaked
+        - event: ServiceForceUnstaked(uint256,indexed uint256,indexed address,indexed
+            address,uint256[],uint256,uint256)
+          handler: handleServiceForceUnstaked
+        - event: ServicesEvicted(indexed uint256,uint256[],address[],address[],uint256[])
+          handler: handleServicesEvicted
+      file: ./src/staking-proxy.ts

--- a/subgraphs/pearl-transactions/tests/staking.test.ts
+++ b/subgraphs/pearl-transactions/tests/staking.test.ts
@@ -1,0 +1,619 @@
+import {
+  afterEach,
+  assert,
+  beforeEach,
+  clearStore,
+  createMockedFunction,
+  dataSourceMock,
+  describe,
+  newMockEvent,
+  test,
+} from "matchstick-as/assembly/index";
+import { Address, BigInt, Bytes, ethereum } from "@graphprotocol/graph-ts";
+import { StakingContract } from "../generated/schema";
+import { InstanceCreated } from "../generated/StakingFactory/StakingFactory";
+import {
+  RewardClaimed,
+  ServiceForceUnstaked,
+  ServiceStaked,
+  ServiceUnstaked,
+  ServicesEvicted,
+} from "../generated/templates/StakingProxy/StakingProxy";
+import { Transfer } from "../generated/ServiceRegistryL2/ServiceRegistryL2";
+import { handleInstanceCreated } from "../src/staking-factory";
+import {
+  handleRewardClaimed,
+  handleServiceForceUnstaked,
+  handleServiceStaked,
+  handleServiceUnstaked,
+  handleServicesEvicted,
+} from "../src/staking-proxy";
+import { handleServiceNftTransfer } from "../src/service-registry";
+
+// ----------------- Fixtures -----------------
+
+const ZERO = Address.zero();
+const MASTER_EOA = Address.fromString(
+  "0x1111111111111111111111111111111111111111"
+);
+const BACKUP_EOA = Address.fromString(
+  "0x2222222222222222222222222222222222222222"
+);
+const MASTER_SAFE = Address.fromString(
+  "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+);
+const AGENT_SAFE = Address.fromString(
+  "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+);
+const STAKING_FACTORY_GNOSIS = Address.fromString(
+  "0xb0228CA253A88Bc8eb4ca70BCAC8f87b381f4700"
+);
+const STAKING_PROXY = Address.fromString(
+  "0x9999999999999999999999999999999999999999"
+);
+const ALLOWED_IMPL_GNOSIS = Address.fromString(
+  "0xEa00be6690a871827fAfD705440D20dd75e67AB1"
+);
+const DISALLOWED_IMPL = Address.fromString(
+  "0xdeaddeaddeaddeaddeaddeaddeaddeaddeaddead"
+);
+
+const SERVICE_ID = BigInt.fromI32(42);
+const SERVICE_ID_2 = BigInt.fromI32(43);
+const EPOCH = BigInt.fromI32(7);
+const REWARD = BigInt.fromString("1500000000000000000"); // 1.5 OLAS
+const MIN_STAKING_DEPOSIT = BigInt.fromString("10000000000000000000"); // 10 OLAS
+const NUM_AGENT_INSTANCES = BigInt.fromI32(1);
+
+function mockTx(salt: i32): Bytes {
+  return Bytes.fromHexString(
+    "0x" + "00".repeat(28) + salt.toString(16).padStart(8, "0")
+  );
+}
+
+function mockGetOwners(safe: Address, owners: Address[]): void {
+  const valueArray: ethereum.Value[] = [];
+  for (let i = 0; i < owners.length; i++) {
+    valueArray.push(ethereum.Value.fromAddress(owners[i]));
+  }
+  createMockedFunction(safe, "getOwners", "getOwners():(address[])").returns([
+    ethereum.Value.fromArray(valueArray),
+  ]);
+}
+
+function mockGetThreshold(safe: Address, threshold: i32): void {
+  createMockedFunction(
+    safe,
+    "getThreshold",
+    "getThreshold():(uint256)"
+  ).returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(threshold))]);
+}
+
+function mockProxyConfig(
+  proxy: Address,
+  minStakingDeposit: BigInt,
+  numAgentInstances: BigInt
+): void {
+  createMockedFunction(
+    proxy,
+    "minStakingDeposit",
+    "minStakingDeposit():(uint256)"
+  ).returns([ethereum.Value.fromUnsignedBigInt(minStakingDeposit)]);
+  createMockedFunction(
+    proxy,
+    "numAgentInstances",
+    "numAgentInstances():(uint256)"
+  ).returns([ethereum.Value.fromUnsignedBigInt(numAgentInstances)]);
+}
+
+function setMockEventBoilerplate<T extends ethereum.Event>(
+  event: T,
+  txHash: Bytes,
+  logIndex: i32,
+  address: Address
+): T {
+  event.address = address;
+  event.transaction.hash = txHash;
+  event.logIndex = BigInt.fromI32(logIndex);
+  return event;
+}
+
+// ----------------- Event constructors -----------------
+
+function newInstanceCreated(
+  sender: Address,
+  instance: Address,
+  implementation: Address,
+  txHash: Bytes
+): InstanceCreated {
+  const mock = newMockEvent();
+  const e = new InstanceCreated(
+    mock.address,
+    mock.logIndex,
+    mock.transactionLogIndex,
+    mock.logType,
+    mock.block,
+    mock.transaction,
+    mock.parameters,
+    mock.receipt
+  );
+  e.parameters = new Array();
+  e.parameters.push(
+    new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender))
+  );
+  e.parameters.push(
+    new ethereum.EventParam("instance", ethereum.Value.fromAddress(instance))
+  );
+  e.parameters.push(
+    new ethereum.EventParam(
+      "implementation",
+      ethereum.Value.fromAddress(implementation)
+    )
+  );
+  return setMockEventBoilerplate(e, txHash, 0, STAKING_FACTORY_GNOSIS);
+}
+
+function newServiceStaked(
+  serviceId: BigInt,
+  epoch: BigInt,
+  owner: Address,
+  multisig: Address,
+  proxy: Address,
+  txHash: Bytes
+): ServiceStaked {
+  const mock = newMockEvent();
+  const e = new ServiceStaked(
+    mock.address,
+    mock.logIndex,
+    mock.transactionLogIndex,
+    mock.logType,
+    mock.block,
+    mock.transaction,
+    mock.parameters,
+    mock.receipt
+  );
+  e.parameters = new Array();
+  e.parameters.push(
+    new ethereum.EventParam(
+      "epoch",
+      ethereum.Value.fromUnsignedBigInt(epoch)
+    )
+  );
+  e.parameters.push(
+    new ethereum.EventParam(
+      "serviceId",
+      ethereum.Value.fromUnsignedBigInt(serviceId)
+    )
+  );
+  e.parameters.push(
+    new ethereum.EventParam("owner", ethereum.Value.fromAddress(owner))
+  );
+  e.parameters.push(
+    new ethereum.EventParam("multisig", ethereum.Value.fromAddress(multisig))
+  );
+  e.parameters.push(
+    new ethereum.EventParam(
+      "nonces",
+      ethereum.Value.fromUnsignedBigIntArray([])
+    )
+  );
+  return setMockEventBoilerplate(e, txHash, 0, proxy);
+}
+
+function newRewardClaimed(
+  serviceId: BigInt,
+  epoch: BigInt,
+  owner: Address,
+  multisig: Address,
+  reward: BigInt,
+  proxy: Address,
+  txHash: Bytes
+): RewardClaimed {
+  const mock = newMockEvent();
+  const e = new RewardClaimed(
+    mock.address,
+    mock.logIndex,
+    mock.transactionLogIndex,
+    mock.logType,
+    mock.block,
+    mock.transaction,
+    mock.parameters,
+    mock.receipt
+  );
+  e.parameters = new Array();
+  e.parameters.push(
+    new ethereum.EventParam(
+      "epoch",
+      ethereum.Value.fromUnsignedBigInt(epoch)
+    )
+  );
+  e.parameters.push(
+    new ethereum.EventParam(
+      "serviceId",
+      ethereum.Value.fromUnsignedBigInt(serviceId)
+    )
+  );
+  e.parameters.push(
+    new ethereum.EventParam("owner", ethereum.Value.fromAddress(owner))
+  );
+  e.parameters.push(
+    new ethereum.EventParam("multisig", ethereum.Value.fromAddress(multisig))
+  );
+  e.parameters.push(
+    new ethereum.EventParam(
+      "nonces",
+      ethereum.Value.fromUnsignedBigIntArray([])
+    )
+  );
+  e.parameters.push(
+    new ethereum.EventParam(
+      "reward",
+      ethereum.Value.fromUnsignedBigInt(reward)
+    )
+  );
+  return setMockEventBoilerplate(e, txHash, 0, proxy);
+}
+
+function newServiceUnstaked(
+  serviceId: BigInt,
+  epoch: BigInt,
+  owner: Address,
+  multisig: Address,
+  reward: BigInt,
+  proxy: Address,
+  txHash: Bytes
+): ServiceUnstaked {
+  const mock = newMockEvent();
+  const e = new ServiceUnstaked(
+    mock.address,
+    mock.logIndex,
+    mock.transactionLogIndex,
+    mock.logType,
+    mock.block,
+    mock.transaction,
+    mock.parameters,
+    mock.receipt
+  );
+  e.parameters = new Array();
+  e.parameters.push(
+    new ethereum.EventParam(
+      "epoch",
+      ethereum.Value.fromUnsignedBigInt(epoch)
+    )
+  );
+  e.parameters.push(
+    new ethereum.EventParam(
+      "serviceId",
+      ethereum.Value.fromUnsignedBigInt(serviceId)
+    )
+  );
+  e.parameters.push(
+    new ethereum.EventParam("owner", ethereum.Value.fromAddress(owner))
+  );
+  e.parameters.push(
+    new ethereum.EventParam("multisig", ethereum.Value.fromAddress(multisig))
+  );
+  e.parameters.push(
+    new ethereum.EventParam(
+      "nonces",
+      ethereum.Value.fromUnsignedBigIntArray([])
+    )
+  );
+  e.parameters.push(
+    new ethereum.EventParam(
+      "reward",
+      ethereum.Value.fromUnsignedBigInt(reward)
+    )
+  );
+  e.parameters.push(
+    new ethereum.EventParam(
+      "availableRewards",
+      ethereum.Value.fromUnsignedBigInt(BigInt.zero())
+    )
+  );
+  return setMockEventBoilerplate(e, txHash, 0, proxy);
+}
+
+function newServicesEvicted(
+  epoch: BigInt,
+  serviceIds: BigInt[],
+  owners: Address[],
+  multisigs: Address[],
+  proxy: Address,
+  txHash: Bytes
+): ServicesEvicted {
+  const mock = newMockEvent();
+  const e = new ServicesEvicted(
+    mock.address,
+    mock.logIndex,
+    mock.transactionLogIndex,
+    mock.logType,
+    mock.block,
+    mock.transaction,
+    mock.parameters,
+    mock.receipt
+  );
+  e.parameters = new Array();
+  e.parameters.push(
+    new ethereum.EventParam(
+      "epoch",
+      ethereum.Value.fromUnsignedBigInt(epoch)
+    )
+  );
+  e.parameters.push(
+    new ethereum.EventParam(
+      "serviceIds",
+      ethereum.Value.fromUnsignedBigIntArray(serviceIds)
+    )
+  );
+  e.parameters.push(
+    new ethereum.EventParam("owners", ethereum.Value.fromAddressArray(owners))
+  );
+  e.parameters.push(
+    new ethereum.EventParam(
+      "multisigs",
+      ethereum.Value.fromAddressArray(multisigs)
+    )
+  );
+  e.parameters.push(
+    new ethereum.EventParam(
+      "serviceInactivity",
+      ethereum.Value.fromUnsignedBigIntArray([])
+    )
+  );
+  return setMockEventBoilerplate(e, txHash, 0, proxy);
+}
+
+function newNftTransfer(
+  from: Address,
+  to: Address,
+  tokenId: BigInt,
+  txHash: Bytes,
+  logIndex: i32
+): Transfer {
+  const mock = newMockEvent();
+  const e = new Transfer(
+    mock.address,
+    mock.logIndex,
+    mock.transactionLogIndex,
+    mock.logType,
+    mock.block,
+    mock.transaction,
+    mock.parameters,
+    mock.receipt
+  );
+  e.parameters = new Array();
+  e.parameters.push(
+    new ethereum.EventParam("from", ethereum.Value.fromAddress(from))
+  );
+  e.parameters.push(
+    new ethereum.EventParam("to", ethereum.Value.fromAddress(to))
+  );
+  e.parameters.push(
+    new ethereum.EventParam(
+      "id",
+      ethereum.Value.fromUnsignedBigInt(tokenId)
+    )
+  );
+  return setMockEventBoilerplate(
+    e,
+    txHash,
+    logIndex,
+    Address.fromString("0x9338b5153AE39BB89f50468E608eD9d764B755fD")
+  );
+}
+
+// ----------------- Tests -----------------
+
+describe("pearl-transactions / Phase 1b — staking", () => {
+  beforeEach(() => {
+    clearStore();
+    // Pearl-transactions only supports gnosis/matic/optimism/base.
+    // Matchstick defaults to mainnet, so the network resolver crashes
+    // unless we override here.
+    dataSourceMock.setNetwork("gnosis");
+    mockGetOwners(MASTER_SAFE, [MASTER_EOA, BACKUP_EOA]);
+    mockGetThreshold(MASTER_SAFE, 1);
+    mockProxyConfig(STAKING_PROXY, MIN_STAKING_DEPOSIT, NUM_AGENT_INSTANCES);
+  });
+
+  afterEach(() => {
+    clearStore();
+  });
+
+  test("InstanceCreated with allowed implementation creates StakingContract", () => {
+    const tx = mockTx(1);
+    handleInstanceCreated(
+      newInstanceCreated(MASTER_SAFE, STAKING_PROXY, ALLOWED_IMPL_GNOSIS, tx)
+    );
+
+    assert.entityCount("StakingContract", 1);
+    assert.fieldEquals(
+      "StakingContract",
+      STAKING_PROXY.toHexString(),
+      "implementation",
+      ALLOWED_IMPL_GNOSIS.toHexString()
+    );
+    assert.fieldEquals(
+      "StakingContract",
+      STAKING_PROXY.toHexString(),
+      "minStakingDeposit",
+      MIN_STAKING_DEPOSIT.toString()
+    );
+    assert.fieldEquals(
+      "StakingContract",
+      STAKING_PROXY.toHexString(),
+      "numAgentInstances",
+      NUM_AGENT_INSTANCES.toString()
+    );
+  });
+
+  test("InstanceCreated with disallowed implementation is skipped", () => {
+    const tx = mockTx(2);
+    handleInstanceCreated(
+      newInstanceCreated(MASTER_SAFE, STAKING_PROXY, DISALLOWED_IMPL, tx)
+    );
+    assert.entityCount("StakingContract", 0);
+  });
+
+  test("ServiceStaked sets masterSafe + agentSafe + state + currentStakingContract", () => {
+    const tx = mockTx(3);
+    handleServiceStaked(
+      newServiceStaked(SERVICE_ID, EPOCH, MASTER_SAFE, AGENT_SAFE, STAKING_PROXY, tx)
+    );
+
+    assert.fieldEquals("Service", "42", "state", "STAKED");
+    assert.fieldEquals(
+      "Service",
+      "42",
+      "masterSafe",
+      MASTER_SAFE.toHexString()
+    );
+    assert.fieldEquals(
+      "Service",
+      "42",
+      "agentSafe",
+      AGENT_SAFE.toHexString()
+    );
+    assert.fieldEquals(
+      "Service",
+      "42",
+      "currentStakingContract",
+      STAKING_PROXY.toHexString()
+    );
+    // SAFE_DEPLOYED row should have been emitted by getOrCreateMasterSafe.
+    assert.entityCount("MasterSafe", 1);
+    assert.entityCount("AgentSafe", 1);
+  });
+
+  test("RewardClaimed emits row + bumps cumulative + daily rollup", () => {
+    const tx1 = mockTx(4);
+    handleServiceStaked(
+      newServiceStaked(SERVICE_ID, EPOCH, MASTER_SAFE, AGENT_SAFE, STAKING_PROXY, tx1)
+    );
+
+    const tx2 = mockTx(5);
+    handleRewardClaimed(
+      newRewardClaimed(
+        SERVICE_ID,
+        EPOCH,
+        MASTER_SAFE,
+        AGENT_SAFE,
+        REWARD,
+        STAKING_PROXY,
+        tx2
+      )
+    );
+
+    const id = tx2.concatI32(0);
+    assert.fieldEquals(
+      "FundsMovement",
+      id.toHexString(),
+      "category",
+      "STAKING_REWARD_CLAIM"
+    );
+    assert.fieldEquals(
+      "FundsMovement",
+      id.toHexString(),
+      "amount",
+      REWARD.toString()
+    );
+    assert.fieldEquals(
+      "FundsMovement",
+      id.toHexString(),
+      "to",
+      AGENT_SAFE.toHexString()
+    );
+
+    assert.fieldEquals(
+      "Service",
+      "42",
+      "totalOlasRewardsClaimed",
+      REWARD.toString()
+    );
+    assert.entityCount("DailyServiceFunds", 1);
+  });
+
+  test("ServiceUnstaked emits row + clears currentStakingContract + state=UNSTAKED", () => {
+    const tx1 = mockTx(6);
+    handleServiceStaked(
+      newServiceStaked(SERVICE_ID, EPOCH, MASTER_SAFE, AGENT_SAFE, STAKING_PROXY, tx1)
+    );
+
+    const tx2 = mockTx(7);
+    handleServiceUnstaked(
+      newServiceUnstaked(
+        SERVICE_ID,
+        EPOCH,
+        MASTER_SAFE,
+        AGENT_SAFE,
+        REWARD,
+        STAKING_PROXY,
+        tx2
+      )
+    );
+
+    assert.fieldEquals("Service", "42", "state", "UNSTAKED");
+    // currentStakingContract should be cleared (null).
+    const id = tx2.concatI32(0);
+    assert.fieldEquals(
+      "FundsMovement",
+      id.toHexString(),
+      "category",
+      "UNSTAKE_REWARD"
+    );
+  });
+
+  test("ServicesEvicted emits one informational row per affected service", () => {
+    const tx = mockTx(8);
+    handleServicesEvicted(
+      newServicesEvicted(
+        EPOCH,
+        [SERVICE_ID, SERVICE_ID_2],
+        [MASTER_SAFE, MASTER_SAFE],
+        [AGENT_SAFE, AGENT_SAFE],
+        STAKING_PROXY,
+        tx
+      )
+    );
+
+    // Two FundsMovement rows, both SERVICE_EVICTED with amount 0.
+    assert.entityCount("FundsMovement", 2);
+    const id1 = tx.concatI32(0);
+    const id2 = tx.concatI32(1);
+    assert.fieldEquals("FundsMovement", id1.toHexString(), "category", "SERVICE_EVICTED");
+    assert.fieldEquals("FundsMovement", id1.toHexString(), "amount", "0");
+    assert.fieldEquals("FundsMovement", id2.toHexString(), "category", "SERVICE_EVICTED");
+  });
+
+  test("NFT-Transfer to a known StakingContract does NOT call getOwners()", () => {
+    // Seed the StakingContract entity first.
+    const sc = new StakingContract(STAKING_PROXY);
+    sc.implementation = ALLOWED_IMPL_GNOSIS;
+    sc.minStakingDeposit = MIN_STAKING_DEPOSIT;
+    sc.numAgentInstances = NUM_AGENT_INSTANCES;
+    sc.createdBlock = BigInt.fromI32(1);
+    sc.createdTimestamp = BigInt.fromI32(1);
+    sc.save();
+
+    // No mockGetOwners() call for STAKING_PROXY — if the handler
+    // calls getOwners() on it we'd get a revert in matchstick (or a
+    // missing-mock error). The guard should prevent the call.
+    const tx = mockTx(9);
+    handleServiceNftTransfer(
+      newNftTransfer(MASTER_SAFE, STAKING_PROXY, SERVICE_ID, tx, 0)
+    );
+
+    // No MasterSafe entity should have been created for the proxy.
+    assert.entityCount("MasterSafe", 0);
+    // Service still gets nftCustodian updated.
+    assert.fieldEquals(
+      "Service",
+      "42",
+      "nftCustodian",
+      STAKING_PROXY.toHexString()
+    );
+    // Custody change row is still recorded.
+    assert.entityCount("ServiceNftCustodyChange", 1);
+  });
+});


### PR DESCRIPTION
## Summary

Step 4 of [`IMPLEMENTATION-PLAN.md`](https://github.com/valory-xyz/autonolas-subgraph-studio/blob/main/subgraphs/pearl-funds/IMPLEMENTATION-PLAN.md) §8. **Stacked on PR #131** (Phase 1a) — base branch is `phase-1a/pearl-transactions`. When #131 merges, GitHub retargets this to `main` and the diff narrows to just the Phase 1b additions.

Completes Phase 1 of the semantic ledger: full staking-side coverage (factory + dynamic proxy template + reward / unstake / eviction rows + daily snapshots) plus the NFT-handler narrowing that resolves the Phase 1a staking-proxy TODO.

## What landed

**Schema:** `StakingContract` entity, `Service.currentStakingContract` + `Service.totalOlasRewardsClaimed`, `DailyServiceFunds`, three new `FundsCategory` values + `FundsMovement.stakingContract` / `FundsMovement.epoch`.

**Manifest / data sources:** `StakingFactory` static + `StakingProxy` dynamic template (events: `ServiceStaked`, `RewardClaimed`, `ServiceUnstaked`, `ServiceForceUnstaked`, `ServicesEvicted`). `networks.json` extended with StakingFactory per-network addresses; `isAllowedImplementation` allow-list converged with `subgraphs/staking/src/utils.ts`.

**Handlers:**
- `src/staking-factory.ts` `handleInstanceCreated` — implementation allow-list guard; eth_call config snapshot; spawn template.
- `src/staking-proxy.ts` — 5 handlers: `handleServiceStaked` (canonical Master + Agent Safe discovery — `owner`/`multisig` are event params), `handleRewardClaimed` + daily rollup, `handleServiceUnstaked` / `handleServiceForceUnstaked`, `handleServicesEvicted` (one informational zero-amount row per affected service).
- `src/service-registry.ts` `handleServiceNftTransfer` — skips the staking-proxy custody hop.

## Rebase + review fixes (vs. first push)

Rebased onto the updated `phase-1a/pearl-transactions` tip (which carries the two Phase-1a review fixes). Two follow-ups here:

1. **NFT-recipient classification is now defence-in-depth.** The handler skips known staking proxies via `isStakingContract` (cheap, no eth_call) **and** falls through to the Phase-1a `getOwners()` null-probe for anything else. The probe is the safety net for proxies created before the `StakingFactory` start block (or by an older factory) that aren't in the `StakingContract` set — those would otherwise revert + clobber the link.
2. **`handleServiceStaked` null-checks `getOrCreateMasterSafe`** — Phase 1a made it return `MasterSafe | null`; `owner` is the Master Safe so it normally resolves, but the link is now guarded rather than assumed.

## Verification against `autonolas-registries` + `subgraphs/staking`

- `isAllowedImplementation` addresses match the canonical staking allow-list for all 4 networks (gnosis / matic / optimism / base).
- `StakingFactory` addresses + start blocks in `networks.json` match `subgraphs/staking/networks.json` exactly.
- `_stake` transfers the NFT Master Safe → staking proxy and records `sInfo.owner = msg.sender`, consistent with `ServiceStaked.owner` being the Master Safe; `_unstake` returns the NFT to the owner.

## Test plan

- [x] `yarn install` + `generate-manifests` + `codegen` + `test` — **17/17 Matchstick passing** (10 Phase-1a + 7 Phase-1b). `staking.test.ts` sets `dataSourceMock.setNetwork("gnosis")` (matchstick defaults to mainnet, which this subgraph's resolvers don't cover).
- [x] `node scripts/audit-install-hooks.mjs` — OK.
- [x] `lockfile-lint` on `subgraphs/pearl-transactions/yarn.lock` — no issues.
- [x] `gitleaks protect --staged` — no leaks.
- [x] Root `Dependency audit` green on the rebased branch (the `tmp` advisory that affected the pre-rebase branch is no longer an issue post-rebase on `main`).

## Follow-up

| Step | Adds |
|---|---|
| 5 — Verify Phase 1 on Studio | spot-check stake/claim/unstake against block explorer |
| 6 — graph-node template `startBlock` verification | Open Q #6; gates §6.2 option |
| 7 — Phase 2a | OLAS + Safe templates + `AgentFundingEvent` + `SAFE_SETUP_TRANSFER` |
| 8 — Phase 2b | USDC / USDC.e benchmark + product decision |
