### PR TITLE
fix(pearl-transactions): hide registry dust + carry agent link on bond rows

### DIFF
--- a/subgraphs/pearl-transactions/CLAUDE.md
+++ b/subgraphs/pearl-transactions/CLAUDE.md
@@ -49,7 +49,15 @@ deploy; watch Polygon USDC.e sync (the §2.2 cost hotspot).
   queue; dual-guarded Master Safe discovery on the NFT path.
 - **`ServiceRegistryTokenUtility`** (`src/service-registry-token-utility.ts`)
   — `TokenDeposit` / `TokenRefund`. Producer side: creates the
-  `SERVICE_BOND_DEPOSIT` / `_REFUND` row (amount only) + enqueues it.
+  `SERVICE_BOND_DEPOSIT` / `_REFUND` row + stamps `masterSafe` from the bond
+  payer (`account`, guarded to tracked Master Safes) + enqueues it. The
+  consumer (`dequeueAndAttribute`) backfills `serviceId` + `bondType` +
+  `agentSafe` (and `masterSafe` as fallback). This single SEMANTIC row is the
+  complete bond record — `classifyTransfer` drops the Master Safe ↔ SRTU OLAS
+  `RAW_TRANSFER` duplicate so the wallet (masterSafe-filtered) doesn't
+  double-count. `agentSafe` resolves on refunds (multisig already exists); a
+  genesis deposit leaves it null but `service.agentIds` still yields the
+  display name.
 - **`StakingFactory`** (`src/staking-factory.ts`) — `InstanceCreated`:
   allow-list check → spawn `StakingProxy` template + create `StakingContract`.
 - **`StakingProxy`** template (`src/staking-proxy.ts`) — `ServiceStaked`
@@ -83,10 +91,15 @@ deploy; watch Polygon USDC.e sync (the §2.2 cost hotspot).
   `serviceId` + `bondType`). Hence `FundsMovement` is mutable. `bondType`
   stays null when no SR event follows.
 - **`classifyTransfer`** — routes `(from, to)` against `TrackedSafe` /
-  `TrackedEOA` / `StakingContract` / SRTU, most-specific first, into the
-  `FundsCategory` (`MASTER_FUNDING_IN`, `MASTER_TO_AGENT`, `AGENT_TO_MASTER`,
-  `MASTER_WITHDRAWAL`, `STAKING_REWARD_CLAIM`, `SAFE_SETUP_TRANSFER`, …).
-  Returns null for untracked counterparties (row dropped).
+  `TrackedEOA` / `StakingContract` / SRTU / ServiceRegistryL2, most-specific
+  first, into the `FundsCategory` (`MASTER_FUNDING_IN`, `MASTER_TO_AGENT`,
+  `AGENT_TO_MASTER`, `MASTER_WITHDRAWAL`, `STAKING_REWARD_CLAIM`,
+  `SAFE_SETUP_TRANSFER`, …). Returns null for untracked counterparties (row
+  dropped) **and** for Master Safe ↔ SRTU OLAS hops (deduped against the
+  SEMANTIC bond row). Inbound to a Master Safe **from the ServiceRegistryL2
+  contract** is classified `OTHER` (protocol dust — e.g. 1-wei native refunds
+  during terminate/unbond — not a user deposit; `getServiceRegistryAddress`
+  in constants.ts).
 - **`getOrCreateToken`** — OLAS / wrapped-native 18 decimals; stablecoins
   (USDC / USDC.e / pUSD) 6 decimals via `getStablecoinSymbol` (constants.ts);
   `log.critical` + UNKNOWN/18 if an indexed token has no resolver branch.
@@ -141,7 +154,7 @@ deploy; watch Polygon USDC.e sync (the §2.2 cost hotspot).
 
 ## Tests
 
-44 Matchstick tests across `tests/service-registry.test.ts` (Phase 1a),
+46 Matchstick tests across `tests/service-registry.test.ts` (Phase 1a),
 `tests/staking.test.ts` (Phase 1b), `tests/phase-2a.test.ts` (Phase 2a + the
 Phase-2b stablecoin suite — all 8 (chain, token) tuples). `yarn test`.
 

--- a/subgraphs/pearl-transactions/src/constants.ts
+++ b/subgraphs/pearl-transactions/src/constants.ts
@@ -88,6 +88,36 @@ export function getSrtuAddress(network: string): Address {
   return Address.zero();
 }
 
