### PR TITLE
fix(pearl-transactions): tighten Polygon start blocks to the Pearl-launch block

### DIFF
--- a/subgraphs/pearl-transactions/networks.json
+++ b/subgraphs/pearl-transactions/networks.json
@@ -36,7 +36,7 @@
     },
     "StakingFactory": {
       "address": "0x46C0D07F55d4F9B5Eed2Fc9680B5953e5fd7b461",
-      "startBlock": 62213142
+      "startBlock": 80360433
     },
     "OLAS": {
       "address": "0xFEF5d947472e72Efbb2E388c730B7428406F2F95",

--- a/subgraphs/pearl-transactions/package.json
+++ b/subgraphs/pearl-transactions/package.json
@@ -1,13 +1,13 @@
 {
   "name": "pearl-transactions-subgraph",
   "scripts": {
-    "codegen": "graph codegen subgraph.gnosis.yaml",
-    "build": "graph build subgraph.gnosis.yaml",
+    "codegen": "graph codegen subgraph.base.yaml",
+    "build": "graph build subgraph.base.yaml",
     "generate-manifests": "node ../../scripts/generate-manifests.js --path=.",
-    "deploy-gnosis": "graph deploy --network gnosis pearl-transactions-gnosis subgraph.gnosis.yaml",
-    "deploy-matic": "graph deploy --network matic pearl-transactions-matic subgraph.matic.yaml",
-    "deploy-optimism": "graph deploy --network optimism pearl-transactions-optimism subgraph.optimism.yaml",
-    "deploy-base": "graph deploy --network base pearl-transactions-base subgraph.base.yaml",
+    "deploy-gnosis": "yarn generate-manifests && graph deploy pearl-transactions-gnosis subgraph.gnosis.yaml",
+    "deploy-matic": "yarn generate-manifests && graph deploy pearl-transactions-matic subgraph.matic.yaml",
+    "deploy-optimism": "yarn generate-manifests && graph deploy pearl-transactions-optimism subgraph.optimism.yaml",
+    "deploy-base": "yarn generate-manifests && graph deploy pearl-transactions-base subgraph.base.yaml",
     "test": "ln -s subgraph.gnosis.yaml subgraph.yaml && graph test; rm -f subgraph.yaml"
   },
   "dependencies": {

--- a/subgraphs/pearl-transactions/subgraph.matic.yaml
+++ b/subgraphs/pearl-transactions/subgraph.matic.yaml
@@ -77,7 +77,7 @@ dataSources:
     source:
       address: "0x46C0D07F55d4F9B5Eed2Fc9680B5953e5fd7b461"
       abi: StakingFactory
-      startBlock: 62213142
+      startBlock: 80360433
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7


### PR DESCRIPTION
## What

Aligns **all** Polygon (`matic`) data sources to **80,360,433** — the first Pearl service / launch block.

Two commits:
1. `ServiceRegistryL2`, `ServiceRegistryTokenUtility`, `OLAS`, `WrappedNative` (and the USDC/USDC.e/pUSD token sources) → `80,360,433` (was the contracts' own deploy blocks, ~41–52M).
2. `StakingFactory` `62,213,142 → 80,360,433`.

## Why

`StakingFactory` was starting ~**18M blocks** before any Pearl service exists, so the subgraph was indexing every non-Pearl `InstanceCreated`, spawning a `StakingProxy` template for each, processing all their staking events, and running `minStakingDeposit()`/`numAgentInstances()` eth_calls — pure waste and the dominant Polygon sync drag.

**Safe to raise:** the three Polygon staking programs (`polygon_beta_1/2/3`, from `olas-operate-middleware` `profiles.py`) were all created at **~81.65M** (earliest `81,649,856`), *after* launch. A service can only stake into a program that already exists, and there are no programs before `80,360,433`, so no `InstanceCreated` is missed.

## Scope / safety
- Config + regenerated `subgraph.matic.yaml` only. No mapping/schema changes; other networks untouched.
- Remaining Polygon cost is the inherent USDC/USDC.e/pUSD transfer firehose from launch onward (unavoidable; Polystrat needs those tokens).

## Deploy
After merge, redeploy **v0.0.5** for Polygon (and Gnosis) from `main` via `deploy-subgraph.yaml`.