### PR TITLE
fix(pearl-transactions): ServicesEvicted ID collision + token decimals fallback

### DIFF
--- a/subgraphs/pearl-transactions/CLAUDE.md
+++ b/subgraphs/pearl-transactions/CLAUDE.md
@@ -102,7 +102,7 @@ deploy; watch Polygon USDC.e sync (the §2.2 cost hotspot).
   in constants.ts).
 - **`getOrCreateToken`** — OLAS / wrapped-native 18 decimals; stablecoins
   (USDC / USDC.e / pUSD) 6 decimals via `getStablecoinSymbol` (constants.ts);
-  `log.critical` + UNKNOWN/18 if an indexed token has no resolver branch.
+  `log.critical` + UNKNOWN/6 if an indexed token has no resolver branch.
 - **`AgentFundingEvent`** — groups same-tx `MASTER_TO_AGENT` rows so one
   funding action is one consumer row.
 - **`SAFE_SETUP_TRANSFER` / Path A** — the first live Master-EOA → Master-Safe

--- a/subgraphs/pearl-transactions/src/erc20.ts
+++ b/subgraphs/pearl-transactions/src/erc20.ts
@@ -32,7 +32,7 @@ export function handleErc20Transfer(event: TransferEvent): void {
   const amount = event.params.value;
   const token = event.address;
 
-  const classification = classifyTransfer(from, to, null);
+  const classification = classifyTransfer(from, to);
   if (classification === null) {
     return;
   }

--- a/subgraphs/pearl-transactions/src/safe.ts
+++ b/subgraphs/pearl-transactions/src/safe.ts
@@ -30,7 +30,7 @@ export function handleSafeReceived(event: SafeReceivedEvent): void {
   const to = event.address;
   const amount = event.params.value;
 
-  const classification = classifyTransfer(from, to, null);
+  const classification = classifyTransfer(from, to);
   if (classification === null) return;
 
   const row = new FundsMovement(fundsMovementId(event));

--- a/subgraphs/pearl-transactions/src/staking-proxy.ts
+++ b/subgraphs/pearl-transactions/src/staking-proxy.ts
@@ -185,8 +185,13 @@ export function handleServicesEvicted(event: ServicesEvictedEvent): void {
     const service = getOrCreateService(serviceId, event);
 
     // Unique-id per (tx, logIndex, serviceId-slot) since ServicesEvicted
-    // is one event affecting many services. Use logIndex + i.
-    const id = event.transaction.hash.concatI32(event.logIndex.toI32() + i);
+    // is one event affecting many services. Compose logIndex AND the slot
+    // index as separate segments — `logIndex + i` would collide with any
+    // other event in the same tx whose logIndex falls in [logIndex+1,
+    // logIndex+K-1] and silently overwrite its FundsMovement row.
+    const id = event.transaction.hash
+      .concatI32(event.logIndex.toI32())
+      .concatI32(i);
     const row = new FundsMovement(id);
     row.service = service.id;
     if (service.masterSafe !== null) {

--- a/subgraphs/pearl-transactions/src/utils.ts
+++ b/subgraphs/pearl-transactions/src/utils.ts
@@ -648,16 +648,19 @@ export function getOrCreateToken(tokenAddress: Address): Token {
       // Reached here only via a tracked Transfer, so this is an indexed
       // token with no metadata resolver — almost certainly an
       // `erc20Tokens` entry in networks.json without a matching
-      // getStablecoinSymbol branch. UNKNOWN/18 would silently misformat a
-      // 6-decimal stablecoin by 10^12 in every consumer, and first-write-
-      // wins makes it permanent. Loud on purpose so it surfaces in
-      // indexing logs, not in the wallet UI.
+      // getStablecoinSymbol branch. Every such indexed token (OLAS and
+      // wrapped-native are handled above) is a stablecoin, so default to
+      // 6 decimals — NOT 18: an 18-decimal fallback would silently
+      // misformat the amount by 10^12 in every consumer, and first-write-
+      // wins makes it permanent. log.critical is loud on purpose (drift
+      // canary), but we must not rely on it aborting — graph-node may
+      // continue — so the persisted value has to be safe by itself.
       log.critical(
-        "getOrCreateToken: no symbol/decimals resolver for indexed token {} on {} — add a getStablecoinSymbol branch (networks.json `erc20Tokens` and the resolver are out of sync). Falling back to UNKNOWN/18.",
+        "getOrCreateToken: no symbol/decimals resolver for indexed token {} on {} — add a getStablecoinSymbol branch (networks.json `erc20Tokens` and the resolver are out of sync). Defaulting to UNKNOWN/6.",
         [tokenAddress.toHexString(), network]
       );
       token.symbol = "UNKNOWN";
-      token.decimals = 18;
+      token.decimals = 6;
     }
   }
   token.save();
@@ -680,7 +683,9 @@ export function upsertTokenBalance(
     bal = new TokenBalance(id);
     bal.safe = safe;
     bal.token = getOrCreateToken(tokenAddress).id;
-    bal.balance = isDelta ? amount : amount;
+    // First sighting: the initial balance is `amount` whether it's the
+    // first signed delta or an absolute baseline write.
+    bal.balance = amount;
   } else {
     bal.balance = isDelta ? bal.balance.plus(amount) : amount;
   }
@@ -721,8 +726,7 @@ export class ClassifyResult {
 // silently dropped").
 export function classifyTransfer(
   from: Address,
-  to: Address,
-  masterSafePtr: MasterSafe | null
+  to: Address
 ): ClassifyResult | null {
   const fromMaster = TrackedSafe.load(from);
   const toMaster = TrackedSafe.load(to);

--- a/subgraphs/pearl-transactions/tests/phase-2a.test.ts
+++ b/subgraphs/pearl-transactions/tests/phase-2a.test.ts
@@ -757,7 +757,7 @@ describe("pearl-transactions / Phase 2a — raw OLAS + Safe template", () => {
 //
 // Covers every (chain, token) tuple in getStablecoinSymbol so a typo in
 // any address literal (or a missing resolver branch) fails loudly here
-// instead of silently mapping to UNKNOWN/18 in production. Each case sets
+// instead of silently mapping to UNKNOWN/6 in production. Each case sets
 // its own network so there's no cross-test ordering dependency.
 describe("pearl-transactions / Phase 2b — stablecoins", () => {
   beforeEach(() => {

--- a/subgraphs/pearl-transactions/tests/staking.test.ts
+++ b/subgraphs/pearl-transactions/tests/staking.test.ts
@@ -588,6 +588,65 @@ describe("pearl-transactions / Phase 1b — staking", () => {
     assert.fieldEquals("FundsMovement", id2.toHexString(), "category", "SERVICE_EVICTED");
   });
 
+  test(
+    "ServicesEvicted slot id does NOT collide with another same-tx FundsMovement",
+    () => {
+      // Regression for the row-id collision the fix prevents. Fire a 2-service
+      // eviction at logIndex 2, then a RewardClaimed in the SAME tx at
+      // logIndex 3. Under the old id scheme `txHash.concatI32(logIndex + i)`
+      // the eviction's slot-1 row (2 + 1 = 3) aliased the reward row's
+      // single-segment id `txHash.concatI32(3)` and one silently overwrote the
+      // other → only 2 rows. The two-segment id keeps all three distinct.
+      const tx = mockTx(20);
+
+      const evicted = newServicesEvicted(
+        EPOCH,
+        [SERVICE_ID, SERVICE_ID_2],
+        [MASTER_SAFE, MASTER_SAFE],
+        [AGENT_SAFE, AGENT_SAFE],
+        STAKING_PROXY,
+        tx
+      );
+      evicted.logIndex = BigInt.fromI32(2);
+      handleServicesEvicted(evicted);
+
+      const claimed = newRewardClaimed(
+        SERVICE_ID,
+        EPOCH,
+        MASTER_SAFE,
+        AGENT_SAFE,
+        REWARD,
+        STAKING_PROXY,
+        tx
+      );
+      claimed.logIndex = BigInt.fromI32(3);
+      handleRewardClaimed(claimed);
+
+      // All three rows survive (would be 2 under the old colliding scheme).
+      assert.entityCount("FundsMovement", 3);
+      // Eviction rows: two-segment ids (logIndex 2, slots 0/1).
+      assert.fieldEquals(
+        "FundsMovement",
+        tx.concatI32(2).concatI32(0).toHexString(),
+        "category",
+        "SERVICE_EVICTED"
+      );
+      assert.fieldEquals(
+        "FundsMovement",
+        tx.concatI32(2).concatI32(1).toHexString(),
+        "category",
+        "SERVICE_EVICTED"
+      );
+      // The reward row at single-segment logIndex 3 is intact, NOT clobbered.
+      assert.fieldEquals(
+        "FundsMovement",
+        tx.concatI32(3).toHexString(),
+        "category",
+        "STAKING_REWARD_CLAIM"
+      );
+    }
+  );
+
   test("NFT-Transfer to a known StakingContract does NOT call getOwners()", () => {
     // Seed the StakingContract entity first.
     const sc = new StakingContract(STAKING_PROXY);

--- a/subgraphs/pearl-transactions/tests/staking.test.ts
+++ b/subgraphs/pearl-transactions/tests/staking.test.ts
@@ -577,10 +577,12 @@ describe("pearl-transactions / Phase 1b — staking", () => {
       )
     );
 
-    // Two FundsMovement rows, both SERVICE_EVICTED with amount 0.
+    // Two FundsMovement rows, both SERVICE_EVICTED with amount 0. IDs
+    // compose the event logIndex (0 on the mock) AND the slot index as
+    // separate segments, so the rows can't collide with same-tx events.
     assert.entityCount("FundsMovement", 2);
-    const id1 = tx.concatI32(0);
-    const id2 = tx.concatI32(1);
+    const id1 = tx.concatI32(0).concatI32(0);
+    const id2 = tx.concatI32(0).concatI32(1);
     assert.fieldEquals("FundsMovement", id1.toHexString(), "category", "SERVICE_EVICTED");
     assert.fieldEquals("FundsMovement", id1.toHexString(), "amount", "0");
     assert.fieldEquals("FundsMovement", id2.toHexString(), "category", "SERVICE_EVICTED");


### PR DESCRIPTION
Addresses correctness findings raised by @DIvyaNautiyal07 in the review of the self-hosted Gnosis port ([valory-xyz/autonolas-subgraph#102](https://github.com/valory-xyz/autonolas-subgraph/pull/102)). Fixing here in the canonical source first per the sync policy; the port re-mirrors after this merges.

## P1 — correctness

- **`ServicesEvicted` row-ID collision** (`staking-proxy.ts`). The per-slot id was `txHash.concatI32(logIndex + i)`. A `ServicesEvicted` at logIndex `N` affecting `K` services claimed ids `N..N+K-1`, so any other event in the same tx at a logIndex in `[N+1, N+K-1]` produced the same id and **silently overwrote** its `FundsMovement` row. Now composes logIndex and the slot index as **separate** segments (`concatI32(logIndex).concatI32(i)`).
- **`getOrCreateToken` decimals fallback** (`utils.ts`). The no-resolver branch persisted `UNKNOWN/18`. This branch is only reachable for an *indexed* token, and every indexed non-OLAS/non-wrapped token is a **6-decimal stablecoin**, so an 18-dec fallback misformats amounts by 10^12 — and first-write-wins makes it permanent. We can't rely on `log.critical` aborting (graph-node may continue), so the persisted value must be safe by itself: **default to 6**. Kept the loud `log.critical` as the drift canary.

## Clear nits

- Collapse the `isDelta ? amount : amount` identical-branch no-op in `upsertTokenBalance`.
- Drop the unused `masterSafePtr` param from `classifyTransfer` (every caller passed `null`) + update the two callers.

## Tests

Eviction test updated to the new compound id. `yarn build` ✅, `yarn test` → **46 pass** ✅.

## Follow-ups (not in this PR)

The P2 hardening items from the review (allow-list silent skip, operator-EOA tracking gap, `drainPendingRegistration` cleanup, `Address.zero()` phantom refs, masterEoa-rotation test gap) are tracked for a separate batch. Native-out placeholder remains the documented v1 limitation.

> Note: ships in a future redeploy (v0.0.7) of the 4 Studio subgraphs + re-mirror into the self-hosted port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)