+// ServiceRegistryL2 address resolver (mirrors networks.json). Used by
+// classifyTransfer to recognise dust the registry contract itself sends
+// to a Master Safe (e.g. 1-wei native refunds emitted during
+// terminate / unbond). Those are protocol bookkeeping, NOT user
+// deposits, so they must classify as OTHER rather than
+// MASTER_FUNDING_IN.
+const SERVICE_REGISTRY_GNOSIS = "0x9338b5153AE39BB89f50468E608eD9d764B755fD";
+const SERVICE_REGISTRY_POLYGON = "0xE3607b00E75f6405248323A9417ff6b39B244b50";
+const SERVICE_REGISTRY_OPTIMISM = "0x3d77596beb0f130a4415df3D2D8232B3d3D31e44";
+const SERVICE_REGISTRY_BASE = "0x3C1fF68f5aa342D296d4DEe4Bb1cACCA912D95fE";
+
+export function getServiceRegistryAddress(network: string): Address {
+  if (network == "gnosis" || network == "xdai") {
+    return Address.fromString(SERVICE_REGISTRY_GNOSIS);
+  }
+  if (network == "matic" || network == "polygon") {
+    return Address.fromString(SERVICE_REGISTRY_POLYGON);
+  }
+  if (network == "optimism") {
+    return Address.fromString(SERVICE_REGISTRY_OPTIMISM);
+  }
+  if (network == "base") {
+    return Address.fromString(SERVICE_REGISTRY_BASE);
+  }
+  log.critical("Unsupported network in getServiceRegistryAddress: {}", [
+    network,
+  ]);
+  return Address.zero();
+}
+
 // Wrapped-native resolvers (Rev. 4 — added per @Tanya-atatakai's PR #130
 // review). Each chain has exactly one wrapped native asset that Pearl
 // services may touch (DEX swaps, Omen settlements on Gnosis). Indexed

--- a/subgraphs/pearl-transactions/src/service-registry-token-utility.ts
+++ b/subgraphs/pearl-transactions/src/service-registry-token-utility.ts
@@ -1,14 +1,28 @@
+import { Address } from "@graphprotocol/graph-ts";
 import {
   TokenDeposit as TokenDepositEvent,
   TokenRefund as TokenRefundEvent,
 } from "../generated/ServiceRegistryTokenUtility/ServiceRegistryTokenUtility";
-import { FundsMovement } from "../generated/schema";
+import { FundsMovement, TrackedSafe } from "../generated/schema";
 import {
   CATEGORY_SERVICE_BOND_DEPOSIT,
   CATEGORY_SERVICE_BOND_REFUND,
   SOURCE_SEMANTIC,
 } from "./constants";
 import { enqueuePendingBondRow, fundsMovementId } from "./utils";
+
+// linkBondMasterSafe — the SRTU `account` is the bond payer, which in
+// Pearl is the Master Safe. Stamp it onto the SEMANTIC bond row so the
+// wallet (which filters FundsMovement by masterSafe) surfaces this row
+// directly — the RAW_TRANSFER duplicate that used to carry the link is
+// now suppressed in classifyTransfer. Guarded to addresses already
+// tracked as MASTER so non-Pearl bonds stay unlinked.
+function linkBondMasterSafe(row: FundsMovement, account: Address): void {
+  const tracked = TrackedSafe.load(account);
+  if (tracked != null && tracked.role == "MASTER") {
+    row.masterSafe = tracked.masterSafe;
+  }
+}
 
 // handleTokenDeposit — fires once per activateRegistrationTokenDeposit
 // (security deposit) and once per registerAgentsTokenDeposit (agent
