### PR TITLE
sync(predict-polymarket): add dailyTradedSettled + resolution fixes

### DIFF
--- a/subgraphs/predict/predict-polymarket/schema.graphql
+++ b/subgraphs/predict/predict-polymarket/schema.graphql
@@ -145,6 +145,12 @@ type DailyProfitStatistic @entity(immutable: false) {
   totalTraded: BigInt! # total traded today, regardless of market settlement
   totalPayout: BigInt! # Payouts received today
 
+  # Cost basis of bets that became settled on this day. Written by processMarketResolution.
+  # Lets ROI for arbitrary windows be computed as profit / dailyTradedSettled without
+  # having to derive `cost = payout - profit`, which is wrong here because totalTraded
+  # lands on bet day, dailyProfit on resolution day, and totalPayout on redemption day.
+  dailyTradedSettled: BigInt!
+
   # Profit realized on this day (from settlements/payouts)
   dailyProfit: BigInt!
 

--- a/subgraphs/predict/predict-polymarket/src/ctf-exchange.ts
+++ b/subgraphs/predict/predict-polymarket/src/ctf-exchange.ts
@@ -100,6 +100,11 @@ export function handleOrderFilled(event: OrderFilledEvent): void {
   let question = Question.load(tokenRegistry.conditionId);
   if (question !== null) {
     bet.question = question.id;
+  } else {
+    log.warning("Question not found for conditionId {} in tx {}", [
+      tokenRegistry.conditionId.toHexString(),
+      event.transaction.hash.toHexString(),
+    ]);
   }
   bet.save();
 

--- a/subgraphs/predict/predict-polymarket/src/utils.ts
+++ b/subgraphs/predict/predict-polymarket/src/utils.ts
@@ -69,6 +69,7 @@ export function getDailyProfitStatistic(
     statistic.totalBets = 0;
     statistic.totalTraded = BigInt.zero();
     statistic.totalPayout = BigInt.zero();
+    statistic.dailyTradedSettled = BigInt.zero();
     statistic.dailyProfit = BigInt.zero();
     statistic.profitParticipants = [];
   }
@@ -181,7 +182,10 @@ export function processMarketResolution(
   payouts: BigInt[],
   event: ethereum.Event
 ): void {
-  // 1. Create the Resolution entity
+  // 1. Create the Resolution entity (skip if already resolved)
+  let existingResolution = QuestionResolution.load(conditionId);
+  if (existingResolution !== null) return;
+
   let resolution = new QuestionResolution(conditionId);
   resolution.question = conditionId;
   resolution.winningIndex = winningOutcome;
@@ -263,6 +267,7 @@ export function processMarketResolution(
       : getDailyProfitStatistic(participant.traderAgent, event.block.timestamp);
 
     dailyStat.dailyProfit = dailyStat.dailyProfit.plus(profit);
+    dailyStat.dailyTradedSettled = dailyStat.dailyTradedSettled.plus(amountToSettle);
     addProfitParticipant(dailyStat, conditionId);
     dailyStatsCache.set(statId, dailyStat);
 
@@ -286,14 +291,12 @@ export function processMarketResolution(
   saveMapValues(agentCache);
   saveMapValues(dailyStatsCache);
 
-  // 6. Apply global deltas
-  if (!globalTradedSettledDelta.equals(BigInt.zero())) {
+  // 6. Apply global deltas (only save if at least one participant was processed)
+  if (!globalTradedSettledDelta.equals(BigInt.zero()) || !globalExpectedPayoutDelta.equals(BigInt.zero())) {
     global.totalTradedSettled = global.totalTradedSettled.plus(globalTradedSettledDelta);
-  }
-  if (!globalExpectedPayoutDelta.equals(BigInt.zero())) {
     global.totalExpectedPayout = global.totalExpectedPayout.plus(globalExpectedPayoutDelta);
+    global.save();
   }
-  global.save();
 }
 
 /**

--- a/subgraphs/predict/predict-polymarket/tests/profit.test.ts
+++ b/subgraphs/predict/predict-polymarket/tests/profit.test.ts
@@ -112,6 +112,7 @@ describe("Profit Chart Integration", () => {
 
     let day3Id = AGENT.toHexString() + "_" + day3TSNormalized.toString();
     assert.fieldEquals("DailyProfitStatistic", day3Id, "dailyProfit", "-1000");
+    assert.fieldEquals("DailyProfitStatistic", day3Id, "dailyTradedSettled", "1000");
     assert.fieldEquals("DailyProfitStatistic", day3Id, "profitParticipants", "[" + CONDITION_LOST.toHexString() + "]");
   });
 
@@ -138,6 +139,7 @@ describe("Profit Chart Integration", () => {
     // Profit recorded on Day 3: expectedPayout(2000) - totalTraded(1000) = 1000
     let day3Id = AGENT.toHexString() + "_" + day3TSNormalized.toString();
     assert.fieldEquals("DailyProfitStatistic", day3Id, "dailyProfit", "1000");
+    assert.fieldEquals("DailyProfitStatistic", day3Id, "dailyTradedSettled", "1000");
     assert.fieldEquals("DailyProfitStatistic", day3Id, "profitParticipants", "[" + CONDITION_WON.toHexString() + "]");
 
     // Verify expectedPayout on participant
@@ -259,6 +261,8 @@ describe("Profit Chart Integration", () => {
 
     // Both bets lost: -1000 - 2000 = -3000
     assert.fieldEquals("DailyProfitStatistic", day3Id, "dailyProfit", "-3000");
+    // Cost settled across both markets on day 3: 1000 + 2000 = 3000
+    assert.fieldEquals("DailyProfitStatistic", day3Id, "dailyTradedSettled", "3000");
   });
 
   /**
@@ -887,5 +891,56 @@ describe("Profit Chart Integration", () => {
     assert.fieldEquals("Global", "", "totalTradedSettled", "3500");
     assert.fieldEquals("Global", "", "totalPayout", "2000");
     assert.fieldEquals("Global", "", "totalTraded", "3500");
+  });
+
+  /**
+   * Test: Duplicate resolution is a no-op (fix #6)
+   * If QuestionResolved fires twice for the same market, the second is skipped.
+   */
+  test("Duplicate resolution: second QuestionResolved is a no-op", () => {
+    setupMarket(CONDITION_LOST, QUESTION_LOST, TOKEN_0_LOST, TOKEN_1_LOST);
+
+    handleOrderFilled(createOrderFilledEvent(AGENT, BigInt.fromI32(1000), BigInt.fromI32(2000), TOKEN_0_LOST, START_TS));
+
+    // First resolution
+    let day3TS = START_TS.plus(BigInt.fromI32(DAY * 2));
+    let payouts = [BigInt.fromI32(0), BigInt.fromString("1000000000000000000")];
+    handleOOQuestionResolved(createQuestionResolvedEvent(QUESTION_LOST, payouts, BigInt.fromI32(1), day3TS));
+
+    assert.fieldEquals("TraderAgent", AGENT.toHexString(), "totalTradedSettled", "1000");
+    assert.fieldEquals("TraderAgent", AGENT.toHexString(), "totalExpectedPayout", "0");
+
+    // Second resolution (duplicate) — should be no-op
+    let day5TS = START_TS.plus(BigInt.fromI32(DAY * 4));
+    handleOOQuestionResolved(createQuestionResolvedEvent(QUESTION_LOST, payouts, BigInt.fromI32(1), day5TS));
+
+    // Totals unchanged — no double-counting
+    assert.fieldEquals("TraderAgent", AGENT.toHexString(), "totalTradedSettled", "1000");
+    assert.fieldEquals("TraderAgent", AGENT.toHexString(), "totalExpectedPayout", "0");
+    assert.fieldEquals("Global", "", "totalTradedSettled", "1000");
+  });
+
+  /**
+   * Test: Global is NOT updated when no participants are processed (fix #7)
+   * Resolution with no bets but an existing Global doesn't modify settled totals.
+   */
+  test("Resolution with no participants: global settled totals unchanged", () => {
+    setupMarket(CONDITION_LOST, QUESTION_LOST, TOKEN_0_LOST, TOKEN_1_LOST);
+    setupMarket(CONDITION_WON, QUESTION_WON, TOKEN_0_WON, TOKEN_1_WON);
+
+    // Place a bet on CONDITION_WON so Global gets created
+    handleOrderFilled(createOrderFilledEvent(AGENT, BigInt.fromI32(500), BigInt.fromI32(1000), TOKEN_0_WON, START_TS));
+
+    assert.fieldEquals("Global", "", "totalTraded", "500");
+    assert.fieldEquals("Global", "", "totalTradedSettled", "0");
+
+    // Resolve CONDITION_LOST (no participants in this market) — global should NOT change
+    let day3TS = START_TS.plus(BigInt.fromI32(DAY * 2));
+    let payouts = [BigInt.fromI32(0), BigInt.fromString("1000000000000000000")];
+    handleOOQuestionResolved(createQuestionResolvedEvent(QUESTION_LOST, payouts, BigInt.fromI32(1), day3TS));
+
+    // Global unchanged — no participants to settle
+    assert.fieldEquals("Global", "", "totalTradedSettled", "0");
+    assert.fieldEquals("Global", "", "totalExpectedPayout", "0");
   });
 });


### PR DESCRIPTION
## What

Brings `subgraphs/predict/predict-polymarket` in line with the canonical version in `autonolas-subgraph`. The studio copy was behind on code; this transfers the missing logic while **preserving intentional config divergence**.

## Code changes (transferred)

- **schema.graphql** — add `DailyProfitStatistic.dailyTradedSettled` (cost basis of bets that became settled on a given day, enabling correct ROI-per-window computation).
- **src/utils.ts** — track `dailyTradedSettled`; guard against duplicate `QuestionResolved` events (second fire is a no-op); only save `Global` when there's an actual delta.
- **src/ctf-exchange.ts** — `log.warning` when a question can't be found for a `conditionId`.
- **tests/profit.test.ts** — new `dailyTradedSettled` assertions plus 2 new tests (duplicate resolution no-op, no-participants global guard).

## Intentionally NOT changed (studio-specific divergence)

- `subgraph.yaml` — `prune: auto` (pruning excluded per request) and `../../../abis/` paths (correct for studio's deeper nesting).
- `package.json` — studio's `resolutions` supply-chain block.
- `README.md` — `CLAUDE.md` reference (studio convention).

## Testing

`yarn codegen` succeeds; all **109 Matchstick tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)