### PR TITLE
fix(pearl-transactions): tighten Polygon start blocks to first-service block (80,360,433)

### DIFF
--- a/subgraphs/pearl-transactions/networks.json
+++ b/subgraphs/pearl-transactions/networks.json
@@ -28,11 +28,11 @@
   "matic": {
     "ServiceRegistryL2": {
       "address": "0xE3607b00E75f6405248323A9417ff6b39B244b50",
-      "startBlock": 41783952
+      "startBlock": 80360433
     },
     "ServiceRegistryTokenUtility": {
       "address": "0xa45E64d13A30a51b91ae0eb182e88a40e9b18eD8",
-      "startBlock": 52737296
+      "startBlock": 80360433
     },
     "StakingFactory": {
       "address": "0x46C0D07F55d4F9B5Eed2Fc9680B5953e5fd7b461",
@@ -40,11 +40,11 @@
     },
     "OLAS": {
       "address": "0xFEF5d947472e72Efbb2E388c730B7428406F2F95",
-      "startBlock": 41783952
+      "startBlock": 80360433
     },
     "WrappedNative": {
       "address": "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",
-      "startBlock": 41783952
+      "startBlock": 80360433
     },
     "erc20Tokens": [
       { "name": "USDC", "address": "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359" },

--- a/subgraphs/pearl-transactions/subgraph.matic.yaml
+++ b/subgraphs/pearl-transactions/subgraph.matic.yaml
@@ -10,7 +10,7 @@ dataSources:
     source:
       address: "0xE3607b00E75f6405248323A9417ff6b39B244b50"
       abi: ServiceRegistryL2
-      startBlock: 41783952
+      startBlock: 80360433
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -53,7 +53,7 @@ dataSources:
     source:
       address: "0xa45E64d13A30a51b91ae0eb182e88a40e9b18eD8"
       abi: ServiceRegistryTokenUtility
-      startBlock: 52737296
+      startBlock: 80360433
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -99,7 +99,7 @@ dataSources:
     source:
       address: "0xFEF5d947472e72Efbb2E388c730B7428406F2F95"
       abi: ERC20
-      startBlock: 41783952
+      startBlock: 80360433
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -122,7 +122,7 @@ dataSources:
     source:
       address: "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270"
       abi: ERC20
-      startBlock: 41783952
+      startBlock: 80360433
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -148,7 +148,7 @@ dataSources:
     source:
       address: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359"
       abi: ERC20
-      startBlock: 41783952
+      startBlock: 80360433
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -171,7 +171,7 @@ dataSources:
     source:
       address: "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174"
       abi: ERC20
-      startBlock: 41783952
+      startBlock: 80360433
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -194,7 +194,7 @@ dataSources:
     source:
       address: "0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB"
       abi: ERC20
-      startBlock: 41783952
+      startBlock: 80360433
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7


### PR DESCRIPTION
## Summary

Tighten the **Polygon** start blocks to the first-service block, fixing the slow Polygon sync.

The Polygon data sources started at the ServiceRegistryL2 **contract deploy** (`41,783,952`, ~Apr 2023), but the **first service** on that registry wasn't registered until **`80,360,433`** (verified on-chain; the same block [`predict-polymarket/subgraph.yaml:13`](../subgraphs/predict/predict-polymarket/subgraph.yaml) starts from). Nothing Pearl-relevant — services, bonds, staking, or any token touching a tracked Safe — can predate the first service, so **~38M blocks of token-`Transfer` scanning (including the USDC.e firehose, the §2.2/§6.3 cost hotspot) was pure waste** — the cause of the slow Polygon sync.

## Change (`networks.json` → regenerated `subgraph.matic.yaml`)

| Data source | Before | After |
|---|---|---|
| ServiceRegistryL2 | 41,783,952 | **80,360,433** |
| ServiceRegistryTokenUtility | 52,737,296 | **80,360,433** |
| OLAS / WrappedNative | 41,783,952 | **80,360,433** |
| stablecoins (`erc20Tokens`, incl. USDC.e) | 41,783,952 (inherited) | **80,360,433** |
| StakingFactory | 62,213,142 | **kept** |

## Why it's zero data loss

A token transfer only produces a row once its Safe is **tracked**, and Safes are only tracked via registry/staking events (≥ 80,360,433). So token transfers before then were dropped at 41.78M anyway — moving the start to 80.36M removes only empty scanning.

**StakingFactory kept at 62,213,142:** `InstanceCreated` (proxy creation) can predate a service staking into it, so it must not be missed; it's low-volume, so scanning from 62M is cheap.

## Rollout

Takes effect on a **fresh deploy (v0.0.4)** — the live v0.0.3 already started at 41.78M and will keep grinding; redeploy Polygon at v0.0.4 after this merges and it should sync dramatically faster.

> Follow-up worth checking: Gnosis likely has the same pattern (contract deploy ≫ first service). Lower urgency (Gnosis token volume is low), but the same tightening would help.