@@ -26,6 +40,7 @@ export function handleTokenDeposit(event: TokenDepositEvent): void {
   row.amount = event.params.amount;
   row.from = event.params.account;
   row.to = event.address;
+  linkBondMasterSafe(row, event.params.account);
   row.blockNumber = event.block.number;
   row.blockTimestamp = event.block.timestamp;
   row.transactionHash = event.transaction.hash;
@@ -45,6 +60,7 @@ export function handleTokenRefund(event: TokenRefundEvent): void {
   row.amount = event.params.amount;
   row.from = event.address;
   row.to = event.params.account;
+  linkBondMasterSafe(row, event.params.account);
   row.blockNumber = event.block.number;
   row.blockTimestamp = event.block.timestamp;
   row.transactionHash = event.transaction.hash;

--- a/subgraphs/pearl-transactions/src/utils.ts
+++ b/subgraphs/pearl-transactions/src/utils.ts
@@ -31,11 +31,10 @@ import {
   CATEGORY_OTHER,
   CATEGORY_SAFE_DEPLOYED,
   CATEGORY_SAFE_SETUP_TRANSFER,
-  CATEGORY_SERVICE_BOND_DEPOSIT,
-  CATEGORY_SERVICE_BOND_REFUND,
   SERVICE_STATE_REGISTERED,
   SOURCE_SEMANTIC,
   getOlasAddress,
+  getServiceRegistryAddress,
   getSrtuAddress,
   getStablecoinSymbol,
   getWrappedNativeAddress,
@@ -472,6 +471,23 @@ export function dequeueAndAttribute(
       if (movement != null) {
         movement.service = serviceId.toString();
         movement.bondType = bondType;
+        // Backfill the agent link so the wallet can render the agent
+        // name on stake / unstake rows. The Service carries agentIds
+        // (set at RegisterInstance) for the display name regardless; the
+        // agentSafe multisig only exists post-CreateMultisigWithAgents,
+        // so it resolves on refunds and any re-stake but is null on the
+        // very first deposit (the name still resolves via service.agentIds).
+        // masterSafe is normally stamped by the SRTU producer; fall back
+        // to the Service link here for services discovered out of order.
+        const service = Service.load(serviceId.toString());
+        if (service != null) {
+          if (movement.masterSafe === null && service.masterSafe !== null) {
+            movement.masterSafe = service.masterSafe;
+          }
+          if (service.agentSafe !== null) {
+            movement.agentSafe = service.agentSafe;
+          }
+        }
         movement.save();
       }
       return;
@@ -717,37 +733,31 @@ export function classifyTransfer(
   const srtuAddr = getSrtuAddress(currentNetwork());
   const fromIsSrtu = from.equals(srtuAddr);
   const toIsSrtu = to.equals(srtuAddr);
+  const registryAddr = getServiceRegistryAddress(currentNetwork());
 
   // Most-specific patterns first.
 
-  // Master Safe → SRTU → SERVICE_BOND_DEPOSIT raw reconciliation
-  // (Phase 1a's SRTU handler already booked the canonical SEMANTIC
-  // rows; consumer filters by source=SEMANTIC).
+  // Master Safe ↔ SRTU OLAS transfers are the on-chain bond movement.
+  // The SRTU handler (handleTokenDeposit / handleTokenRefund) already
+  // books the canonical SEMANTIC bond row and the consumer backfills
+  // serviceId + bondType + masterSafe + agentSafe onto it, so that one
+  // row is the complete record. Emitting a second RAW_TRANSFER row here
+  // would double-count the bond in any masterSafe-filtered wallet query,
+  // so we drop it (return null). The OLAS TokenBalance delta is updated
+  // separately in handleErc20Transfer and is unaffected.
   if (
     fromMaster != null &&
     fromMaster.role == "MASTER" &&
     toIsSrtu
   ) {
-    return new ClassifyResult(
-      CATEGORY_SERVICE_BOND_DEPOSIT,
-      null,
-      fromMaster.masterSafe,
-      null
-    );
+    return null;
   }
-
-  // SRTU → Master Safe → SERVICE_BOND_REFUND raw reconciliation.
   if (
     fromIsSrtu &&
     toMaster != null &&
     toMaster.role == "MASTER"
   ) {
-    return new ClassifyResult(
-      CATEGORY_SERVICE_BOND_REFUND,
-      null,
-      toMaster.masterSafe,
-      null
-    );
+    return null;
   }
 
   // Master Safe → Agent Safe / Agent EOA → MASTER_TO_AGENT (grouped).
@@ -801,6 +811,14 @@ export function classifyTransfer(
 
   // EOA (Master EOA / other) → Master Safe.
   if (toMaster != null && toMaster.role == "MASTER") {
+    // The ServiceRegistryL2 contract itself sends tiny native dust to the
+    // Master Safe during terminate / unbond (observed: 1-wei xDAI refunds
+    // sharing a tx with SERVICE_BOND_REFUND). That is protocol
+    // bookkeeping, not a user deposit, so classify it OTHER (kept for the
+    // forensic view, hidden from the wallet) rather than MASTER_FUNDING_IN.
+    if (from.equals(registryAddr)) {
+      return new ClassifyResult(CATEGORY_OTHER, null, toMaster.masterSafe, null);
+    }
     const ms = MasterSafe.load(toMaster.masterSafe);
     if (ms != null && !ms.setupTransferSeen && fromEOA != null && fromEOA.role == "MASTER_EOA") {
       // First Master EOA → Master Safe hop after creation.

--- a/subgraphs/pearl-transactions/tests/phase-2a.test.ts
+++ b/subgraphs/pearl-transactions/tests/phase-2a.test.ts
@@ -372,6 +372,24 @@ describe("pearl-transactions / Phase 2a — raw OLAS + Safe template", () => {
     );
   });
 
+  test("ServiceRegistryL2 dust → Master Safe classifies as OTHER, not MASTER_FUNDING_IN", () => {
+    seedMasterSafe(/* setupTransferSeen = */ true);
+    // The ServiceRegistryL2 contract sends tiny native dust to the Master
+    // Safe during terminate / unbond. It shares the classifier with the
+    // OLAS handler, so a transfer from the registry address must NOT be
+    // mistaken for a user deposit.
+    const REGISTRY_GNOSIS = Address.fromString(
+      "0x9338b5153AE39BB89f50468E608eD9d764B755fD"
+    );
+    const tx = mockTx(99);
+    handleErc20Transfer(
+      newOlasTransfer(REGISTRY_GNOSIS, MASTER_SAFE, AMOUNT, tx, 0)
+    );
+
+    const id = tx.concatI32(0);
+    assert.fieldEquals("FundsMovement", id.toHexString(), "category", "OTHER");
+  });
+
   test("Master Safe → Agent Safe groups under AgentFundingEvent", () => {
     seedMasterSafe(true);
     seedAgentSafe(SERVICE_ID);
@@ -515,7 +533,7 @@ describe("pearl-transactions / Phase 2a — raw OLAS + Safe template", () => {
     );
   });
 
-  test("Master Safe → SRTU → SERVICE_BOND_DEPOSIT raw reconciliation row", () => {
+  test("Master Safe → SRTU OLAS Transfer emits no RAW bond row (deduped vs SEMANTIC)", () => {
     seedMasterSafe(true);
     const SRTU_GNOSIS = Address.fromString(
       "0xa45E64d13A30a51b91ae0eb182e88a40e9b18eD8"
@@ -523,22 +541,14 @@ describe("pearl-transactions / Phase 2a — raw OLAS + Safe template", () => {
     const tx = mockTx(21);
     handleErc20Transfer(newOlasTransfer(MASTER_SAFE, SRTU_GNOSIS, AMOUNT, tx, 0));
 
-    const id = tx.concatI32(0);
-    assert.fieldEquals(
-      "FundsMovement",
-      id.toHexString(),
-      "category",
-      "SERVICE_BOND_DEPOSIT"
-    );
-    assert.fieldEquals(
-      "FundsMovement",
-      id.toHexString(),
-      "source",
-      "RAW_TRANSFER"
-    );
+    // classifyTransfer drops the Master Safe ↔ SRTU OLAS hop: the SRTU
+    // handler already books the canonical SEMANTIC bond row (now carrying
+    // masterSafe), so a second RAW_TRANSFER row here would double-count
+    // the bond in a masterSafe-filtered wallet query.
+    assert.entityCount("FundsMovement", 0);
   });
 
-  test("SRTU → Master Safe → SERVICE_BOND_REFUND raw reconciliation row", () => {
+  test("SRTU → Master Safe OLAS Transfer emits no RAW bond row (deduped vs SEMANTIC)", () => {
     seedMasterSafe(true);
     const SRTU_GNOSIS = Address.fromString(
       "0xa45E64d13A30a51b91ae0eb182e88a40e9b18eD8"
@@ -546,19 +556,7 @@ describe("pearl-transactions / Phase 2a — raw OLAS + Safe template", () => {
     const tx = mockTx(22);
     handleErc20Transfer(newOlasTransfer(SRTU_GNOSIS, MASTER_SAFE, AMOUNT, tx, 0));
 
-    const id = tx.concatI32(0);
-    assert.fieldEquals(
-      "FundsMovement",
-      id.toHexString(),
-      "category",
-      "SERVICE_BOND_REFUND"
-    );
-    assert.fieldEquals(
-      "FundsMovement",
-      id.toHexString(),
-      "source",
-      "RAW_TRANSFER"
-    );
+    assert.entityCount("FundsMovement", 0);
   });
 
   test("StakingProxy → Agent Safe OLAS Transfer = STAKING_REWARD_CLAIM raw reconciliation", () => {

--- a/subgraphs/pearl-transactions/tests/service-registry.test.ts
+++ b/subgraphs/pearl-transactions/tests/service-registry.test.ts
@@ -751,6 +751,57 @@ describe("pearl-transactions / Phase 1a — registry + Master EOA + SRTU bonds",
   );
 
   test(
+    "Bond rows carry masterSafe + agentSafe so the wallet can show the agent name",
+    () => {
+      // Establish a fully-formed service the way it exists on-chain by the
+      // time an unstake/refund happens: the NFT mint tracks the Master Safe
+      // (role=MASTER) and links service.masterSafe; CreateMultisigWithAgents
+      // links service.agentSafe.
+      mockGetOwners(MASTER_SAFE, [MASTER_EOA, BACKUP_EOA]);
+      mockGetThreshold(MASTER_SAFE, 1);
+
+      const setupTx = mockTx(30);
+      handleServiceNftTransfer(
+        newNftTransfer(ZERO, MASTER_SAFE, SERVICE_ID, setupTx, 0)
+      );
+      handleCreateMultisigWithAgents(
+        newCreateMultisig(SERVICE_ID, AGENT_SAFE, setupTx, 1)
+      );
+
+      // Unstake: TokenRefund (SRTU producer, stamps masterSafe from the
+      // bond payer) → OperatorUnbond (SR consumer, backfills service +
+      // bondType + agentSafe).
+      const tx = mockTx(31);
+      handleTokenRefund(
+        newTokenRefund(MASTER_SAFE, OLAS_GNOSIS, AGENT_BOND, tx, 0)
+      );
+      handleOperatorUnbond(newOperatorUnbond(OPERATOR, SERVICE_ID, tx, 1));
+
+      const id = tx.concatI32(0);
+      assertBondRow(
+        tx,
+        0,
+        "SERVICE_BOND_REFUND",
+        "AGENT_BOND",
+        "42",
+        AGENT_BOND.toString()
+      );
+      assert.fieldEquals(
+        "FundsMovement",
+        id.toHexString(),
+        "masterSafe",
+        MASTER_SAFE.toHexString()
+      );
+      assert.fieldEquals(
+        "FundsMovement",
+        id.toHexString(),
+        "agentSafe",
+        AGENT_SAFE.toHexString()
+      );
+    }
+  );
+
+  test(
     "TokenDeposit with no prior attribution → row recorded; service + bondType unset",
     () => {
       const tx = mockTx(7);


### PR DESCRIPTION
## Why

Two wallet-history correctness bugs surfaced during Gnosis QA of VLOP-73:

1. **Registry dust shown as deposits.** The `ServiceRegistryL2` contract sends 1-wei native dust to the Master Safe during terminate/unbond. `classifyTransfer` fell through to `MASTER_FUNDING_IN`, so the wallet rendered these as `+0.00 XDAI` **Deposit** rows (sharing a tx with the real `SERVICE_BOND_REFUND`).
2. **Bonds showed a generic "Agent" name** (e.g. "Agent stake/unstake" instead of "Omenstrat stake/unstake"). The wallet filters `FundsMovement` by `masterSafe`, so it saw the **RAW_TRANSFER** bond row (carries `masterSafe`, but no `service`/`agentSafe`) rather than the **SEMANTIC** bond row (carries `service` + `bondType`, but `masterSafe` was null).

## What

- **`getServiceRegistryAddress(network)`** added to `constants.ts` (mirrors `networks.json`, all 4 chains).
- **`classifyTransfer`**:
  - Inbound to a Master Safe **from the registry contract → `OTHER`** (kept for the forensic view, hidden from the wallet) instead of `MASTER_FUNDING_IN`.
  - Master Safe ↔ SRTU OLAS hops now **return `null`** — the RAW duplicate is dropped so the SEMANTIC row is the single bond record (no double-count in a `masterSafe`-filtered query). `TokenBalance` is unaffected (bonds were never in its update branches).
- **Bond rows are now self-contained.** The SRTU producer stamps `masterSafe` from the bond payer (`account`, guarded to tracked Master Safes); `dequeueAndAttribute` backfills `agentSafe` (+ `masterSafe` fallback) from the now-known `Service`. So one SEMANTIC row carries `masterSafe + service + bondType + agentSafe`. `agentSafe` resolves on **unstake** (multisig exists); a genesis **stake** leaves it null but `service.agentIds` still yields the display name.

## Tests

- The 2 "RAW reconciliation row" tests become **suppression** assertions (the hop no longer emits a RAW row).
- Adds a **registry-dust → OTHER** test and a **bond row carries masterSafe + agentSafe** test.
- `yarn test` → **46 pass**; `yarn build` clean.

## Consumer note

A complementary frontend change (read the agent name from the bond row's direct `service` when `agentSafe` is null, for the genesis-stake case) lands on the Operate-app VLOP-73 branch. Requires a **v0.0.6** redeploy to surface on-chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)