### PR TITLE
phase-2b(pearl-transactions): stablecoin Transfer data sources (USDC / USDC.e / pUSD)

### DIFF
--- a/scripts/generate-manifests.js
+++ b/scripts/generate-manifests.js
@@ -65,6 +65,15 @@ function replacePlaceholders(template, network, networkData) {
 // fields are name + address. Start block = the chain's ServiceRegistryL2
 // deploy block: no Pearl Safe predates it, so it's a provably-safe lower
 // bound (plan Open Q #7) without needing a per-token deploy block.
+//
+// Maintenance notes for `erc20Tokens` in networks.json:
+//   - Treat the array as APPEND-ONLY. The generated data-source order
+//     follows the array order; reordering existing entries between
+//     deploys can disturb grafting / partial-reindex. Add new tokens at
+//     the end; reorder only via a fresh deploy.
+//   - Every entry must have a matching branch in `getStablecoinSymbol`
+//     (src/constants.ts) or its Token rows fall back to UNKNOWN/18 — the
+//     handler logs `log.critical` if that happens (src/utils.ts).
 function renderErc20TokenDataSources(graphNetwork, networkData) {
   const tokens = networkData.erc20Tokens;
   if (!Array.isArray(tokens) || tokens.length === 0) return '';

--- a/scripts/generate-manifests.js
+++ b/scripts/generate-manifests.js
@@ -34,6 +34,8 @@ function replacePlaceholders(template, network, networkData) {
   for (const [contractName, contractData] of Object.entries(networkData)) {
     // Skip non-contract fields (e.g. "network" override)
     if (typeof contractData !== 'object' || contractData === null) continue;
+    // Skip arrays (e.g. "erc20Tokens") — handled by the marker below.
+    if (Array.isArray(contractData)) continue;
     result = result.replace(
       new RegExp(`{{ ${contractName}\\.address }}`, 'g'),
       contractData.address
@@ -44,7 +46,56 @@ function replacePlaceholders(template, network, networkData) {
     );
   }
 
+  // Expand the optional per-network ERC-20 Transfer data sources into the
+  // {{ erc20TokenDataSources }} marker. Lets a network declare a variable
+  // number of plain ERC-20 Transfer sources (e.g. stablecoins, which
+  // differ in count per chain) without a fixed placeholder per token.
+  // No-op for templates without the marker and networks without the array.
+  result = result.replace(
+    /{{ erc20TokenDataSources }}/g,
+    renderErc20TokenDataSources(graphNetwork, networkData)
+  );
+
   return result;
+}
+
+// renderErc20TokenDataSources — build one `Transfer → handleErc20Transfer`
+// data source per entry in networkData.erc20Tokens ([{name, address}]).
+// All such tokens share the same handler/ABI/entities; the only per-token
+// fields are name + address. Start block = the chain's ServiceRegistryL2
+// deploy block: no Pearl Safe predates it, so it's a provably-safe lower
+// bound (plan Open Q #7) without needing a per-token deploy block.
+function renderErc20TokenDataSources(graphNetwork, networkData) {
+  const tokens = networkData.erc20Tokens;
+  if (!Array.isArray(tokens) || tokens.length === 0) return '';
+  const startBlock = networkData.ServiceRegistryL2.startBlock;
+  return tokens
+    .map(
+      (t) => `  - kind: ethereum
+    name: ${t.name}
+    network: ${graphNetwork}
+    source:
+      address: "${t.address}"
+      abi: ERC20
+      startBlock: ${startBlock}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - FundsMovement
+        - TokenBalance
+        - Token
+        - AgentFundingEvent
+      abis:
+        - name: ERC20
+          file: ../../abis/ERC20Detailed.json
+      eventHandlers:
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleErc20Transfer
+      file: ./src/erc20.ts`
+    )
+    .join('\n');
 }
 
 // Generate configs

--- a/subgraphs/pearl-transactions/CLAUDE.md
+++ b/subgraphs/pearl-transactions/CLAUDE.md
@@ -94,8 +94,10 @@ that apply to Phase 1a as-shipped:
 | 5 — Verify on Studio | Spot-check stake/claim/unstake against block explorer for a known Pearl service | — |
 | 6 — Verify graph-node `startBlock`-in-context | Open Q #6: determines option for §6.2 pre-stake-transfer recovery | §6.2 |
 | 7 — Phase 2a | OLAS `Transfer` data source + per-Safe `Safe` templates; `classifyTransfer`; `TrackedSafe` / `TrackedEOA` / `TokenBalance` / `Token`; `AgentFundingEvent` aggregation | §6.1, §6.2, §6.4, §6.5 |
-| 8 — Phase 2b | USDC / USDC.e benchmark + product decision (§6.3) | §6.3 |
+| 8 — Phase 2b | Stablecoin `Transfer` data sources via the same `handleErc20Transfer` handler. Per-chain token set sourced from the Operate app (`frontend/config/tokens.ts`): gnosis USDC + USDC.e; matic USDC + USDC.e + pUSD; optimism USDC + USDC.e; base USDC (all 6 decimals). Rendered from a per-network `erc20Tokens` array in `networks.json` via the `{{ erc20TokenDataSources }}` marker (see `generate-manifests.js`); start block = chain's `ServiceRegistryL2` block (provably-safe lower bound). On-chain path chosen over the §6.3 off-chain fallback; the §6.3a Polygon sync benchmark was **deferred** (Studio deploy not yet provisioned) — revisit if Polygon full-sync proves too slow. | §6.3 |
 | 9 — Docs | Finalize this file + `README.md`; update root `CLAUDE.md` | — |
+
+> **Note:** this file's "Current state" header above still reflects Phase 1a; phases 1b/2a/2b landed without refreshing it. A full CLAUDE.md catch-up is the step-9 docs pass.
 
 ## Development workflow
 

--- a/subgraphs/pearl-transactions/networks.json
+++ b/subgraphs/pearl-transactions/networks.json
@@ -19,7 +19,11 @@
     "WrappedNative": {
       "address": "0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d",
       "startBlock": 27871084
-    }
+    },
+    "erc20Tokens": [
+      { "name": "USDC", "address": "0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83" },
+      { "name": "USDCe", "address": "0x2a22f9c3b484c3629090FeED35F17Ff8F88f76F0" }
+    ]
   },
   "matic": {
     "ServiceRegistryL2": {
@@ -41,7 +45,12 @@
     "WrappedNative": {
       "address": "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",
       "startBlock": 41783952
-    }
+    },
+    "erc20Tokens": [
+      { "name": "USDC", "address": "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359" },
+      { "name": "USDCe", "address": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174" },
+      { "name": "PUSD", "address": "0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB" }
+    ]
   },
   "optimism": {
     "ServiceRegistryL2": {
@@ -63,7 +72,11 @@
     "WrappedNative": {
       "address": "0x4200000000000000000000000000000000000006",
       "startBlock": 116423039
-    }
+    },
+    "erc20Tokens": [
+      { "name": "USDC", "address": "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85" },
+      { "name": "USDCe", "address": "0x7F5c764cBc14f9669B88837ca1490cCa17c31607" }
+    ]
   },
   "base": {
     "ServiceRegistryL2": {
@@ -85,6 +98,9 @@
     "WrappedNative": {
       "address": "0x4200000000000000000000000000000000000006",
       "startBlock": 10827380
-    }
+    },
+    "erc20Tokens": [
+      { "name": "USDC", "address": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" }
+    ]
   }
 }

--- a/subgraphs/pearl-transactions/src/constants.ts
+++ b/subgraphs/pearl-transactions/src/constants.ts
@@ -136,7 +136,9 @@ export function getStablecoinSymbol(
   network: string,
   address: Address
 ): string | null {
-  const a = address.toHexString();
+  // Lowercase explicitly: the address literals below are lowercase, and
+  // this drops a hidden dependency on graph-ts toHexString() casing.
+  const a = address.toHexString().toLowerCase();
   if (network == "gnosis" || network == "xdai") {
     if (a == "0xddafbb505ad214d7b80b1f830fccc89b60fb7a83") return "USDC";
     if (a == "0x2a22f9c3b484c3629090feed35f17ff8f88f76f0") return "USDC.e";

--- a/subgraphs/pearl-transactions/src/constants.ts
+++ b/subgraphs/pearl-transactions/src/constants.ts
@@ -126,6 +126,33 @@ export function getWrappedNativeSymbol(network: string): string {
   return "WNATIVE";
 }
 
+// getStablecoinSymbol — Phase 2b stablecoin metadata resolver. Returns
+// the display symbol for a known per-network stablecoin (all 6 decimals),
+// or null if `address` isn't a tracked stablecoin. Addresses mirror the
+// `erc20Tokens` set in networks.json (sourced from the Operate app's
+// frontend/config/tokens.ts). All comparisons are lowercase-hex
+// (graph-ts toHexString() is lowercase).
+export function getStablecoinSymbol(
+  network: string,
+  address: Address
+): string | null {
+  const a = address.toHexString();
+  if (network == "gnosis" || network == "xdai") {
+    if (a == "0xddafbb505ad214d7b80b1f830fccc89b60fb7a83") return "USDC";
+    if (a == "0x2a22f9c3b484c3629090feed35f17ff8f88f76f0") return "USDC.e";
+  } else if (network == "matic" || network == "polygon") {
+    if (a == "0x3c499c542cef5e3811e1192ce70d8cc03d5c3359") return "USDC";
+    if (a == "0x2791bca1f2de4661ed88a30c99a7a9449aa84174") return "USDC.e";
+    if (a == "0xc011a7e12a19f7b1f670d46f03b03f3342e82dfb") return "pUSD";
+  } else if (network == "optimism") {
+    if (a == "0x0b2c639c533813f4aa9d7837caf62653d097ff85") return "USDC";
+    if (a == "0x7f5c764cbc14f9669b88837ca1490cca17c31607") return "USDC.e";
+  } else if (network == "base") {
+    if (a == "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913") return "USDC";
+  }
+  return null;
+}
+
 // isAllowedImplementation — the Olas staking ecosystem allows multiple
 // StakingProxy implementations but pearl-transactions only indexes
 // proxies whose implementation appears on this per-network allow-list.

--- a/subgraphs/pearl-transactions/src/utils.ts
+++ b/subgraphs/pearl-transactions/src/utils.ts
@@ -37,6 +37,7 @@ import {
   SOURCE_SEMANTIC,
   getOlasAddress,
   getSrtuAddress,
+  getStablecoinSymbol,
   getWrappedNativeAddress,
   getWrappedNativeSymbol,
 } from "./constants";
@@ -617,10 +618,17 @@ export function getOrCreateToken(tokenAddress: Address): Token {
     token.symbol = getWrappedNativeSymbol(network);
     token.decimals = 18;
   } else {
-    // Fallback for any unknown token that shows up via classifyTransfer
-    // (shouldn't happen given our data-source set, but defensive).
-    token.symbol = "UNKNOWN";
-    token.decimals = 18;
+    const stablecoin = getStablecoinSymbol(network, tokenAddress);
+    if (stablecoin !== null) {
+      // Phase 2b stablecoins (USDC / USDC.e / pUSD) — all 6 decimals.
+      token.symbol = stablecoin;
+      token.decimals = 6;
+    } else {
+      // Fallback for any unknown token that shows up via classifyTransfer
+      // (shouldn't happen given our data-source set, but defensive).
+      token.symbol = "UNKNOWN";
+      token.decimals = 18;
+    }
   }
   token.save();
   return token;

--- a/subgraphs/pearl-transactions/src/utils.ts
+++ b/subgraphs/pearl-transactions/src/utils.ts
@@ -600,12 +600,17 @@ export function upsertTrackedEOA(
   tracked.save();
 }
 
-// getOrCreateToken — Phase 2a tokens are OLAS (always 18 decimals,
-// symbol "OLAS") and the per-chain wrapped native (always 18 decimals;
-// symbol per getWrappedNativeSymbol). Phase 2b will extend with USDC
-// (6 decimals) and USDC.e (6 decimals). Token metadata is hardcoded
-// rather than queried because the ERC20Detailed ABI in this repo
-// doesn't include symbol() and Pearl's token set is small + known.
+// getOrCreateToken — resolves token metadata for the indexed token set.
+// Metadata is hardcoded (not queried) because the ERC20Detailed ABI in
+// this repo doesn't include symbol()/decimals() and Pearl's token set is
+// small + known:
+//   - OLAS — 18 decimals (per-chain address via getOlasAddress).
+//   - wrapped native — 18 decimals (symbol per getWrappedNativeSymbol).
+//   - stablecoins — USDC / USDC.e / pUSD, all 6 decimals, resolved per
+//     chain via getStablecoinSymbol (the set varies per chain — see
+//     networks.json `erc20Tokens`).
+// First write wins (early return on an existing Token), so a wrong
+// decimals value would persist forever — hence the log.critical guard.
 export function getOrCreateToken(tokenAddress: Address): Token {
   let token = Token.load(tokenAddress);
   if (token != null) return token;
@@ -620,12 +625,21 @@ export function getOrCreateToken(tokenAddress: Address): Token {
   } else {
     const stablecoin = getStablecoinSymbol(network, tokenAddress);
     if (stablecoin !== null) {
-      // Phase 2b stablecoins (USDC / USDC.e / pUSD) — all 6 decimals.
+      // Per-chain stablecoin (USDC / USDC.e / pUSD) — all 6 decimals.
       token.symbol = stablecoin;
       token.decimals = 6;
     } else {
-      // Fallback for any unknown token that shows up via classifyTransfer
-      // (shouldn't happen given our data-source set, but defensive).
+      // Reached here only via a tracked Transfer, so this is an indexed
+      // token with no metadata resolver — almost certainly an
+      // `erc20Tokens` entry in networks.json without a matching
+      // getStablecoinSymbol branch. UNKNOWN/18 would silently misformat a
+      // 6-decimal stablecoin by 10^12 in every consumer, and first-write-
+      // wins makes it permanent. Loud on purpose so it surfaces in
+      // indexing logs, not in the wallet UI.
+      log.critical(
+        "getOrCreateToken: no symbol/decimals resolver for indexed token {} on {} — add a getStablecoinSymbol branch (networks.json `erc20Tokens` and the resolver are out of sync). Falling back to UNKNOWN/18.",
+        [tokenAddress.toHexString(), network]
+      );
       token.symbol = "UNKNOWN";
       token.decimals = 18;
     }

--- a/subgraphs/pearl-transactions/subgraph.base.yaml
+++ b/subgraphs/pearl-transactions/subgraph.base.yaml
@@ -139,6 +139,32 @@ dataSources:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleErc20Transfer
       file: ./src/erc20.ts
+  # Phase 2b — per-network stablecoin Transfer data sources (USDC /
+  # USDC.e / pUSD), expanded from networks.json `erc20Tokens` by
+  # generate-manifests.js. Count varies per chain (1–3).
+  - kind: ethereum
+    name: USDC
+    network: base
+    source:
+      address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+      abi: ERC20
+      startBlock: 10827380
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - FundsMovement
+        - TokenBalance
+        - Token
+        - AgentFundingEvent
+      abis:
+        - name: ERC20
+          file: ../../abis/ERC20Detailed.json
+      eventHandlers:
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleErc20Transfer
+      file: ./src/erc20.ts
 templates:
   - name: StakingProxy
     kind: ethereum/contract

--- a/subgraphs/pearl-transactions/subgraph.gnosis.yaml
+++ b/subgraphs/pearl-transactions/subgraph.gnosis.yaml
@@ -139,6 +139,55 @@ dataSources:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleErc20Transfer
       file: ./src/erc20.ts
+  # Phase 2b — per-network stablecoin Transfer data sources (USDC /
+  # USDC.e / pUSD), expanded from networks.json `erc20Tokens` by
+  # generate-manifests.js. Count varies per chain (1–3).
+  - kind: ethereum
+    name: USDC
+    network: gnosis
+    source:
+      address: "0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83"
+      abi: ERC20
+      startBlock: 27871084
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - FundsMovement
+        - TokenBalance
+        - Token
+        - AgentFundingEvent
+      abis:
+        - name: ERC20
+          file: ../../abis/ERC20Detailed.json
+      eventHandlers:
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleErc20Transfer
+      file: ./src/erc20.ts
+  - kind: ethereum
+    name: USDCe
+    network: gnosis
+    source:
+      address: "0x2a22f9c3b484c3629090FeED35F17Ff8F88f76F0"
+      abi: ERC20
+      startBlock: 27871084
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - FundsMovement
+        - TokenBalance
+        - Token
+        - AgentFundingEvent
+      abis:
+        - name: ERC20
+          file: ../../abis/ERC20Detailed.json
+      eventHandlers:
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleErc20Transfer
+      file: ./src/erc20.ts
 templates:
   - name: StakingProxy
     kind: ethereum/contract

--- a/subgraphs/pearl-transactions/subgraph.matic.yaml
+++ b/subgraphs/pearl-transactions/subgraph.matic.yaml
@@ -139,6 +139,78 @@ dataSources:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleErc20Transfer
       file: ./src/erc20.ts
+  # Phase 2b — per-network stablecoin Transfer data sources (USDC /
+  # USDC.e / pUSD), expanded from networks.json `erc20Tokens` by
+  # generate-manifests.js. Count varies per chain (1–3).
+  - kind: ethereum
+    name: USDC
+    network: matic
+    source:
+      address: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359"
+      abi: ERC20
+      startBlock: 41783952
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - FundsMovement
+        - TokenBalance
+        - Token
+        - AgentFundingEvent
+      abis:
+        - name: ERC20
+          file: ../../abis/ERC20Detailed.json
+      eventHandlers:
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleErc20Transfer
+      file: ./src/erc20.ts
+  - kind: ethereum
+    name: USDCe
+    network: matic
+    source:
+      address: "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174"
+      abi: ERC20
+      startBlock: 41783952
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - FundsMovement
+        - TokenBalance
+        - Token
+        - AgentFundingEvent
+      abis:
+        - name: ERC20
+          file: ../../abis/ERC20Detailed.json
+      eventHandlers:
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleErc20Transfer
+      file: ./src/erc20.ts
+  - kind: ethereum
+    name: PUSD
+    network: matic
+    source:
+      address: "0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB"
+      abi: ERC20
+      startBlock: 41783952
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - FundsMovement
+        - TokenBalance
+        - Token
+        - AgentFundingEvent
+      abis:
+        - name: ERC20
+          file: ../../abis/ERC20Detailed.json
+      eventHandlers:
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleErc20Transfer
+      file: ./src/erc20.ts
 templates:
   - name: StakingProxy
     kind: ethereum/contract

--- a/subgraphs/pearl-transactions/subgraph.optimism.yaml
+++ b/subgraphs/pearl-transactions/subgraph.optimism.yaml
@@ -139,6 +139,55 @@ dataSources:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleErc20Transfer
       file: ./src/erc20.ts
+  # Phase 2b — per-network stablecoin Transfer data sources (USDC /
+  # USDC.e / pUSD), expanded from networks.json `erc20Tokens` by
+  # generate-manifests.js. Count varies per chain (1–3).
+  - kind: ethereum
+    name: USDC
+    network: optimism
+    source:
+      address: "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85"
+      abi: ERC20
+      startBlock: 116423039
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - FundsMovement
+        - TokenBalance
+        - Token
+        - AgentFundingEvent
+      abis:
+        - name: ERC20
+          file: ../../abis/ERC20Detailed.json
+      eventHandlers:
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleErc20Transfer
+      file: ./src/erc20.ts
+  - kind: ethereum
+    name: USDCe
+    network: optimism
+    source:
+      address: "0x7F5c764cBc14f9669B88837ca1490cCa17c31607"
+      abi: ERC20
+      startBlock: 116423039
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - FundsMovement
+        - TokenBalance
+        - Token
+        - AgentFundingEvent
+      abis:
+        - name: ERC20
+          file: ../../abis/ERC20Detailed.json
+      eventHandlers:
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleErc20Transfer
+      file: ./src/erc20.ts
 templates:
   - name: StakingProxy
     kind: ethereum/contract

--- a/subgraphs/pearl-transactions/subgraph.template.yaml
+++ b/subgraphs/pearl-transactions/subgraph.template.yaml
@@ -139,6 +139,10 @@ dataSources:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleErc20Transfer
       file: ./src/erc20.ts
+  # Phase 2b — per-network stablecoin Transfer data sources (USDC /
+  # USDC.e / pUSD), expanded from networks.json `erc20Tokens` by
+  # generate-manifests.js. Count varies per chain (1–3).
+{{ erc20TokenDataSources }}
 templates:
   - name: StakingProxy
     kind: ethereum/contract

--- a/subgraphs/pearl-transactions/tests/phase-2a.test.ts
+++ b/subgraphs/pearl-transactions/tests/phase-2a.test.ts
@@ -131,6 +131,48 @@ function newErc20TransferAt(
   return e;
 }
 
+// assertStablecoinResolves — seed a Master Safe (setupTransferSeen=true so
+// the inbound classifies as MASTER_FUNDING_IN), fire a Master EOA → Master
+// Safe stablecoin Transfer on `network`, and assert the Token resolves to
+// the expected 6-decimal symbol. File-scoped (not nested in a describe) to
+// avoid the AssemblyScript closure-capture WASM-validator error.
+function assertStablecoinResolves(
+  network: string,
+  tokenStr: string,
+  expectedSymbol: string,
+  salt: i32
+): void {
+  dataSourceMock.setNetwork(network);
+  seedMasterSafe(true);
+  const token = Address.fromString(tokenStr);
+  const tx = mockTx(salt);
+  handleErc20Transfer(
+    newErc20TransferAt(
+      token,
+      MASTER_EOA,
+      MASTER_SAFE,
+      BigInt.fromString("1000000"),
+      tx,
+      0
+    )
+  );
+  const id = tx.concatI32(0);
+  assert.fieldEquals(
+    "FundsMovement",
+    id.toHexString(),
+    "category",
+    "MASTER_FUNDING_IN"
+  );
+  assert.fieldEquals(
+    "FundsMovement",
+    id.toHexString(),
+    "token",
+    token.toHexString()
+  );
+  assert.fieldEquals("Token", token.toHexString(), "symbol", expectedSymbol);
+  assert.fieldEquals("Token", token.toHexString(), "decimals", "6");
+}
+
 function newSafeReceived(
   sender: Address,
   value: BigInt,
@@ -711,51 +753,95 @@ describe("pearl-transactions / Phase 2a — raw OLAS + Safe template", () => {
     );
   });
 
-  // ---- Phase 2b — stablecoins (USDC / USDC.e / pUSD, all 6 decimals) ----
+});
 
-  test("Gnosis USDC.e Transfer routes via the generic handler; Token = USDC.e @ 6 decimals", () => {
-    seedMasterSafe(true);
-    const USDCE_GNOSIS = Address.fromString(
-      "0x2a22f9c3b484c3629090FeED35F17Ff8F88f76F0"
-    );
-    const amount = BigInt.fromString("1000000"); // 1 USDC.e (6 decimals)
-    const tx = mockTx(31);
-    handleErc20Transfer(
-      newErc20TransferAt(USDCE_GNOSIS, MASTER_EOA, MASTER_SAFE, amount, tx, 0)
-    );
-
-    const id = tx.concatI32(0);
-    assert.fieldEquals("FundsMovement", id.toHexString(), "category", "MASTER_FUNDING_IN");
-    assert.fieldEquals(
-      "FundsMovement",
-      id.toHexString(),
-      "token",
-      USDCE_GNOSIS.toHexString()
-    );
-    assert.fieldEquals("Token", USDCE_GNOSIS.toHexString(), "symbol", "USDC.e");
-    assert.fieldEquals("Token", USDCE_GNOSIS.toHexString(), "decimals", "6");
+// ---- Phase 2b — stablecoins (USDC / USDC.e / pUSD; all 6 decimals) ----
+//
+// Covers every (chain, token) tuple in getStablecoinSymbol so a typo in
+// any address literal (or a missing resolver branch) fails loudly here
+// instead of silently mapping to UNKNOWN/18 in production. Each case sets
+// its own network so there's no cross-test ordering dependency.
+describe("pearl-transactions / Phase 2b — stablecoins", () => {
+  beforeEach(() => {
+    clearStore();
+    dataSourceMock.setNetwork("gnosis");
   });
 
-  test("Polygon pUSD Transfer resolves to pUSD @ 6 decimals", () => {
-    dataSourceMock.setNetwork("matic");
-    seedMasterSafe(true);
-    const PUSD_POLYGON = Address.fromString(
-      "0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB"
-    );
-    const amount = BigInt.fromString("2500000"); // 2.5 pUSD (6 decimals)
-    const tx = mockTx(32);
-    handleErc20Transfer(
-      newErc20TransferAt(PUSD_POLYGON, MASTER_EOA, MASTER_SAFE, amount, tx, 0)
-    );
+  afterEach(() => {
+    clearStore();
+    // Reset so a stray network doesn't leak into any later suite.
+    dataSourceMock.setNetwork("gnosis");
+  });
 
-    const id = tx.concatI32(0);
-    assert.fieldEquals(
-      "FundsMovement",
-      id.toHexString(),
-      "token",
-      PUSD_POLYGON.toHexString()
+  test("gnosis USDC resolves @ 6 decimals", () => {
+    assertStablecoinResolves(
+      "gnosis",
+      "0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83",
+      "USDC",
+      31
     );
-    assert.fieldEquals("Token", PUSD_POLYGON.toHexString(), "symbol", "pUSD");
-    assert.fieldEquals("Token", PUSD_POLYGON.toHexString(), "decimals", "6");
+  });
+
+  test("gnosis USDC.e resolves @ 6 decimals", () => {
+    assertStablecoinResolves(
+      "gnosis",
+      "0x2a22f9c3b484c3629090FeED35F17Ff8F88f76F0",
+      "USDC.e",
+      32
+    );
+  });
+
+  test("matic USDC resolves @ 6 decimals", () => {
+    assertStablecoinResolves(
+      "matic",
+      "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
+      "USDC",
+      33
+    );
+  });
+
+  test("matic USDC.e resolves @ 6 decimals", () => {
+    assertStablecoinResolves(
+      "matic",
+      "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+      "USDC.e",
+      34
+    );
+  });
+
+  test("matic pUSD resolves @ 6 decimals", () => {
+    assertStablecoinResolves(
+      "matic",
+      "0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB",
+      "pUSD",
+      35
+    );
+  });
+
+  test("optimism USDC resolves @ 6 decimals", () => {
+    assertStablecoinResolves(
+      "optimism",
+      "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85",
+      "USDC",
+      36
+    );
+  });
+
+  test("optimism USDC.e resolves @ 6 decimals", () => {
+    assertStablecoinResolves(
+      "optimism",
+      "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
+      "USDC.e",
+      37
+    );
+  });
+
+  test("base USDC resolves @ 6 decimals", () => {
+    assertStablecoinResolves(
+      "base",
+      "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      "USDC",
+      38
+    );
   });
 });

--- a/subgraphs/pearl-transactions/tests/phase-2a.test.ts
+++ b/subgraphs/pearl-transactions/tests/phase-2a.test.ts
@@ -115,6 +115,22 @@ function newOlasTransfer(
   return setMockEventBoilerplate(e, txHash, logIndex, OLAS_GNOSIS);
 }
 
+// newErc20TransferAt — a Transfer event whose `event.address` is an
+// arbitrary token (handleErc20Transfer reads event.address for the row's
+// `token`, so the same handler serves every ERC-20 data source).
+function newErc20TransferAt(
+  token: Address,
+  from: Address,
+  to: Address,
+  amount: BigInt,
+  txHash: Bytes,
+  logIndex: i32
+): OlasTransfer {
+  const e = newOlasTransfer(from, to, amount, txHash, logIndex);
+  e.address = token;
+  return e;
+}
+
 function newSafeReceived(
   sender: Address,
   value: BigInt,
@@ -693,5 +709,53 @@ describe("pearl-transactions / Phase 2a — raw OLAS + Safe template", () => {
       "category",
       "MASTER_FUNDING_IN"
     );
+  });
+
+  // ---- Phase 2b — stablecoins (USDC / USDC.e / pUSD, all 6 decimals) ----
+
+  test("Gnosis USDC.e Transfer routes via the generic handler; Token = USDC.e @ 6 decimals", () => {
+    seedMasterSafe(true);
+    const USDCE_GNOSIS = Address.fromString(
+      "0x2a22f9c3b484c3629090FeED35F17Ff8F88f76F0"
+    );
+    const amount = BigInt.fromString("1000000"); // 1 USDC.e (6 decimals)
+    const tx = mockTx(31);
+    handleErc20Transfer(
+      newErc20TransferAt(USDCE_GNOSIS, MASTER_EOA, MASTER_SAFE, amount, tx, 0)
+    );
+
+    const id = tx.concatI32(0);
+    assert.fieldEquals("FundsMovement", id.toHexString(), "category", "MASTER_FUNDING_IN");
+    assert.fieldEquals(
+      "FundsMovement",
+      id.toHexString(),
+      "token",
+      USDCE_GNOSIS.toHexString()
+    );
+    assert.fieldEquals("Token", USDCE_GNOSIS.toHexString(), "symbol", "USDC.e");
+    assert.fieldEquals("Token", USDCE_GNOSIS.toHexString(), "decimals", "6");
+  });
+
+  test("Polygon pUSD Transfer resolves to pUSD @ 6 decimals", () => {
+    dataSourceMock.setNetwork("matic");
+    seedMasterSafe(true);
+    const PUSD_POLYGON = Address.fromString(
+      "0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB"
+    );
+    const amount = BigInt.fromString("2500000"); // 2.5 pUSD (6 decimals)
+    const tx = mockTx(32);
+    handleErc20Transfer(
+      newErc20TransferAt(PUSD_POLYGON, MASTER_EOA, MASTER_SAFE, amount, tx, 0)
+    );
+
+    const id = tx.concatI32(0);
+    assert.fieldEquals(
+      "FundsMovement",
+      id.toHexString(),
+      "token",
+      PUSD_POLYGON.toHexString()
+    );
+    assert.fieldEquals("Token", PUSD_POLYGON.toHexString(), "symbol", "pUSD");
+    assert.fieldEquals("Token", PUSD_POLYGON.toHexString(), "decimals", "6");
   });
 });


### PR DESCRIPTION
## Summary

Phase 2b (plan §8 step 8) — adds the **stablecoin `Transfer` data sources** the Pearl wallet surfaces, completing the raw-token ledger. Reuses the Phase-2a generic `handleErc20Transfer` + `classifyTransfer` unchanged (the row's `token` comes from `event.address`), so this is almost entirely manifest/config + token-metadata.

Stacked on Phase-2a (#133, merged) → based on `main`.

## Token set (sourced from the Operate app `frontend/config/tokens.ts`)

All **6-decimal**:

| Chain | Tokens |
|---|---|
| gnosis | USDC `0xDDAfbb50…`, USDC.e `0x2a22f9c3…` |
| matic | USDC `0x3c499c54…`, USDC.e `0x2791Bca1…`, pUSD `0xC011a7E1…` |
| optimism | USDC `0x0b2C639c…`, USDC.e `0x7F5c764c…` |
| base | USDC `0x833589fC…` |

> **Note:** plan §6.3 assumed Polystrat funds in USDC.e on Polygon, but the current app config shows it uses **USDC + pUSD** — the token set follows the app as source of truth, not the (stale on this point) plan.

## What changed

- **`scripts/generate-manifests.js`** — optional per-network `erc20Tokens` array expands into N `Transfer` data sources via a new `{{ erc20TokenDataSources }}` template marker. **Guarded + additive**: no-op for templates without the marker and networks without the array. Verified the other 12 subgraphs generate **byte-identical** output (regenerated staking / tokenomics-l2 / liquidity-l2 / service-registry — the only diff, service-registry, reproduces with the *original* script too = pre-existing drift, not this change).
- **`networks.json`** — `erc20Tokens` arrays per network. Each data source's `startBlock` = that chain's `ServiceRegistryL2` block (provably-safe lower bound — no Pearl Safe predates it, per plan Open Q #7) — no per-token deploy-block lookup needed.
- **`constants.ts`** — `getStablecoinSymbol(network, address)` resolver; **`utils.ts`** `getOrCreateToken` tags USDC / USDC.e / pUSD at **6 decimals** (others stay 18).
- **`tests/phase-2a.test.ts`** — Gnosis USDC.e @ 6 decimals + Polygon pUSD @ 6 decimals (network switch). The generic classify routing is already covered by the Phase-2a suite.

## Test plan

- [x] `yarn install` + `generate-manifests` + `codegen` + `test` — **38/38 Matchstick passing**.
- [x] Verified the shared `generate-manifests.js` change is a no-op for the other 12 subgraphs.
- [x] `gitleaks` / lockfile-lint — no issues.

## Deferred (not in this PR)

- **§6.3a Polygon sync benchmark** — wanted a throwaway USDC.e sync measurement before committing on-chain; deferred because Studio deploy isn't provisioned yet. On-chain path chosen per product. **Revisit if Polygon full-sync proves too slow** (USDC.e on Polygon is the §2.2 cost hotspot).
- **CLAUDE.md / README full refresh** — Phase 9 docs sweep (only the Phase 2b table row is updated here).

Related: plan #129, scaffold #130, phase-1a #131, phase-1b #132, phase-2a #133.
