### PR TITLE
perf(pearl-transactions): clean-sync indexing release (#148 proposals)

### DIFF
--- a/subgraphs/pearl-funds/IMPLEMENTATION-PLAN.md
+++ b/subgraphs/pearl-funds/IMPLEMENTATION-PLAN.md
@@ -1,9 +1,9 @@
 # Pearl Funds-Movement Subgraph — Implementation Plan
 
-**Status:** Implemented through Phase 2a (PRs #131/#132/#133 merged to `main`); Phase 2b (#138) in review. This plan is the design-of-record.
+**Status:** Implemented through Phase 2b (#138); clean-sync indexing release (#148 proposals / #149) consolidated the tracking + bond entities and flipped the high-cardinality ledger to immutable (see Rev. 8). This plan is the design-of-record.
 **Subgraph:** `subgraphs/pearl-transactions/` (renamed from `pearl-funds` per §11 #5)
 **Target networks (v1):** Gnosis, Polygon, Optimism, Base
-**Last updated:** 2026-06-01 (Rev. 7 — Phase 2b token-set reconciliation: pUSD is a separate Polymarket contract `0xC011a7E1…`, not a USDC.e UI alias; §4.5 token table + §4.3 networks table rebuilt to the shipped per-chain set (USDC / USDC.e / pUSD); §6.3 records the ship-on-chain decision + Polygon USDC.e rollback condition; Polystrat funds in USDC + pUSD. Rev. 6 — back-propagated the PR #131/#132 producer/consumer fixes so the plan matches shipped code: §3.3 SRTU is indexed, §4.6 SRTU-before-SR event order, §5.1/§5.2 inverted bond-attribution entities + handlers, §5.1 FundsMovement/Token mutability, §5.2 dual NFT guard + handleServiceStaked null-check, §5.4/§7/§8 staleness, pearl-transactions path. Rev. 5 — product decisions finalised: OPENING_BALANCE rows removed, opening balances delegated to the frontend via historyFloorBlock; native → Agent EOA confirmed accepted gap; AC #3 = Path A. Rev. 4 addressed PR #130 review + §11 #6. Rev. 3 added §4.5/§4.6. Rev. 2 added SRTU bond indexing, agent-ID anti-hardcoding, Master EOA tracking. Rev. 1 addressed PR #129 feedback.)
+**Last updated:** 2026-06-12 (Rev. 8 — back-propagated the clean-sync indexing release (#148 proposals #2/#3/#4/#5, PR #149) so the plan matches shipped code: `FundsMovement` flipped to `immutable: true` and the only mutated rows (SRTU bond deposit/refund) split into a new mutable `BondMovement` entity (§5.1) — the producer creates a `BondMovement` row and the consumer backfills it (§5.2), and a complete ledger is now `FundsMovement` ∪ `BondMovement`; `TrackedSafe` + `TrackedEOA` consolidated into a single immutable `TrackedAddress` (roles MASTER / AGENT / MASTER_EOA / AGENT_EOA / STAKING) so `classifyTransfer` does two hot-path loads instead of six (§6.4/§6.5); `Token` made immutable; service ids migrated to `Bytes` (`serviceEntityId`). Rev. 7 — Phase 2b token-set reconciliation: pUSD is a separate Polymarket contract `0xC011a7E1…`, not a USDC.e UI alias; §4.5 token table + §4.3 networks table rebuilt to the shipped per-chain set (USDC / USDC.e / pUSD); §6.3 records the ship-on-chain decision + Polygon USDC.e rollback condition; Polystrat funds in USDC + pUSD. Rev. 6 — back-propagated the PR #131/#132 producer/consumer fixes so the plan matches shipped code: §3.3 SRTU is indexed, §4.6 SRTU-before-SR event order, §5.1/§5.2 inverted bond-attribution entities + handlers, §5.1 FundsMovement/Token mutability, §5.2 dual NFT guard + handleServiceStaked null-check, §5.4/§7/§8 staleness, pearl-transactions path. Rev. 5 — product decisions finalised: OPENING_BALANCE rows removed, opening balances delegated to the frontend via historyFloorBlock; native → Agent EOA confirmed accepted gap; AC #3 = Path A. Rev. 4 addressed PR #130 review + §11 #6. Rev. 3 added §4.5/§4.6. Rev. 2 added SRTU bond indexing, agent-ID anti-hardcoding, Master EOA tracking. Rev. 1 addressed PR #129 feedback.)
 
 This document scopes a new subgraph that indexes **funds movement for the
 Master Safe and Agent Safe of Pearl predict services**. It covers Phase 1
@@ -110,8 +110,8 @@ review):
   new Pearl agent type launches** — the constant list lives in the
   compiled mapping, so any change requires redeploy + resync. This is
   exactly the kind of brittleness the trade subgraph plan avoided.
-- The indexing-cost concern in §2.2 is bounded by the size of
-  `TrackedSafe` in Phase 2, **not** by the total number of indexed
+- The indexing-cost concern in §2.2 is bounded by the size of the
+  `TrackedAddress` set in Phase 2, **not** by the total number of indexed
   services. `ServiceRegistryL2` event volume is low (same shape as the
   `service-registry` subgraph), so indexing every service is cheap.
 - Recording `agentIds` + `operators` on each `Service` preserves every
@@ -128,7 +128,7 @@ filter on these — they're consumer query parameters):
 | Gnosis (omenstrat) | **25** | Confirmed by maintainer; matches `valory-xyz/autonolas-subgraph` PR #89 (`PREDICT_AGENT_ID = 25`) |
 | Polygon (polystrat) | **86** | `predict-polymarket/src/constants.ts` |
 
-Phase 2's `TrackedSafe` set still needs a gate to keep the cost low. The
+Phase 2's `TrackedAddress` set still needs a gate to keep the cost low. The
 gate moves from "is this a Pearl predict service" to "does this service
 appear in the Pearl predict cohort or any other tracked cohort" — for
 v1 the only cohort we spawn `Safe` templates for is the Pearl predict
@@ -149,7 +149,7 @@ flows. Mode is intentionally omitted (deprecated network).
 Pearl predict services are the **primary consumer cohort** for v1
 (`agent ID 25` on Gnosis, `agent ID 86` on Polygon); the schema and
 data sources are deliberately agent-agnostic so other Pearl agent types
-(Optimus / babydegen / agents.fun) become drop-in additions of `TrackedSafe`
+(Optimus / babydegen / agents.fun) become drop-in additions of `TrackedAddress`
 seeding rather than full reindexes.
 
 ### 3.2 Phasing
@@ -169,7 +169,7 @@ visibility) and must clear both gates before commitment.
 
 - **Other Pearl agent types' Phase 2 cohorts** (Optimus / babydegen,
   agents.fun, etc.) — services for *every* agent type are still indexed
-  in Phase 1, but `TrackedSafe` seeding in Phase 2 is initially scoped to
+  in Phase 1, but `TrackedAddress` seeding in Phase 2 is initially scoped to
   the Pearl predict cohort to bound cost. Adding cohorts later is a
   per-deployment constant change, not a re-architecture.
 - **Mode network** — deprecated.
@@ -473,7 +473,7 @@ sequenceDiagram
 
 Bond-type attribution is best-effort per §5.2. Because the SRTU event
 fires *before* its ServiceRegistryL2 counterpart in every path, the SRTU
-handler is the **producer** (creates the `FundsMovement` row + enqueues
+handler is the **producer** (creates the `BondMovement` row + enqueues
 it) and the ServiceRegistryL2 handler is the **consumer** (`ActivateRegistration`
 / `RegisterInstance` / `TerminateService` / `OperatorUnbond` dequeue the
 row and backfill `serviceId` + `bondType`). The diagram shows the
@@ -614,18 +614,17 @@ enum FundsSource {
   RAW_TRANSFER                        # Direct ERC-20/native Transfer observed on chain
 }
 
-type FundsMovement @entity(immutable: false) {
-  # Mutable: SRTU TokenDeposit/TokenRefund rows are created amount-only by
-  # the SRTU producer and backfilled with serviceId + bondType by the
-  # ServiceRegistryL2 consumer later in the same tx (see §5.2). All other
-  # rows are write-once in practice.
+type FundsMovement @entity(immutable: true) {
+  # Immutable (Rev. 8): every FundsMovement is write-once. The only rows that
+  # were ever backfilled (SRTU TokenDeposit/TokenRefund bond rows) now live in
+  # the separate mutable BondMovement entity below, so this high-cardinality
+  # ledger skips block-range versioning — cheaper writes AND cheaper reads.
   id: Bytes!                          # txHash.concatI32(logIndex) — for semantic rows lacking a logIndex, use a stable sub-index
   service: Service
   masterSafe: MasterSafe
   agentSafe: AgentSafe
   category: FundsCategory!
   source: FundsSource!
-  bondType: ServiceBondType           # nullable; only populated for SERVICE_BOND_DEPOSIT / SERVICE_BOND_REFUND when disambiguation succeeds
   token: Bytes                        # token address (null for SAFE_DEPLOYED + pure NFT custody)
   amount: BigInt!                     # 0 for SAFE_DEPLOYED / SERVICE_EVICTED informational rows
   from: Bytes!
@@ -635,6 +634,29 @@ type FundsMovement @entity(immutable: false) {
   # Phase 2 backref — see §6.5; null on all Phase 1 rows and on Phase 2 rows
   # that aren't part of a multi-row agent-funding action.
   agentFundingEvent: AgentFundingEvent
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
+  transactionHash: Bytes!
+}
+
+# SRTU bond deposit / refund rows (Rev. 8). Split out of FundsMovement because
+# they are the ONLY rows that get mutated: the SRTU producer creates the row
+# serviceId/bondType-less and the matching ServiceRegistryL2 consumer backfills
+# serviceId + bondType + agentSafe later in the same tx (see PendingBondRow +
+# §5.2). Isolating this small mutable entity lets FundsMovement stay immutable.
+# Consumer note: a complete ledger is FundsMovement ∪ BondMovement.
+type BondMovement @entity(immutable: false) {
+  id: Bytes!                          # txHash.concatI32(logIndex)
+  service: Service
+  masterSafe: MasterSafe
+  agentSafe: AgentSafe
+  category: FundsCategory!            # SERVICE_BOND_DEPOSIT | SERVICE_BOND_REFUND
+  source: FundsSource!
+  bondType: ServiceBondType           # nullable; only populated when disambiguation succeeds
+  token: Bytes
+  amount: BigInt!
+  from: Bytes!
+  to: Bytes!
   blockNumber: BigInt!
   blockTimestamp: BigInt!
   transactionHash: Bytes!
@@ -672,7 +694,7 @@ type PendingRegistration @entity(immutable: false) {
 # Same-tx bond-attribution queue for SRTU TokenDeposit/TokenRefund
 # disambiguation. The SRTU event fires BEFORE its ServiceRegistryL2
 # counterpart in every path (§4.6), so the SRTU handler is the PRODUCER
-# (creates the FundsMovement row + enqueues its id) and the SR handler is
+# (creates the BondMovement row + enqueues its id) and the SR handler is
 # the CONSUMER (dequeues + backfills serviceId + bondType). Three entities:
 type PendingBondCounter @entity(immutable: false) {
   id: Bytes!                          # tx.hash
@@ -681,7 +703,7 @@ type PendingBondCounter @entity(immutable: false) {
 }
 type PendingBondRow @entity(immutable: false) {
   id: Bytes!                          # tx.hash.concatI32(slot)
-  fundsMovement: Bytes!               # FundsMovement id awaiting serviceId + bondType
+  bondMovement: Bytes!                # BondMovement id awaiting serviceId + bondType
   attributed: Boolean!
 }
 # Dedupe guard: registerAgents emits one TokenDeposit but RegisterInstance
@@ -711,8 +733,8 @@ idempotent — subsequent calls just update `lastActivityTimestamp`.
 | `handleCreateMultisigWithAgents` | `ServiceRegistryL2.CreateMultisigWithAgents` | Create `Service` + `AgentSafe`, drain `PendingRegistration`, write `ServiceIndex`. |
 | `handleServiceNftTransfer` | `ServiceRegistryL2.Transfer` (ERC-721) | Update `Service.nftCustodian`; emit `ServiceNftCustodyChange`. **Dual guard** before treating `to` as a Master Safe: (1) `isStakingContract(to)` early-return (fast path, no eth_call — the NFT moves to the staking proxy on stake); (2) `getOrCreateMasterSafe(to, …)` returns `null` when `getOwners()` reverts (defence-in-depth for proxies created before `StakingFactory.startBlock` or by an older factory). Only the resolved-Safe case links `service.masterSafe`, so a stake hop never clobbers the real link. |
 | `handleTerminateService` | `ServiceRegistryL2.TerminateService` | `Service.state = TERMINATED`. **Consumer:** dequeue the pending bond row enqueued by the preceding `terminateTokenRefund` and tag it `bondType=SECURITY_DEPOSIT`. |
-| `handleTokenDeposit` | `ServiceRegistryTokenUtility.TokenDeposit` | **Producer:** create `FundsMovement(SERVICE_BOND_DEPOSIT, source=SEMANTIC, token, amount, from=account, to=SRTU)` (amount only — `serviceId`/`bondType` left null) and enqueue its id in the per-tx queue. The following ServiceRegistryL2 event (`ActivateRegistration` / `RegisterInstance`) backfills them. Fires twice per stake-side multicall; both rows persisted. |
-| `handleTokenRefund` | `ServiceRegistryTokenUtility.TokenRefund` | Mirror of `handleTokenDeposit`: producer of `FundsMovement(SERVICE_BOND_REFUND, source=SEMANTIC, token, amount, from=SRTU, to=account)`; backfilled by the following `TerminateService` / `OperatorUnbond`. Fires twice per unstake-side multicall. |
+| `handleTokenDeposit` | `ServiceRegistryTokenUtility.TokenDeposit` | **Producer:** create `BondMovement(SERVICE_BOND_DEPOSIT, source=SEMANTIC, token, amount, from=account, to=SRTU)` (amount only — `serviceId`/`bondType` left null) and enqueue its id in the per-tx queue. The following ServiceRegistryL2 event (`ActivateRegistration` / `RegisterInstance`) backfills them. Fires twice per stake-side multicall; both rows persisted. Also books the bond leg's `TokenBalance` debit. |
+| `handleTokenRefund` | `ServiceRegistryTokenUtility.TokenRefund` | Mirror of `handleTokenDeposit`: producer of `BondMovement(SERVICE_BOND_REFUND, source=SEMANTIC, token, amount, from=SRTU, to=account)`; backfilled by the following `TerminateService` / `OperatorUnbond`; books the `TokenBalance` credit. Fires twice per unstake-side multicall. |
 | `handleInstanceCreated` | `StakingFactory.InstanceCreated` | Spawn the `StakingProxy` template; snapshot `StakingContract` config (`minStakingDeposit`, `numAgentInstances`, `implementation`) via contract calls — copy `staking/src/staking-factory.ts`. |
 | `handleServiceStaked` | `StakingProxy.ServiceStaked` | `getOrCreateMasterSafe(owner, …)` (fires `SAFE_DEPLOYED` on first sighting via the staking path — the canonical discovery path, since `owner`/`multisig` are event params); **link only when it resolves** (`if (masterSafe != null) service.masterSafe = masterSafe.id` — null for a non-Safe/EOA owner rather than crashing). Set `agentSafe = multisig`, `state = STAKED`, `currentStakingContract`. **No synthetic `STAKING_DEPOSIT` row** — the bond movement is captured by two real `SERVICE_BOND_DEPOSIT` rows from the SRTU handlers above. |
 | `handleRewardClaimed` | `StakingProxy.RewardClaimed` | `FundsMovement(STAKING_REWARD_CLAIM, source=SEMANTIC, token=OLAS, amount=reward, from=stakingContract, to=agentSafe)`; bump cumulative counters on `Service` / `MasterSafe`; update `DailyServiceFunds`. |
@@ -729,7 +751,7 @@ Disambiguation uses a per-tx queue (`PendingBondCounter` +
 `PendingBondRow`). Because the SRTU function is called *before* the
 registry function in every path (§4.6), the SRTU handler is the
 **producer**: `handleTokenDeposit` / `handleTokenRefund` create the
-`FundsMovement` row (amount only) and enqueue its id. The following
+`BondMovement` row (amount only) and enqueue its id. The following
 `ServiceRegistryL2` handler is the **consumer**: `ActivateRegistration`
 → SECURITY_DEPOSIT, `RegisterInstance` → AGENT_BOND (guarded once per
 service by `AgentBondAttributionGuard`), `TerminateService` →
@@ -806,12 +828,13 @@ incompatible event ABIs.
 ### 6.1 Phase 2a — OLAS `Transfer` data source + agent-funding aggregation
 
 OLAS volume on all four chains is low; a full `Transfer` data source is
-cheap. The handler filters to a `TrackedAddress` set (an O(1) lookup
-combining `TrackedSafe` for Master / Agent Safes with `TrackedEOA` for
-Master EOAs — the latter added per the Rev. 2 maintainer ask so that
-Master EOA → Master Safe funding hops are captured in their own right,
-not only as the recipient side of a Safe event). The handler classifies
-(see also §6.4):
+cheap. The handler filters to a `TrackedAddress` set (an O(1) lookup over
+one immutable table holding Master / Agent Safes (MASTER / AGENT), Master
+EOAs (MASTER_EOA, added per the Rev. 2 maintainer ask so that Master EOA →
+Master Safe funding hops are captured in their own right, not only as the
+recipient side of a Safe event), agent EOAs, and indexed staking proxies —
+Rev. 8 consolidated the original `TrackedSafe` + `TrackedEOA` into this
+single immutable table). The handler classifies (see also §6.4):
 
 - **First Master EOA → Master Safe transfer of any token after
   `SAFE_DEPLOYED`** ⇒ `SAFE_SETUP_TRANSFER` — per PR #129 review, this
@@ -941,7 +964,7 @@ review):
    time.
 2. If projected sync is acceptable (target: full historical sync in
    days, not weeks) → ship 2b as a normal `Transfer` data source with
-   the `TrackedSafe` in-handler filter.
+   the `TrackedAddress` in-handler filter.
 3. If not acceptable → do **not** ship 2b on-chain. Document the
    off-chain alternative the prior plan already endorsed
    ([`pearl/SUBGRAPH_PLAN.md`](../pearl/SUBGRAPH_PLAN.md) §6.1: USDC /
@@ -980,9 +1003,11 @@ which client path consumers prepare for.
 A shared `classifyTransfer(from, to)` helper resolves each raw transfer's
 `category` by matching `from`/`to` against:
 
-- `TrackedSafe` (role: MASTER / AGENT)
-- `TrackedEOA` (role: MASTER_EOA / AGENT_EOA) — added in Rev. 2 so Master
-  EOA hops are first-class, not just inferred via Safe `SafeReceived`
+- `TrackedAddress` (role: MASTER / AGENT / MASTER_EOA / AGENT_EOA / STAKING)
+  — Rev. 8 consolidated the original `TrackedSafe` (MASTER / AGENT) and
+  `TrackedEOA` (MASTER_EOA / AGENT_EOA, added Rev. 2 so Master EOA hops are
+  first-class rather than inferred via Safe `SafeReceived`) into one immutable
+  table, so `classifyTransfer` does two loads (`from` + `to`) instead of six
 - `StakingContract` (any indexed `StakingProxy`)
 - `ServiceRegistryL2` (per-network constant)
 - `ServiceRegistryTokenUtility` (per-network constant) — Rev. 2; routes
@@ -996,28 +1021,24 @@ Unmatched ⇒ `OTHER`.
 ### 6.5 Schema additions (Phase 2)
 
 ```graphql
-type Token @entity(immutable: false) {
+type Token @entity(immutable: true) {   # Rev. 8 — first write wins, never updated
   id: Bytes!                          # token address
   symbol: String!
   decimals: Int!
 }
 
-type TrackedSafe @entity(immutable: false) {
-  id: Bytes!                          # Safe address
-  role: String!                       # MASTER | AGENT
-  service: Service!
-}
-
-# Added Rev. 2 — Master EOAs (and optionally agent EOAs) tracked alongside
-# Safes so OLAS handler classify() can route Master EOA hops without
-# relying on Safe SafeReceived inference. Populated by getOrCreateMasterSafe
-# (Phase 1) and by RegisterInstance (for agent EOAs, when needed).
-type TrackedEOA @entity(immutable: false) {
-  id: Bytes!                          # EOA address
-  role: String!                       # MASTER_EOA | AGENT_EOA
-  masterSafe: MasterSafe              # backref (always set for MASTER_EOA)
-  service: Service                    # set for AGENT_EOA; null for MASTER_EOA shared across services
-  firstTrackedBlock: BigInt!          # block at which we first identified this EOA
+# Rev. 8 — consolidates the original TrackedSafe (MASTER / AGENT) and TrackedEOA
+# (MASTER_EOA / AGENT_EOA) into one immutable table, plus the STAKING role for
+# indexed staking proxies. One load per address lets classifyTransfer do two
+# hot-path reads (from + to) instead of six. Immutable: upserts early-return on
+# an existing row and nothing mutates it. Populated by getOrCreateMasterSafe
+# (Phase 1), RegisterInstance (agent EOAs), and the StakingFactory handler.
+type TrackedAddress @entity(immutable: true) {
+  id: Bytes!                          # tracked address
+  role: String!                       # MASTER | AGENT | MASTER_EOA | AGENT_EOA | STAKING
+  masterSafe: MasterSafe              # null for STAKING (and any AGENT_EOA not yet linked)
+  service: Service                    # null for MASTER / MASTER_EOA / STAKING
+  firstTrackedBlock: BigInt!          # block at which we first identified this address
 }
 
 type TokenBalance @entity(immutable: false) {
@@ -1132,7 +1153,7 @@ How the work was sequenced (✅ = merged to `main`):
 1. ✅ **Plan** (this PR, #129) + **Scaffold** (#130) — `subgraphs/pearl-transactions/` skeleton + `ci.yml` matrix entry.
 2. ✅ **Phase 1a** (#131) — `ServiceRegistryL2` handlers; `ServiceRegistryTokenUtility` `TokenDeposit` / `TokenRefund`; `Service` / `MasterSafe` / `AgentSafe` / NFT custody; `getOrCreateMasterSafe` (`getOwners()` eth_call + `SAFE_DEPLOYED`); two `SERVICE_BOND_DEPOSIT` / `_REFUND` rows with the producer/consumer bond queue. (#131 also fixed the SRTU-before-SR ordering + the non-Safe NFT guard.)
 3. ✅ **Phase 1b** (#132) — `StakingFactory` + `StakingProxy`; `STAKING_REWARD_CLAIM` / `UNSTAKE_REWARD` / `SERVICE_EVICTED`; `DailyServiceFunds`.
-4. ✅ **Phase 2a** (#133) — OLAS + WrappedNative `Transfer` data sources + per-Safe `Safe` template; `classifyTransfer`; `TrackedSafe` / `TrackedEOA` / `TokenBalance` / `Token`; `AgentFundingEvent`; `SAFE_SETUP_TRANSFER` (first live inbound hop) + `historyFloorBlock` per the Path A decision (§6.2); owner-list maintenance.
+4. ✅ **Phase 2a** (#133) — OLAS + WrappedNative `Transfer` data sources + per-Safe `Safe` template; `classifyTransfer`; `TrackedAddress` (Rev. 8; originally `TrackedSafe` + `TrackedEOA`) / `TokenBalance` / `Token`; `AgentFundingEvent`; `SAFE_SETUP_TRANSFER` (first live inbound hop) + `historyFloorBlock` per the Path A decision (§6.2); owner-list maintenance.
 5. 🔄 **Phase 2b** (#138, in review) — stablecoin `Transfer` data sources (USDC / USDC.e / pUSD per chain, §6.3); on-chain path chosen, the §6.3a Polygon sync benchmark deferred.
 
 **§11 #6** (graph-node backdated `startBlock`) was verified NOT SUPPORTED — Path B is dead; AC #3 resolved via Path A (§6.2), so there is no "option 1 vs option 2" decision left.
@@ -1185,7 +1206,7 @@ Matchstick (`matchstick-as` 0.6.0), mirroring the repo's existing suites.
   row; **Master Safe → SRTU OLAS Transfer produces a row with
   `category = SERVICE_BOND_DEPOSIT`, `source = RAW_TRANSFER` and
   consumers filtering by `source = SEMANTIC` see only the two typed
-  bond rows from Phase 1**; **Master EOA in `TrackedEOA` set —
+  bond rows from Phase 1**; **Master EOA in `TrackedAddress` set (MASTER_EOA role) —
   Master EOA → Master Safe OLAS transfer triggers `SAFE_SETUP_TRANSFER`
   on first qualifying inbound and `MASTER_FUNDING_IN` afterwards;
   Master EOA → unrelated EOA classified `OTHER`, not silently dropped**;

--- a/subgraphs/pearl-transactions/CLAUDE.md
+++ b/subgraphs/pearl-transactions/CLAUDE.md
@@ -15,7 +15,7 @@ the consumer.)
 |---|---|---|
 | 1a | #131 | `ServiceRegistryL2` + `ServiceRegistryTokenUtility`; `Service` / `MasterSafe` / `AgentSafe`; Master EOA via `getOwners()`; `SAFE_DEPLOYED`; SRTU bond deposit/refund rows |
 | 1b | #132 | `StakingFactory` + `StakingProxy` template; reward / unstake / eviction rows; `DailyServiceFunds` |
-| 2a | #133 | OLAS + WrappedNative `Transfer` + per-Safe `Safe` template; `classifyTransfer`; `TrackedSafe`/`TrackedEOA`/`TokenBalance`/`Token`; `AgentFundingEvent`; `SAFE_SETUP_TRANSFER` + `historyFloorBlock` (Path A) |
+| 2a | #133 | OLAS + WrappedNative `Transfer` + per-Safe `Safe` template; `classifyTransfer`; `TrackedAddress` (consolidated from the original `TrackedSafe`+`TrackedEOA`)/`TokenBalance`/`Token`; `AgentFundingEvent`; `SAFE_SETUP_TRANSFER` + `historyFloorBlock` (Path A) |
 | 2b | #138 | Per-chain stablecoin `Transfer` data sources — USDC / USDC.e / pUSD |
 
 **Deployed:** `pearl-gnosis-transactions` + `pearl-polygon-transactions`

--- a/subgraphs/pearl-transactions/CLAUDE.md
+++ b/subgraphs/pearl-transactions/CLAUDE.md
@@ -128,6 +128,18 @@ deploy; watch Polygon USDC.e sync (the §2.2 cost hotspot).
 
 - `bondType` attribution is best-effort; unmodeled call orderings leave it
   null but preserve the amount.
+- **Master Safe → Master Safe transfers** (funds migration between Pearl
+  installs) classify `MASTER_FUNDING_IN` for the recipient; both sides'
+  `TokenBalance` are updated (the sender debit rides on
+  `ClassifyResult.senderMasterId`), but the sender's masterSafe-filtered
+  HISTORY shows no outgoing row — same accepted shape as the native-out gap.
+- **`AgentFundingEvent.totalOlasAmount` is OLAS-only** (the bump is gated on
+  the token); same-tx stablecoin funding legs link via `transfers` but don't
+  contribute to either total.
+- The **bond legs' `TokenBalance` deltas are booked by the SRTU handlers**
+  (`handleTokenDeposit` debit / `handleTokenRefund` credit) — the raw
+  Master ↔ SRTU `Transfer` is suppressed in `classifyTransfer`, so the
+  balance effect lands exactly once.
 - SRTU bond rows are **token-secured-only**. Every `TokenDeposit` /
   `TokenRefund` emit in `ServiceRegistryTokenUtility` sits inside an
   `if (token != address(0))` guard, so ETH/native-secured services emit no
@@ -168,7 +180,7 @@ deploy; watch Polygon USDC.e sync (the §2.2 cost hotspot).
 
 ## Tests
 
-48 Matchstick tests across `tests/service-registry.test.ts` (Phase 1a),
+53 Matchstick tests across `tests/service-registry.test.ts` (Phase 1a),
 `tests/staking.test.ts` (Phase 1b), `tests/phase-2a.test.ts` (Phase 2a + the
 Phase-2b stablecoin suite — all 8 (chain, token) tuples). `yarn test`.
 

--- a/subgraphs/pearl-transactions/CLAUDE.md
+++ b/subgraphs/pearl-transactions/CLAUDE.md
@@ -33,10 +33,16 @@ deploy; watch Polygon USDC.e sync (the §2.2 cost hotspot).
   `historyFloorBlock`, `setupTransferSeen`), `AgentSafe`, `Service`
   (`agentIds`/`operators` consumer-filter lists, `state`, `nftCustodian`,
   `currentStakingContract`, `totalOlasRewardsClaimed`), `StakingContract`.
-- **Ledger:** `FundsMovement` (**`immutable: false`** — see bond queue
-  below), `DailyServiceFunds`, `ServiceNftCustodyChange`,
-  `AgentFundingEvent`.
-- **Phase-2 tracking:** `Token`, `TrackedSafe`, `TrackedEOA`, `TokenBalance`.
+- **Ledger:** `FundsMovement` (**`immutable: true`** — the bond rows that used
+  to be backfilled now live in a separate mutable `BondMovement` entity, so the
+  high-cardinality ledger skips block-range versioning), `BondMovement`
+  (SRTU bond deposit/refund; mutable, backfilled via the queue),
+  `DailyServiceFunds`, `ServiceNftCustodyChange`, `AgentFundingEvent`.
+  **Consumer note:** a complete ledger is `FundsMovement` **∪** `BondMovement`.
+- **Phase-2 tracking:** `Token` (immutable), `TrackedAddress` (immutable —
+  one table for MASTER / AGENT / MASTER_EOA / AGENT_EOA / STAKING roles,
+  replacing the old `TrackedSafe`+`TrackedEOA`; halves `classifyTransfer`'s
+  hot-path loads from 6 → 2), `TokenBalance`.
 - **Internal helpers:** `ServiceIndex`, `PendingRegistration`,
   `PendingBondCounter`, `PendingBondRow`, `AgentBondAttributionGuard`.
 - **Enums:** `FundsCategory`, `ServiceBondType`, `FundsSource`.
@@ -93,12 +99,13 @@ deploy; watch Polygon USDC.e sync (the §2.2 cost hotspot).
   on-chain the SRTU event fires **before** its `ServiceRegistryL2`
   counterpart in every path (`ServiceManager` calls `*TokenDeposit`/
   `*TokenRefund` before the registry fn), so the **SRTU handler is the
-  producer** (creates the `FundsMovement` row + enqueues its id) and the
+  producer** (creates the `BondMovement` row + enqueues its id) and the
   **`ServiceRegistryL2` handler is the consumer** (dequeues + backfills
-  `serviceId` + `bondType`). Hence `FundsMovement` is mutable. `bondType`
-  stays null when no SR event follows.
-- **`classifyTransfer`** — routes `(from, to)` against `TrackedSafe` /
-  `TrackedEOA` / `StakingContract` / SRTU / ServiceRegistryL2, most-specific
+  `serviceId` + `bondType`). Bond rows are the only backfilled rows, so they
+  live in the mutable `BondMovement` entity (letting `FundsMovement` stay
+  immutable). `bondType` stays null when no SR event follows.
+- **`classifyTransfer`** — two `TrackedAddress` loads (`from` + `to`) route
+  `(from, to)` by role against SRTU / ServiceRegistryL2, most-specific
   first, into the `FundsCategory` (`MASTER_FUNDING_IN`, `MASTER_TO_AGENT`,
   `AGENT_TO_MASTER`, `MASTER_WITHDRAWAL`, `STAKING_REWARD_CLAIM`,
   `SAFE_SETUP_TRANSFER`, …). Returns null for untracked counterparties (row

--- a/subgraphs/pearl-transactions/CLAUDE.md
+++ b/subgraphs/pearl-transactions/CLAUDE.md
@@ -168,7 +168,7 @@ deploy; watch Polygon USDC.e sync (the §2.2 cost hotspot).
 
 ## Tests
 
-46 Matchstick tests across `tests/service-registry.test.ts` (Phase 1a),
+48 Matchstick tests across `tests/service-registry.test.ts` (Phase 1a),
 `tests/staking.test.ts` (Phase 1b), `tests/phase-2a.test.ts` (Phase 2a + the
 Phase-2b stablecoin suite — all 8 (chain, token) tuples). `yarn test`.
 

--- a/subgraphs/pearl-transactions/README.md
+++ b/subgraphs/pearl-transactions/README.md
@@ -13,12 +13,16 @@ transaction-history view (VLOP-73).
 
 ## What it covers
 
-A single `FundsMovement` ledger, classified per row, plus the entity graph
-(`MasterSafe` / `AgentSafe` / `Service` / `StakingContract`) and helpers
-(`AgentFundingEvent`, `TokenBalance`, `DailyServiceFunds`,
-`ServiceNftCustodyChange`).
+An immutable `FundsMovement` ledger, classified per row, plus a small mutable
+`BondMovement` ledger for SRTU bond deposits/refunds (the only rows that get
+backfilled — split out so `FundsMovement` can stay immutable). **A complete
+wallet ledger is `fundsMovements` ∪ `bondMovements`.** Entity graph:
+`MasterSafe` / `AgentSafe` / `Service` / `StakingContract`; helpers:
+`AgentFundingEvent`, `TokenBalance`, `DailyServiceFunds`,
+`ServiceNftCustodyChange`.
 
-`FundsMovement.category` values:
+Category values (`FundsCategory`, shared by both ledgers — the
+`SERVICE_BOND_*` values appear only on `BondMovement`):
 
 | Category | Meaning |
 |---|---|
@@ -29,7 +33,7 @@ A single `FundsMovement` ledger, classified per row, plus the entity graph
 | `MASTER_TO_AGENT` | Master Safe → Agent Safe/EOA (grouped via `AgentFundingEvent`) |
 | `AGENT_TO_MASTER` | Agent Safe → Master Safe in native / non-OLAS token |
 | `AGENT_OLAS_TO_MASTER` | Agent Safe → Master Safe in OLAS (reward sweeps + manual returns; split out so the wallet can exclude it at query time) |
-| `SERVICE_BOND_DEPOSIT` / `SERVICE_BOND_REFUND` | SRTU bond posted / refunded (with `bondType`) |
+| `SERVICE_BOND_DEPOSIT` / `SERVICE_BOND_REFUND` | SRTU bond posted / refunded (with `bondType`) — **`BondMovement` rows, not `FundsMovement`** |
 | `STAKING_REWARD_CLAIM` / `UNSTAKE_REWARD` / `SERVICE_EVICTED` | Staking events |
 | `AGENT_TO_APP` / `APP_TO_AGENT` / `OTHER` | App-contract flows / untyped |
 
@@ -44,6 +48,9 @@ Studio: `https://api.studio.thegraph.com/query/1716136/pearl-<network>-transacti
 
 ### Wallet history for a Master Safe
 
+A complete history is the union of the two ledgers — `bondType` lives only on
+`bondMovements`, and `Service.id` is Bytes, so read the numeric `serviceId`:
+
 ```graphql
 query History($safe: Bytes!) {
   fundsMovements(
@@ -56,10 +63,26 @@ query History($safe: Bytes!) {
     source
     amount
     token            # null = native coin
-    bondType
     from
     to
-    service { id }
+    service { serviceId }
+    agentSafe { id }
+    blockTimestamp
+    transactionHash
+  }
+  bondMovements(
+    where: { masterSafe: $safe }
+    orderBy: blockTimestamp
+    orderDirection: desc
+    first: 100
+  ) {
+    category         # SERVICE_BOND_DEPOSIT | SERVICE_BOND_REFUND
+    bondType         # SECURITY_DEPOSIT | AGENT_BOND (null if unattributed)
+    amount
+    token
+    from
+    to
+    service { serviceId }
     agentSafe { id }
     blockTimestamp
     transactionHash
@@ -104,7 +127,7 @@ emits no opening-balance row).
 yarn install
 yarn generate-manifests   # render per-network manifests
 yarn codegen
-yarn test                 # 44 Matchstick tests
+yarn test                 # 48 Matchstick tests
 ```
 
 See [`CLAUDE.md`](./CLAUDE.md) for architecture and

--- a/subgraphs/pearl-transactions/README.md
+++ b/subgraphs/pearl-transactions/README.md
@@ -127,7 +127,7 @@ emits no opening-balance row).
 yarn install
 yarn generate-manifests   # render per-network manifests
 yarn codegen
-yarn test                 # 48 Matchstick tests
+yarn test                 # 53 Matchstick tests
 ```
 
 See [`CLAUDE.md`](./CLAUDE.md) for architecture and

--- a/subgraphs/pearl-transactions/STEP5-VERIFICATION.md
+++ b/subgraphs/pearl-transactions/STEP5-VERIFICATION.md
@@ -68,11 +68,19 @@ For one Master Safe + service:
 query Rows($safe: Bytes!) {
   fundsMovements(where: { masterSafe: $safe }, orderBy: blockTimestamp,
                  orderDirection: desc, first: 100) {
-    category source amount token bondType from to
-    service { id } blockNumber transactionHash
+    category source amount token from to
+    service { serviceId } blockNumber transactionHash
+  }
+  bondMovements(where: { masterSafe: $safe }, orderBy: blockTimestamp,
+                orderDirection: desc, first: 100) {
+    category bondType amount token from to
+    service { serviceId } blockNumber transactionHash
   }
 }
 ```
+(Bond rows live in `bondMovements` — `bondType` no longer exists on
+`fundsMovements`, and `Service.id` is Bytes, so read the numeric `serviceId`.)
+
 Pick a service that has staked at least once and verify against the explorer:
 - [ ] **Stake:** two `SERVICE_BOND_DEPOSIT` rows (SECURITY_DEPOSIT + AGENT_BOND);
       amounts match the SRTU `TokenDeposit` logs in that tx

--- a/subgraphs/pearl-transactions/schema.graphql
+++ b/subgraphs/pearl-transactions/schema.graphql
@@ -47,8 +47,8 @@ type AgentSafe @entity(immutable: false) {
 }
 
 type Service @entity(immutable: false) {
-  id: ID!                             # serviceId as string
-  serviceId: BigInt!
+  id: Bytes!                          # serviceId as Bytes (Bytes.fromBigInt(serviceId)) — halves FK storage vs the old string id
+  serviceId: BigInt!                  # numeric service id (use this for display)
   agentIds: [Int!]!                   # deduplicated; from RegisterInstance — consumer filter
   operators: [Bytes!]!                # deduplicated; sub-cohort filter
   masterSafe: MasterSafe
@@ -64,8 +64,8 @@ type Service @entity(immutable: false) {
 # Staking proxy / "staking contract" — created on
 # StakingFactory.InstanceCreated for any allowed implementation. Config
 # snapshot is captured via contract calls at creation time; nothing
-# updates afterward.
-type StakingContract @entity(immutable: false) {
+# updates afterward — hence immutable.
+type StakingContract @entity(immutable: true) {
   id: Bytes!                          # staking proxy address
   implementation: Bytes!
   minStakingDeposit: BigInt!
@@ -117,12 +117,12 @@ enum FundsSource {
   RAW_TRANSFER                        # Direct ERC-20 / native Transfer (Phase 2)
 }
 
-type FundsMovement @entity(immutable: false) {
-  # Mutable: SRTU TokenDeposit/TokenRefund rows are created bondType/
-  # service-less and backfilled by the matching ServiceRegistryL2 handler
-  # later in the same tx (see PendingBondRow). All other rows are
-  # write-once in practice.
-  id: Bytes!                          # see §5.1; tx.hash.concatI32(logIndex) or a stable sub-index for synthetic rows
+type FundsMovement @entity(immutable: true) {
+  # Immutable: every FundsMovement is write-once. The only rows that were ever
+  # backfilled (SRTU bond deposit/refund) now live in BondMovement, so this
+  # high-cardinality ledger skips block-range versioning — cheaper writes AND
+  # cheaper reads (the consumer-facing queries).
+  id: Bytes!                          # tx.hash.concatI32(logIndex) or a stable sub-index for synthetic rows
   service: Service
   masterSafe: MasterSafe
   agentSafe: AgentSafe
@@ -130,10 +130,33 @@ type FundsMovement @entity(immutable: false) {
   epoch: BigInt                       # staking-side row only; from the StakingProxy event
   category: FundsCategory!
   source: FundsSource!
-  bondType: ServiceBondType           # nullable; populated for SERVICE_BOND_DEPOSIT/REFUND when attribution succeeds
   agentFundingEvent: AgentFundingEvent # Phase 2a backref — set for MASTER_TO_AGENT rows grouped by same-tx funding action
   token: Bytes                        # token address (null for SAFE_DEPLOYED / SERVICE_EVICTED / native rows where Token entity is implicit)
   amount: BigInt!                     # 0 for SAFE_DEPLOYED / SERVICE_EVICTED informational rows
+  from: Bytes!
+  to: Bytes!
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
+  transactionHash: Bytes!
+}
+
+# SRTU bond deposit / refund rows. Split out of FundsMovement because they are
+# the only rows that get mutated: the SRTU producer creates the row
+# serviceId/bondType-less and the matching ServiceRegistryL2 consumer backfills
+# serviceId + bondType + agentSafe later in the same tx (see PendingBondRow).
+# Isolating this small mutable entity lets FundsMovement stay immutable.
+# Consumer note: the wallet must union FundsMovement + BondMovement for a
+# complete ledger (bond rows are no longer in FundsMovement).
+type BondMovement @entity(immutable: false) {
+  id: Bytes!                          # tx.hash.concatI32(logIndex)
+  service: Service
+  masterSafe: MasterSafe
+  agentSafe: AgentSafe
+  category: FundsCategory!            # SERVICE_BOND_DEPOSIT | SERVICE_BOND_REFUND
+  source: FundsSource!
+  bondType: ServiceBondType           # nullable; populated when attribution succeeds
+  token: Bytes
+  amount: BigInt!
   from: Bytes!
   to: Bytes!
   blockNumber: BigInt!
@@ -205,7 +228,7 @@ type PendingBondCounter @entity(immutable: false) {
 # OperatorUnbond) backfills the row's serviceId + bondType.
 type PendingBondRow @entity(immutable: false) {
   id: Bytes!                          # tx.hash.concatI32(slot)
-  fundsMovement: Bytes!               # FundsMovement id awaiting serviceId + bondType
+  bondMovement: Bytes!                # BondMovement id awaiting serviceId + bondType
   attributed: Boolean!
 }
 
@@ -220,31 +243,23 @@ type AgentBondAttributionGuard @entity(immutable: true) {
 
 # --- Phase 2a — raw token / native ledger ----------------------------
 
-# Token metadata snapshot. Populated lazily on first encounter.
-type Token @entity(immutable: false) {
+# Token metadata snapshot. Populated lazily on first encounter, first-write-
+# wins — never updated, hence immutable.
+type Token @entity(immutable: true) {
   id: Bytes!                          # token address
   symbol: String!
   decimals: Int!
 }
 
-# A Master Safe or Agent Safe we actively watch. Populated when the
-# entity becomes known via the registry / staking path. Lookup of
-# from/to in the OLAS Transfer handler routes through this table.
-type TrackedSafe @entity(immutable: false) {
-  id: Bytes!                          # Safe address
-  role: String!                       # MASTER | AGENT
-  service: Service                    # null for MASTER (a Master Safe owns multiple services)
-  masterSafe: MasterSafe!
-}
-
-# A Master EOA or Agent EOA we actively watch. Master EOAs are added
-# in Phase 1a via getOrCreateMasterSafe's getOwners(); agent EOAs come
-# from RegisterInstance.agentInstance.
-type TrackedEOA @entity(immutable: false) {
-  id: Bytes!                          # EOA address
-  role: String!                       # MASTER_EOA | AGENT_EOA
-  masterSafe: MasterSafe              # null for AGENT_EOA shared across services
-  service: Service                    # null for MASTER_EOA
+# Every address we actively watch — Master/Agent Safe, Master/Agent EOA, and
+# staking proxy — collapsed into one table so the hot path (classifyTransfer)
+# does TWO loads per transfer (from + to) instead of six. Write-once, hence
+# immutable: upserts early-return on an existing row and nothing mutates it.
+type TrackedAddress @entity(immutable: true) {
+  id: Bytes!                          # tracked address
+  role: String!                       # MASTER | AGENT | MASTER_EOA | AGENT_EOA | STAKING
+  masterSafe: MasterSafe              # null for STAKING (and any AGENT_EOA not yet linked)
+  service: Service                    # null for MASTER / MASTER_EOA / STAKING
   firstTrackedBlock: BigInt!
 }
 

--- a/subgraphs/pearl-transactions/schema.graphql
+++ b/subgraphs/pearl-transactions/schema.graphql
@@ -2,7 +2,7 @@
 #
 # Matches IMPLEMENTATION-PLAN.md §5.1 (semantic ledger) + §6.5 (raw
 # ledger). Phase 2b additions (USDC/USDC.e Transfer data sources) reuse
-# Token / TrackedSafe / TokenBalance and add no new schema; they
+# Token / TrackedAddress / TokenBalance and add no new schema; they
 # arrive in their own PR (benchmark + product-gated per §6.3).
 
 # --- Structural -------------------------------------------------------

--- a/subgraphs/pearl-transactions/src/constants.ts
+++ b/subgraphs/pearl-transactions/src/constants.ts
@@ -72,21 +72,34 @@ const SRTU_POLYGON = "0xa45E64d13A30a51b91ae0eb182e88a40e9b18eD8";
 const SRTU_OPTIMISM = "0xBb7e1D6Cb6F243D6bdE81CE92a9f2aFF7Fbe7eac";
 const SRTU_BASE = "0x34C895f302D0b5cf52ec0Edd3945321EB0f83dd5";
 
+// Memoized: classifyTransfer calls this on EVERY indexed transfer (millions
+// of chain-wide noise events), and Address.fromString re-parses the hex
+// literal each call. The network is fixed per deployment, so cache the
+// resolved address; keyed by network string so tests that switch networks
+// (dataSourceMock.setNetwork) stay correct.
+let srtuCacheNetwork: string = "";
+let srtuCacheAddr: Address | null = null;
+
 export function getSrtuAddress(network: string): Address {
+  if (srtuCacheAddr !== null && srtuCacheNetwork == network) {
+    return srtuCacheAddr as Address;
+  }
+  let addr: Address;
   if (network == "gnosis" || network == "xdai") {
-    return Address.fromString(SRTU_GNOSIS);
+    addr = Address.fromString(SRTU_GNOSIS);
+  } else if (network == "matic" || network == "polygon") {
+    addr = Address.fromString(SRTU_POLYGON);
+  } else if (network == "optimism") {
+    addr = Address.fromString(SRTU_OPTIMISM);
+  } else if (network == "base") {
+    addr = Address.fromString(SRTU_BASE);
+  } else {
+    log.critical("Unsupported network in getSrtuAddress: {}", [network]);
+    addr = Address.zero();
   }
-  if (network == "matic" || network == "polygon") {
-    return Address.fromString(SRTU_POLYGON);
-  }
-  if (network == "optimism") {
-    return Address.fromString(SRTU_OPTIMISM);
-  }
-  if (network == "base") {
-    return Address.fromString(SRTU_BASE);
-  }
-  log.critical("Unsupported network in getSrtuAddress: {}", [network]);
-  return Address.zero();
+  srtuCacheNetwork = network;
+  srtuCacheAddr = addr;
+  return addr;
 }
 
 // ServiceRegistryL2 address resolver (mirrors networks.json). Used by

--- a/subgraphs/pearl-transactions/src/constants.ts
+++ b/subgraphs/pearl-transactions/src/constants.ts
@@ -37,6 +37,15 @@ export const BOND_TYPE_AGENT_BOND = "AGENT_BOND";
 export const SOURCE_SEMANTIC = "SEMANTIC";
 export const SOURCE_RAW_TRANSFER = "RAW_TRANSFER";
 
+// TrackedAddress role string values. Roles are write-once (the entity is
+// immutable), so a typo'd literal would be a permanent silent
+// misclassification — always use these constants.
+export const ROLE_MASTER = "MASTER";
+export const ROLE_AGENT = "AGENT";
+export const ROLE_MASTER_EOA = "MASTER_EOA";
+export const ROLE_AGENT_EOA = "AGENT_EOA";
+export const ROLE_STAKING = "STAKING";
+
 // OLAS token address resolver. Used to tag the SAFE_DEPLOYED row's
 // `token` field as null (no token) and later for raw-transfer
 // classification in Phase 2a.

--- a/subgraphs/pearl-transactions/src/erc20.ts
+++ b/subgraphs/pearl-transactions/src/erc20.ts
@@ -3,7 +3,14 @@ import { Transfer as TransferEvent } from "../generated/OLAS/ERC20";
 import { FundsMovement } from "../generated/schema";
 import {
   CATEGORY_AGENT_OLAS_TO_MASTER,
+  CATEGORY_AGENT_TO_APP,
   CATEGORY_AGENT_TO_MASTER,
+  CATEGORY_APP_TO_AGENT,
+  CATEGORY_MASTER_FUNDING_IN,
+  CATEGORY_MASTER_TO_AGENT,
+  CATEGORY_MASTER_WITHDRAWAL,
+  CATEGORY_SAFE_SETUP_TRANSFER,
+  CATEGORY_STAKING_REWARD_CLAIM,
   SOURCE_RAW_TRANSFER,
   getOlasAddress,
 } from "./constants";
@@ -79,7 +86,7 @@ export function handleErc20Transfer(event: TransferEvent): void {
   // SAFE_SETUP_TRANSFER → flip the MasterSafe flag so subsequent
   // hops are MASTER_FUNDING_IN.
   if (
-    classification.category == "SAFE_SETUP_TRANSFER" &&
+    classification.category == CATEGORY_SAFE_SETUP_TRANSFER &&
     classification.masterSafeId !== null
   ) {
     markSetupTransferSeen(classification.masterSafeId!);
@@ -87,7 +94,7 @@ export function handleErc20Transfer(event: TransferEvent): void {
 
   // MASTER_TO_AGENT → group under AgentFundingEvent.
   if (
-    classification.category == "MASTER_TO_AGENT" &&
+    classification.category == CATEGORY_MASTER_TO_AGENT &&
     classification.masterSafeId !== null &&
     classification.service !== null
   ) {
@@ -98,7 +105,15 @@ export function handleErc20Transfer(event: TransferEvent): void {
       event
     );
     row.agentFundingEvent = afe.id;
-    addToAgentFundingEvent(afe, amount, /* isNative = */ false);
+    // totalOlasAmount is documented as OLAS-only, but this handler serves
+    // every ERC-20 data source — gate the bump on the token actually being
+    // OLAS so a same-tx OLAS + stablecoin funding doesn't sum mixed-decimal
+    // raw units into one number. Non-OLAS legs still link via `transfers`.
+    if (token.equals(getOlasAddress(currentNetwork()))) {
+      addToAgentFundingEvent(afe, amount, /* isNative = */ false);
+    } else {
+      afe.save();
+    }
   }
 
   row.save();
@@ -107,22 +122,22 @@ export function handleErc20Transfer(event: TransferEvent): void {
   // moves balances exactly like AGENT_TO_MASTER (only the category label
   // differs), so it appears in the same branches.
   if (
-    classification.category == "SAFE_SETUP_TRANSFER" ||
-    classification.category == "MASTER_FUNDING_IN" ||
-    classification.category == "AGENT_TO_MASTER" ||
-    classification.category == "AGENT_OLAS_TO_MASTER" ||
-    classification.category == "APP_TO_AGENT" ||
-    classification.category == "STAKING_REWARD_CLAIM"
+    classification.category == CATEGORY_SAFE_SETUP_TRANSFER ||
+    classification.category == CATEGORY_MASTER_FUNDING_IN ||
+    classification.category == CATEGORY_AGENT_TO_MASTER ||
+    classification.category == CATEGORY_AGENT_OLAS_TO_MASTER ||
+    classification.category == CATEGORY_APP_TO_AGENT ||
+    classification.category == CATEGORY_STAKING_REWARD_CLAIM
   ) {
     // "to" is the tracked safe receiving funds.
     upsertTokenBalance(to, token, amount, event, /* isDelta = */ true);
   }
   if (
-    classification.category == "MASTER_WITHDRAWAL" ||
-    classification.category == "MASTER_TO_AGENT" ||
-    classification.category == "AGENT_TO_APP" ||
-    classification.category == "AGENT_TO_MASTER" ||
-    classification.category == "AGENT_OLAS_TO_MASTER"
+    classification.category == CATEGORY_MASTER_WITHDRAWAL ||
+    classification.category == CATEGORY_MASTER_TO_AGENT ||
+    classification.category == CATEGORY_AGENT_TO_APP ||
+    classification.category == CATEGORY_AGENT_TO_MASTER ||
+    classification.category == CATEGORY_AGENT_OLAS_TO_MASTER
   ) {
     // "from" sends funds; bump down.
     upsertTokenBalance(
@@ -134,8 +149,14 @@ export function handleErc20Transfer(event: TransferEvent): void {
     );
   }
   // MASTER_TO_AGENT updates both sides.
-  if (classification.category == "MASTER_TO_AGENT") {
+  if (classification.category == CATEGORY_MASTER_TO_AGENT) {
     upsertTokenBalance(to, token, amount, event, /* isDelta = */ true);
+  }
+  // Master Safe → Master Safe (funds migration): the row classifies as
+  // MASTER_FUNDING_IN for the recipient (credited above); senderMasterId
+  // carries the sending Master Safe so its balance is debited too.
+  if (classification.senderMasterId !== null) {
+    upsertTokenBalance(from, token, amount.neg(), event, /* isDelta = */ true);
   }
   // AGENT_TO_MASTER / AGENT_OLAS_TO_MASTER also update the Master side;
   // handled above for "to".

--- a/subgraphs/pearl-transactions/src/safe.ts
+++ b/subgraphs/pearl-transactions/src/safe.ts
@@ -102,11 +102,11 @@ function emitNativeOutPlaceholder(
 ): void {
   // Only emit if `safeAddr` is a tracked safe — otherwise the event
   // came from an unrelated Safe that shares the template.
-  // (TrackedSafe.load is checked indirectly via classifyTransfer
+  // (TrackedAddress.load is checked indirectly via classifyTransfer
   // when from/to side matters; for placeholder we just need the safe
   // tracked-ness.)
   const masterSafe = MasterSafe.load(safeAddr);
-  // TrackedSafe lookup is more direct but a MasterSafe entity exists
+  // TrackedAddress lookup is more direct but a MasterSafe entity exists
   // iff the safe was first-sighted as a Master Safe. Agent Safes
   // don't get MasterSafe entities, so we'd miss them here. Use
   // classifyTransfer with a synthetic zero-address "from" instead

--- a/subgraphs/pearl-transactions/src/safe.ts
+++ b/subgraphs/pearl-transactions/src/safe.ts
@@ -1,4 +1,4 @@
-import { Address, BigInt, Bytes, ethereum, log } from "@graphprotocol/graph-ts";
+import { Bytes } from "@graphprotocol/graph-ts";
 import {
   AddedOwner as AddedOwnerEvent,
   ChangedThreshold as ChangedThresholdEvent,
@@ -10,6 +10,7 @@ import {
 import { FundsMovement, MasterSafe } from "../generated/schema";
 import {
   CATEGORY_MASTER_FUNDING_IN,
+  CATEGORY_MASTER_TO_AGENT,
   CATEGORY_SAFE_SETUP_TRANSFER,
   SOURCE_RAW_TRANSFER,
 } from "./constants";
@@ -60,7 +61,7 @@ export function handleSafeReceived(event: SafeReceivedEvent): void {
     markSetupTransferSeen(classification.masterSafeId!);
   }
   if (
-    classification.category == "MASTER_TO_AGENT" &&
+    classification.category == CATEGORY_MASTER_TO_AGENT &&
     classification.masterSafeId !== null &&
     classification.service !== null
   ) {
@@ -78,45 +79,23 @@ export function handleSafeReceived(event: SafeReceivedEvent): void {
 }
 
 // handleSafeExecutionSuccess / handleSafeExecutionFromModuleSuccess
-// — native OUT events. Approximate per plan §6.2 / babydegen pattern:
-// Safes executing via a relayer carry value=0 on the outer tx, so we
-// cannot read the moved amount from these events alone. We record a
-// zero-amount placeholder row so the consumer wallet UI can show
-// "Safe executed an outbound tx" without claiming a precise amount.
-// Phase 2b+ could swap this for call/trace handlers if cost permits.
+// — native OUT events. Intentional no-ops for v1: ExecutionSuccess carries
+// no amount/recipient (Safes executing via a relayer carry value=0 on the
+// outer tx), so precise native-out tracking requires call/trace handlers —
+// see plan §6.2 honest-limits doc and the Phase 2b+ option. Deliberately
+// NO store access here: these fire on every execution of every Safe that
+// shares the template, so even a single load would be pure hot-path waste.
 export function handleSafeExecutionSuccess(
   event: ExecutionSuccessEvent
 ): void {
-  emitNativeOutPlaceholder(event.address, event);
+  // no-op (see above)
 }
 
 export function handleSafeExecutionFromModuleSuccess(
   event: ExecutionFromModuleSuccessEvent
 ): void {
-  emitNativeOutPlaceholder(event.address, event);
+  // no-op (see above)
 }
-
-function emitNativeOutPlaceholder(
-  safeAddr: Address,
-  event: ethereum.Event
-): void {
-  // Only emit if `safeAddr` is a tracked safe — otherwise the event
-  // came from an unrelated Safe that shares the template.
-  // (TrackedAddress.load is checked indirectly via classifyTransfer
-  // when from/to side matters; for placeholder we just need the safe
-  // tracked-ness.)
-  const masterSafe = MasterSafe.load(safeAddr);
-  // TrackedAddress lookup is more direct but a MasterSafe entity exists
-  // iff the safe was first-sighted as a Master Safe. Agent Safes
-  // don't get MasterSafe entities, so we'd miss them here. Use
-  // classifyTransfer with a synthetic zero-address "from" instead
-  // to determine tracked-ness; for now, skip the placeholder if
-  // neither MasterSafe nor an AgentSafe entity exists — the
-  // refinement is a Phase 2a.ii follow-up.
-}
-// NOTE: emitNativeOutPlaceholder is intentionally a no-op for v1.
-// Precise native-out tracking requires call/trace handlers — see
-// plan §6.2 honest-limits doc and the Phase 2b+ option.
 
 // handleSafeAddedOwner / handleSafeRemovedOwner /
 // handleSafeChangedThreshold — keep MasterSafe.owners / masterEoa /

--- a/subgraphs/pearl-transactions/src/service-registry-token-utility.ts
+++ b/subgraphs/pearl-transactions/src/service-registry-token-utility.ts
@@ -3,7 +3,7 @@ import {
   TokenDeposit as TokenDepositEvent,
   TokenRefund as TokenRefundEvent,
 } from "../generated/ServiceRegistryTokenUtility/ServiceRegistryTokenUtility";
-import { FundsMovement, TrackedSafe } from "../generated/schema";
+import { BondMovement, TrackedAddress } from "../generated/schema";
 import {
   CATEGORY_SERVICE_BOND_DEPOSIT,
   CATEGORY_SERVICE_BOND_REFUND,
@@ -13,12 +13,12 @@ import { enqueuePendingBondRow, fundsMovementId } from "./utils";
 
 // linkBondMasterSafe — the SRTU `account` is the bond payer, which in
 // Pearl is the Master Safe. Stamp it onto the SEMANTIC bond row so the
-// wallet (which filters FundsMovement by masterSafe) surfaces this row
+// wallet (which filters BondMovement by masterSafe) surfaces this row
 // directly — the RAW_TRANSFER duplicate that used to carry the link is
 // now suppressed in classifyTransfer. Guarded to addresses already
 // tracked as MASTER so non-Pearl bonds stay unlinked.
-function linkBondMasterSafe(row: FundsMovement, account: Address): void {
-  const tracked = TrackedSafe.load(account);
+function linkBondMasterSafe(row: BondMovement, account: Address): void {
+  const tracked = TrackedAddress.load(account);
   if (tracked != null && tracked.role == "MASTER") {
     row.masterSafe = tracked.masterSafe;
   }
@@ -33,7 +33,7 @@ function linkBondMasterSafe(row: FundsMovement, account: Address): void {
 // backfills serviceId + bondType via dequeueAndAttribute. If no such
 // event follows, the row stays attribution-less (amount preserved).
 export function handleTokenDeposit(event: TokenDepositEvent): void {
-  const row = new FundsMovement(fundsMovementId(event));
+  const row = new BondMovement(fundsMovementId(event));
   row.category = CATEGORY_SERVICE_BOND_DEPOSIT;
   row.source = SOURCE_SEMANTIC;
   row.token = event.params.token;
@@ -53,7 +53,7 @@ export function handleTokenDeposit(event: TokenDepositEvent): void {
 // cycle. Backfilled by the following TerminateService (SECURITY_DEPOSIT)
 // or OperatorUnbond (AGENT_BOND) ServiceRegistryL2 event in the same tx.
 export function handleTokenRefund(event: TokenRefundEvent): void {
-  const row = new FundsMovement(fundsMovementId(event));
+  const row = new BondMovement(fundsMovementId(event));
   row.category = CATEGORY_SERVICE_BOND_REFUND;
   row.source = SOURCE_SEMANTIC;
   row.token = event.params.token;

--- a/subgraphs/pearl-transactions/src/service-registry-token-utility.ts
+++ b/subgraphs/pearl-transactions/src/service-registry-token-utility.ts
@@ -7,21 +7,24 @@ import { BondMovement, TrackedAddress } from "../generated/schema";
 import {
   CATEGORY_SERVICE_BOND_DEPOSIT,
   CATEGORY_SERVICE_BOND_REFUND,
+  ROLE_MASTER,
   SOURCE_SEMANTIC,
 } from "./constants";
-import { enqueuePendingBondRow, fundsMovementId } from "./utils";
+import {
+  enqueuePendingBondRow,
+  fundsMovementId,
+  upsertTokenBalance,
+} from "./utils";
 
-// linkBondMasterSafe — the SRTU `account` is the bond payer, which in
-// Pearl is the Master Safe. Stamp it onto the SEMANTIC bond row so the
-// wallet (which filters BondMovement by masterSafe) surfaces this row
-// directly — the RAW_TRANSFER duplicate that used to carry the link is
-// now suppressed in classifyTransfer. Guarded to addresses already
-// tracked as MASTER so non-Pearl bonds stay unlinked.
-function linkBondMasterSafe(row: BondMovement, account: Address): void {
+// isTrackedMaster — the SRTU `account` is the bond payer, which in Pearl
+// is the Master Safe. Guarded to addresses already tracked as MASTER so
+// non-Pearl bonds stay unlinked (and don't touch TokenBalance).
+function isTrackedMaster(account: Address): TrackedAddress | null {
   const tracked = TrackedAddress.load(account);
-  if (tracked != null && tracked.role == "MASTER") {
-    row.masterSafe = tracked.masterSafe;
+  if (tracked != null && tracked.role == ROLE_MASTER) {
+    return tracked;
   }
+  return null;
 }
 
 // handleTokenDeposit — fires once per activateRegistrationTokenDeposit
@@ -32,6 +35,12 @@ function linkBondMasterSafe(row: BondMovement, account: Address): void {
 // ServiceRegistryL2 event (ActivateRegistration / RegisterInstance)
 // backfills serviceId + bondType via dequeueAndAttribute. If no such
 // event follows, the row stays attribution-less (amount preserved).
+//
+// TokenBalance: the raw Master Safe ↔ SRTU Transfer is suppressed in
+// classifyTransfer (deduped against this SEMANTIC row), so the bond's
+// balance effect is booked HERE, exactly once — otherwise the Master
+// Safe's balance would overstate by the bonded amount for the whole
+// staking period.
 export function handleTokenDeposit(event: TokenDepositEvent): void {
   const row = new BondMovement(fundsMovementId(event));
   row.category = CATEGORY_SERVICE_BOND_DEPOSIT;
@@ -40,7 +49,18 @@ export function handleTokenDeposit(event: TokenDepositEvent): void {
   row.amount = event.params.amount;
   row.from = event.params.account;
   row.to = event.address;
-  linkBondMasterSafe(row, event.params.account);
+  const master = isTrackedMaster(event.params.account);
+  if (master != null) {
+    row.masterSafe = master.masterSafe;
+    // Bond leaves the Master Safe → debit.
+    upsertTokenBalance(
+      event.params.account,
+      Address.fromBytes(event.params.token),
+      event.params.amount.neg(),
+      event,
+      /* isDelta = */ true
+    );
+  }
   row.blockNumber = event.block.number;
   row.blockTimestamp = event.block.timestamp;
   row.transactionHash = event.transaction.hash;
@@ -60,7 +80,18 @@ export function handleTokenRefund(event: TokenRefundEvent): void {
   row.amount = event.params.amount;
   row.from = event.address;
   row.to = event.params.account;
-  linkBondMasterSafe(row, event.params.account);
+  const master = isTrackedMaster(event.params.account);
+  if (master != null) {
+    row.masterSafe = master.masterSafe;
+    // Bond returns to the Master Safe → credit (mirror of the deposit debit).
+    upsertTokenBalance(
+      event.params.account,
+      Address.fromBytes(event.params.token),
+      event.params.amount,
+      event,
+      /* isDelta = */ true
+    );
+  }
   row.blockNumber = event.block.number;
   row.blockTimestamp = event.block.timestamp;
   row.transactionHash = event.transaction.hash;

--- a/subgraphs/pearl-transactions/src/service-registry.ts
+++ b/subgraphs/pearl-transactions/src/service-registry.ts
@@ -25,6 +25,7 @@ import {
   getOrCreateMasterSafe,
   getOrCreateService,
   isStakingContract,
+  serviceEntityId,
   setServiceIndex,
 } from "./utils";
 
@@ -42,7 +43,7 @@ export function handleRegisterInstance(event: RegisterInstanceEvent): void {
   const agentId = event.params.agentId.toI32();
   const operator = event.params.operator;
 
-  const existing = Service.load(serviceId.toString());
+  const existing = Service.load(serviceEntityId(serviceId));
   if (existing != null) {
     appendServiceRegistration(existing, agentId, operator);
     existing.updatedTimestamp = event.block.timestamp;
@@ -90,8 +91,9 @@ export function handleCreateMultisigWithAgents(
   service.state = SERVICE_STATE_DEPLOYED;
   service.updatedTimestamp = event.block.timestamp;
   drainPendingRegistration(service, serviceId);
-  service.save();
 
+  // Single save: getOrCreateAgentSafe reads the in-memory `service`, not the
+  // store, so persist once after both mutations land.
   const agentSafe = getOrCreateAgentSafe(multisig, service, event);
   service.agentSafe = agentSafe.id;
   service.save();

--- a/subgraphs/pearl-transactions/src/staking-factory.ts
+++ b/subgraphs/pearl-transactions/src/staking-factory.ts
@@ -3,7 +3,7 @@ import { InstanceCreated as InstanceCreatedEvent } from "../generated/StakingFac
 import { StakingProxy as StakingProxyTemplate } from "../generated/templates";
 import { StakingProxy as StakingProxyContract } from "../generated/templates/StakingProxy/StakingProxy";
 import { isAllowedImplementation } from "./constants";
-import { getOrCreateStakingContract } from "./utils";
+import { getOrCreateStakingContract, upsertTrackedAddress } from "./utils";
 
 // handleInstanceCreated — fires on every StakingFactory.InstanceCreated.
 //
@@ -49,6 +49,17 @@ export function handleInstanceCreated(event: InstanceCreatedEvent): void {
     minStakingDepositResult.value,
     numAgentInstancesResult.value,
     event
+  );
+
+  // Register the proxy as a TrackedAddress(STAKING) so classifyTransfer's hot
+  // path recognises staking-reward sends via the single tracked-address load
+  // (StakingContract stays as the config entity / NFT-guard lookup).
+  upsertTrackedAddress(
+    proxyAddress,
+    "STAKING",
+    null,
+    null,
+    event.block.number
   );
 
   StakingProxyTemplate.create(proxyAddress);

--- a/subgraphs/pearl-transactions/src/staking-factory.ts
+++ b/subgraphs/pearl-transactions/src/staking-factory.ts
@@ -2,7 +2,7 @@ import { log } from "@graphprotocol/graph-ts";
 import { InstanceCreated as InstanceCreatedEvent } from "../generated/StakingFactory/StakingFactory";
 import { StakingProxy as StakingProxyTemplate } from "../generated/templates";
 import { StakingProxy as StakingProxyContract } from "../generated/templates/StakingProxy/StakingProxy";
-import { isAllowedImplementation } from "./constants";
+import { ROLE_STAKING, isAllowedImplementation } from "./constants";
 import { getOrCreateStakingContract, upsertTrackedAddress } from "./utils";
 
 // handleInstanceCreated — fires on every StakingFactory.InstanceCreated.
@@ -56,7 +56,7 @@ export function handleInstanceCreated(event: InstanceCreatedEvent): void {
   // (StakingContract stays as the config entity / NFT-guard lookup).
   upsertTrackedAddress(
     proxyAddress,
-    "STAKING",
+    ROLE_STAKING,
     null,
     null,
     event.block.number

--- a/subgraphs/pearl-transactions/src/staking-proxy.ts
+++ b/subgraphs/pearl-transactions/src/staking-proxy.ts
@@ -39,7 +39,8 @@ export function handleServiceStaked(event: ServiceStakedEvent): void {
   service.state = SERVICE_STATE_STAKED;
   service.currentStakingContract = event.address;
   service.updatedTimestamp = event.block.timestamp;
-  service.save();
+  // Single save: neither getOrCreateMasterSafe nor getOrCreateAgentSafe reloads
+  // Service from the store, so persist once at the end (below).
 
   // `owner` is the Master Safe (ServiceStaked carries it explicitly), so
   // this is the canonical discovery path. getOrCreateMasterSafe returns

--- a/subgraphs/pearl-transactions/src/utils.ts
+++ b/subgraphs/pearl-transactions/src/utils.ts
@@ -236,9 +236,17 @@ export function getOrCreateAgentSafe(
   agentSafe.save();
 
   // Phase 2a: track as TrackedAddress (role=AGENT), spawn Safe template,
-  // and add any operators recorded on the Service so far as TrackedAddress
-  // (role=AGENT_EOA). Additional operators registered later are picked up
-  // incrementally in handleRegisterInstance.
+  // and add the operators recorded on the Service SO FAR as TrackedAddress
+  // (role=AGENT_EOA). Operators registered after this point are not added
+  // retroactively (handleRegisterInstance only appends to Service.operators)
+  // — accepted: Pearl's flow registers all instances before the multisig.
+  //
+  // LOAD-BEARING write-order invariant: in Pearl the Master Safe is also the
+  // service *operator*, so the loop below tries to write it as AGENT_EOA.
+  // That's safe only because TrackedAddress is write-once (upsert
+  // early-returns) and the MASTER row always lands first — the service-NFT
+  // mint / ServiceStaked path runs getOrCreateMasterSafe before any
+  // CreateMultisigWithAgents can reach this function. Don't reorder.
   if (service.masterSafe !== null) {
     upsertTrackedAddress(
       address,

--- a/subgraphs/pearl-transactions/src/utils.ts
+++ b/subgraphs/pearl-transactions/src/utils.ts
@@ -28,9 +28,21 @@ import { GnosisSafe } from "../generated/ServiceRegistryL2/GnosisSafe";
 import { Safe as SafeTemplate } from "../generated/templates";
 import {
   BOND_TYPE_AGENT_BOND,
+  CATEGORY_AGENT_TO_APP,
+  CATEGORY_AGENT_TO_MASTER,
+  CATEGORY_APP_TO_AGENT,
+  CATEGORY_MASTER_FUNDING_IN,
+  CATEGORY_MASTER_TO_AGENT,
+  CATEGORY_MASTER_WITHDRAWAL,
   CATEGORY_OTHER,
   CATEGORY_SAFE_DEPLOYED,
   CATEGORY_SAFE_SETUP_TRANSFER,
+  CATEGORY_STAKING_REWARD_CLAIM,
+  ROLE_AGENT,
+  ROLE_AGENT_EOA,
+  ROLE_MASTER,
+  ROLE_MASTER_EOA,
+  ROLE_STAKING,
   SERVICE_STATE_REGISTERED,
   SOURCE_SEMANTIC,
   getOlasAddress,
@@ -57,25 +69,27 @@ export function safeDeployedId(masterSafe: Bytes): Bytes {
   return Bytes.fromUTF8("safe-deployed:").concat(masterSafe);
 }
 
-export function serviceIndexId(serviceId: BigInt): Bytes {
-  return Bytes.fromByteArray(Bytes.fromBigInt(serviceId));
-}
-
-// Service.id is now Bytes (serviceId as Bytes) — halves FK storage / speeds
-// comparisons vs the old string id. Same byte layout as serviceIndexId.
+// Service.id is Bytes (serviceId as Bytes) — halves FK storage / speeds
+// comparisons vs the old string id. serviceIndexId / pendingRegistrationId
+// share the same byte layout; they alias this helper so the encoding has a
+// single source of truth.
 export function serviceEntityId(serviceId: BigInt): Bytes {
   return Bytes.fromByteArray(Bytes.fromBigInt(serviceId));
 }
 
+export function serviceIndexId(serviceId: BigInt): Bytes {
+  return serviceEntityId(serviceId);
+}
+
 export function pendingRegistrationId(serviceId: BigInt): Bytes {
-  return Bytes.fromByteArray(Bytes.fromBigInt(serviceId));
+  return serviceEntityId(serviceId);
 }
 
 export function agentBondAttributionGuardId(
   txHash: Bytes,
   serviceId: BigInt
 ): Bytes {
-  return txHash.concat(Bytes.fromByteArray(Bytes.fromBigInt(serviceId)));
+  return txHash.concat(serviceEntityId(serviceId));
 }
 
 export function pendingBondRowId(txHash: Bytes, slot: i32): Bytes {
@@ -172,7 +186,7 @@ export function getOrCreateMasterSafe(
   // MASTER_FUNDING_IN.
   upsertTrackedAddress(
     address,
-    "MASTER",
+    ROLE_MASTER,
     masterSafe.id,
     null,
     event.block.number
@@ -180,13 +194,22 @@ export function getOrCreateMasterSafe(
   if (masterSafe.masterEoa.length > 0 && !masterSafe.masterEoa.equals(Address.zero())) {
     upsertTrackedAddress(
       Address.fromBytes(masterSafe.masterEoa),
-      "MASTER_EOA",
+      ROLE_MASTER_EOA,
       masterSafe.id,
       null,
       event.block.number
     );
   }
-  SafeTemplate.create(address);
+  // Spawn the per-Safe template ONCE per address. The MasterSafe.load guard
+  // at the top of this function doesn't cover an address already spawned via
+  // getOrCreateAgentSafe (guarded on AgentSafe.load) — e.g. a service NFT
+  // transferred to an existing Agent Safe (it passes the getOwners() probe).
+  // A second template instance would process every SafeReceived log twice,
+  // and the duplicate FundsMovement save is a deterministic store error now
+  // that the entity is immutable (it was a silent overwrite before).
+  if (AgentSafe.load(address) == null) {
+    SafeTemplate.create(address);
+  }
 
   return masterSafe;
 }
@@ -240,32 +263,40 @@ export function getOrCreateAgentSafe(
   // (role=AGENT_EOA). Operators registered after this point are not added
   // retroactively (handleRegisterInstance only appends to Service.operators)
   // — accepted: Pearl's flow registers all instances before the multisig.
-  //
-  // LOAD-BEARING write-order invariant: in Pearl the Master Safe is also the
-  // service *operator*, so the loop below tries to write it as AGENT_EOA.
-  // That's safe only because TrackedAddress is write-once (upsert
-  // early-returns) and the MASTER row always lands first — the service-NFT
-  // mint / ServiceStaked path runs getOrCreateMasterSafe before any
-  // CreateMultisigWithAgents can reach this function. Don't reorder.
   if (service.masterSafe !== null) {
     upsertTrackedAddress(
       address,
-      "AGENT",
+      ROLE_AGENT,
       service.masterSafe,
       service.id,
       event.block.number
     );
   }
-  SafeTemplate.create(address);
-  const operators = service.operators;
-  for (let i = 0; i < operators.length; i++) {
-    upsertTrackedAddress(
-      Address.fromBytes(operators[i]),
-      "AGENT_EOA",
-      service.masterSafe,
-      service.id,
-      event.block.number
-    );
+  // Spawn the per-Safe template ONCE per address (see the matching guard in
+  // getOrCreateMasterSafe): a duplicate template instance would double-process
+  // SafeReceived logs and crash on the immutable FundsMovement re-save.
+  if (MasterSafe.load(address) == null) {
+    SafeTemplate.create(address);
+  }
+  // Operator rows are written ONLY for Pearl-linked services (masterSafe set),
+  // and the master safe itself is skipped — in Pearl the Master Safe is the
+  // service operator, and TrackedAddress is write-once + immutable, so writing
+  // it as AGENT_EOA before its MASTER row lands would permanently poison the
+  // role and route the user's entire wallet history to OTHER. The registry is
+  // permissionless, so a masterless (non-Pearl) service must not be able to
+  // pre-claim an address that later becomes a Pearl Master Safe.
+  if (service.masterSafe !== null) {
+    const operators = service.operators;
+    for (let i = 0; i < operators.length; i++) {
+      if (operators[i].equals(service.masterSafe!)) continue;
+      upsertTrackedAddress(
+        Address.fromBytes(operators[i]),
+        ROLE_AGENT_EOA,
+        service.masterSafe,
+        service.id,
+        event.block.number
+      );
+    }
   }
   return agentSafe;
 }
@@ -602,11 +633,17 @@ export function getOrCreateStakingContract(
 
 // --- Phase 2a — TrackedAddress / Token / TokenBalance ----------------
 
-// upsertTrackedAddress — idempotent, write-once. The single tracked-address
-// table behind classifyTransfer's hot path. `role` is MASTER | AGENT |
-// MASTER_EOA | AGENT_EOA | STAKING. `masterSafeId` is null for STAKING;
+// upsertTrackedAddress — idempotent, write-once (the entity is immutable).
+// The single tracked-address table behind classifyTransfer's hot path.
+// `role` is one of the ROLE_* constants. `masterSafeId` is null for STAKING;
 // `serviceId` is null for MASTER / MASTER_EOA / STAKING. Both ids are Bytes
 // (the related entity's id).
+//
+// First-write-wins caveat (accepted): an AGENT_EOA shared across services
+// keeps the FIRST service it was seen with — a second service's funding rows
+// to that EOA attribute to service #1. Harmless for masterSafe-filtered
+// wallet queries (the masterSafe link is the same); revisit only if
+// per-service attribution of shared operators ever matters.
 export function upsertTrackedAddress(
   address: Address,
   role: string,
@@ -707,11 +744,16 @@ export function upsertTokenBalance(
 // ClassifyResult — output of classifyTransfer. Carries category +
 // resolved service/masterSafe/agentSafe IDs so the OLAS handler
 // doesn't repeat the lookup. `service` is the Service.id (Bytes) or null.
+// `senderMasterId` is set ONLY for Master Safe → Master Safe transfers
+// (funds migration between Pearl installs): the row classifies as
+// MASTER_FUNDING_IN for the recipient, and this field carries the sending
+// Master Safe so handleErc20Transfer can debit its TokenBalance too.
 export class ClassifyResult {
   category: string;
   service: Bytes | null;
   masterSafeId: Bytes | null;
   agentSafeId: Bytes | null;
+  senderMasterId: Bytes | null = null;
   constructor(
     category: string,
     service: Bytes | null,
@@ -755,18 +797,23 @@ export function classifyTransfer(
   // Master Safe ↔ SRTU OLAS transfers are the on-chain bond movement, already
   // booked as the canonical SEMANTIC BondMovement row (and backfilled by the
   // consumer). A second RAW_TRANSFER row here would double-count in any
-  // masterSafe-filtered wallet query, so drop it. The OLAS TokenBalance delta
-  // is updated separately in handleErc20Transfer and is unaffected.
-  if (fromRole == "MASTER" && toIsSrtu) return null;
-  if (fromIsSrtu && toRole == "MASTER") return null;
+  // masterSafe-filtered wallet query, so drop it. NB: the early null return
+  // means handleErc20Transfer applies NO TokenBalance delta for these legs —
+  // the bond's balance effect is booked by the SRTU handlers
+  // (handleTokenDeposit / handleTokenRefund) instead, exactly once.
+  if (fromRole == ROLE_MASTER && toIsSrtu) return null;
+  if (fromIsSrtu && toRole == ROLE_MASTER) return null;
 
   // Master Safe → Agent Safe / Agent EOA → MASTER_TO_AGENT (grouped).
-  if (fromRole == "MASTER" && (toRole == "AGENT" || toRole == "AGENT_EOA")) {
+  if (
+    fromRole == ROLE_MASTER &&
+    (toRole == ROLE_AGENT || toRole == ROLE_AGENT_EOA)
+  ) {
     return new ClassifyResult(
-      "MASTER_TO_AGENT",
+      CATEGORY_MASTER_TO_AGENT,
       toT!.service,
       fromT!.masterSafe,
-      toRole == "AGENT" ? toT!.id : null
+      toRole == ROLE_AGENT ? toT!.id : null
     );
   }
 
@@ -774,9 +821,9 @@ export function classifyTransfer(
   // manual OLAS returns) is re-tagged AGENT_OLAS_TO_MASTER in
   // handleErc20Transfer after classification (the token isn't visible here);
   // native / non-OLAS stays AGENT_TO_MASTER.
-  if (fromRole == "AGENT" && toRole == "MASTER") {
+  if (fromRole == ROLE_AGENT && toRole == ROLE_MASTER) {
     return new ClassifyResult(
-      "AGENT_TO_MASTER",
+      CATEGORY_AGENT_TO_MASTER,
       fromT!.service,
       toT!.id,
       fromT!.id
@@ -785,17 +832,17 @@ export function classifyTransfer(
 
   // Staking proxy → Agent Safe — STAKING_REWARD_CLAIM (RAW_TRANSFER reconcile
   // of the semantically-booked Phase-1b row).
-  if (fromRole == "STAKING" && toRole == "AGENT") {
+  if (fromRole == ROLE_STAKING && toRole == ROLE_AGENT) {
     return new ClassifyResult(
-      "STAKING_REWARD_CLAIM",
+      CATEGORY_STAKING_REWARD_CLAIM,
       toT!.service,
       toT!.masterSafe,
       toT!.id
     );
   }
 
-  // EOA (Master EOA / other) → Master Safe.
-  if (toRole == "MASTER") {
+  // Anything → Master Safe (EOA deposit, app payout, another Master Safe).
+  if (toRole == ROLE_MASTER) {
     // ServiceRegistryL2 sends tiny native dust to the Master Safe during
     // terminate / unbond (1-wei xDAI refunds sharing a tx with a bond refund).
     // Protocol bookkeeping, not a user deposit → OTHER. The registry address is
@@ -803,31 +850,55 @@ export function classifyTransfer(
     if (from.equals(getServiceRegistryAddress(currentNetwork()))) {
       return new ClassifyResult(CATEGORY_OTHER, null, toT!.id, null);
     }
-    const ms = MasterSafe.load(toT!.id);
-    if (ms != null && !ms.setupTransferSeen && fromRole == "MASTER_EOA") {
-      // First Master EOA → Master Safe hop after creation.
-      return new ClassifyResult("SAFE_SETUP_TRANSFER", null, toT!.id, null);
+    // Check fromRole BEFORE loading MasterSafe — the load is only needed for
+    // the once-per-Safe setup-transfer gate, and this branch runs on every
+    // ordinary deposit.
+    if (fromRole == ROLE_MASTER_EOA) {
+      const ms = MasterSafe.load(toT!.id);
+      if (ms != null && !ms.setupTransferSeen) {
+        // First Master EOA → Master Safe hop after creation.
+        return new ClassifyResult(
+          CATEGORY_SAFE_SETUP_TRANSFER,
+          null,
+          toT!.id,
+          null
+        );
+      }
     }
-    return new ClassifyResult("MASTER_FUNDING_IN", null, toT!.id, null);
+    const result = new ClassifyResult(
+      CATEGORY_MASTER_FUNDING_IN,
+      null,
+      toT!.id,
+      null
+    );
+    // Master Safe → Master Safe (funds migration between Pearl installs):
+    // the row belongs to the recipient, but the sender's TokenBalance must
+    // be debited too — surface the sender so handleErc20Transfer can.
+    // (The sender's masterSafe-filtered HISTORY intentionally shows no row —
+    // same shape as the accepted native-out gap; documented in CLAUDE.md.)
+    if (fromRole == ROLE_MASTER) {
+      result.senderMasterId = fromT!.id;
+    }
+    return result;
   }
 
   // Master Safe → EOA.
-  if (fromRole == "MASTER") {
-    return new ClassifyResult("MASTER_WITHDRAWAL", null, fromT!.id, null);
+  if (fromRole == ROLE_MASTER) {
+    return new ClassifyResult(CATEGORY_MASTER_WITHDRAWAL, null, fromT!.id, null);
   }
 
   // Agent Safe ↔ unknown (treated as app-contract interactions).
-  if (fromRole == "AGENT") {
+  if (fromRole == ROLE_AGENT) {
     return new ClassifyResult(
-      "AGENT_TO_APP",
+      CATEGORY_AGENT_TO_APP,
       fromT!.service,
       fromT!.masterSafe,
       fromT!.id
     );
   }
-  if (toRole == "AGENT") {
+  if (toRole == ROLE_AGENT) {
     return new ClassifyResult(
-      "APP_TO_AGENT",
+      CATEGORY_APP_TO_AGENT,
       toT!.service,
       toT!.masterSafe,
       toT!.id
@@ -882,7 +953,8 @@ export function getOrCreateAgentFundingEvent(
   afe.blockTimestamp = event.block.timestamp;
   afe.totalNativeAmount = BigInt.zero();
   afe.totalOlasAmount = BigInt.zero();
-  afe.save();
+  // No save here — both call sites (erc20.ts / safe.ts) immediately call
+  // addToAgentFundingEvent, which saves after bumping a total.
   return afe;
 }
 

--- a/subgraphs/pearl-transactions/src/utils.ts
+++ b/subgraphs/pearl-transactions/src/utils.ts
@@ -10,6 +10,7 @@ import {
   AgentBondAttributionGuard,
   AgentFundingEvent,
   AgentSafe,
+  BondMovement,
   DailyServiceFunds,
   FundsMovement,
   MasterSafe,
@@ -21,8 +22,7 @@ import {
   StakingContract,
   Token,
   TokenBalance,
-  TrackedEOA,
-  TrackedSafe,
+  TrackedAddress,
 } from "../generated/schema";
 import { GnosisSafe } from "../generated/ServiceRegistryL2/GnosisSafe";
 import { Safe as SafeTemplate } from "../generated/templates";
@@ -58,6 +58,12 @@ export function safeDeployedId(masterSafe: Bytes): Bytes {
 }
 
 export function serviceIndexId(serviceId: BigInt): Bytes {
+  return Bytes.fromByteArray(Bytes.fromBigInt(serviceId));
+}
+
+// Service.id is now Bytes (serviceId as Bytes) — halves FK storage / speeds
+// comparisons vs the old string id. Same byte layout as serviceIndexId.
+export function serviceEntityId(serviceId: BigInt): Bytes {
   return Bytes.fromByteArray(Bytes.fromBigInt(serviceId));
 }
 
@@ -164,9 +170,15 @@ export function getOrCreateMasterSafe(
   // hop is tagged SAFE_SETUP_TRANSFER by classifyTransfer (gated on
   // setupTransferSeen, set false above); subsequent hops are
   // MASTER_FUNDING_IN.
-  upsertTrackedSafe(address, "MASTER", masterSafe.id, null);
+  upsertTrackedAddress(
+    address,
+    "MASTER",
+    masterSafe.id,
+    null,
+    event.block.number
+  );
   if (masterSafe.masterEoa.length > 0 && !masterSafe.masterEoa.equals(Address.zero())) {
-    upsertTrackedEOA(
+    upsertTrackedAddress(
       Address.fromBytes(masterSafe.masterEoa),
       "MASTER_EOA",
       masterSafe.id,
@@ -223,22 +235,23 @@ export function getOrCreateAgentSafe(
   agentSafe.createdTimestamp = event.block.timestamp;
   agentSafe.save();
 
-  // Phase 2a: track as TrackedSafe (role=AGENT), spawn Safe template,
-  // and add any operators recorded on the Service so far as
-  // TrackedEOAs (role=AGENT_EOA). Additional operators registered
-  // later are picked up incrementally in handleRegisterInstance.
+  // Phase 2a: track as TrackedAddress (role=AGENT), spawn Safe template,
+  // and add any operators recorded on the Service so far as TrackedAddress
+  // (role=AGENT_EOA). Additional operators registered later are picked up
+  // incrementally in handleRegisterInstance.
   if (service.masterSafe !== null) {
-    upsertTrackedSafe(
+    upsertTrackedAddress(
       address,
       "AGENT",
-      service.masterSafe!,
-      service.id
+      service.masterSafe,
+      service.id,
+      event.block.number
     );
   }
   SafeTemplate.create(address);
   const operators = service.operators;
   for (let i = 0; i < operators.length; i++) {
-    upsertTrackedEOA(
+    upsertTrackedAddress(
       Address.fromBytes(operators[i]),
       "AGENT_EOA",
       service.masterSafe,
@@ -255,7 +268,7 @@ export function getOrCreateService(
   serviceId: BigInt,
   event: ethereum.Event
 ): Service {
-  const id = serviceId.toString();
+  const id = serviceEntityId(serviceId);
   let service = Service.load(id);
   if (service != null) {
     return service;
@@ -421,23 +434,24 @@ function getOrCreatePendingBondCounter(txHash: Bytes): PendingBondCounter {
     counter = new PendingBondCounter(txHash);
     counter.nextEnqueueSlot = 0;
     counter.nextDequeueSlot = 0;
-    counter.save();
+    // No save here — the only caller (enqueuePendingBondRow) saves after
+    // bumping nextEnqueueSlot, so an early save would be redundant.
   }
   return counter;
 }
 
-// enqueuePendingBondRow — append a FundsMovement row id to the per-tx
+// enqueuePendingBondRow — append a BondMovement row id to the per-tx
 // queue. Called by SRTU handlers (handleTokenDeposit / handleTokenRefund)
 // right after they create the (as-yet unattributed) row.
 export function enqueuePendingBondRow(
   txHash: Bytes,
-  fundsMovementId: Bytes
+  bondMovementId: Bytes
 ): void {
   const counter = getOrCreatePendingBondCounter(txHash);
   const slot = counter.nextEnqueueSlot;
 
   const ptr = new PendingBondRow(pendingBondRowId(txHash, slot));
-  ptr.fundsMovement = fundsMovementId;
+  ptr.bondMovement = bondMovementId;
   ptr.attributed = false;
   ptr.save();
 
@@ -467,9 +481,9 @@ export function dequeueAndAttribute(
       counter.nextDequeueSlot = slot + 1;
       counter.save();
 
-      const movement = FundsMovement.load(ptr.fundsMovement);
+      const movement = BondMovement.load(ptr.bondMovement);
       if (movement != null) {
-        movement.service = serviceId.toString();
+        movement.service = serviceEntityId(serviceId);
         movement.bondType = bondType;
         // Backfill the agent link so the wallet can render the agent
         // name on stake / unstake rows. The Service carries agentIds
@@ -479,7 +493,7 @@ export function dequeueAndAttribute(
         // very first deposit (the name still resolves via service.agentIds).
         // masterSafe is normally stamped by the SRTU producer; fall back
         // to the Service link here for services discovered out of order.
-        const service = Service.load(serviceId.toString());
+        const service = Service.load(serviceEntityId(serviceId));
         if (service != null) {
           if (movement.masterSafe === null && service.masterSafe !== null) {
             movement.masterSafe = service.masterSafe;
@@ -535,7 +549,9 @@ export function addDailyOlasReward(
   blockTimestamp: BigInt
 ): void {
   const day = dayTimestamp(blockTimestamp);
-  const id = service.id + "-" + day.toString();
+  // DailyServiceFunds.id stays a string composite; build it from the numeric
+  // serviceId (service.id is now Bytes).
+  const id = service.serviceId.toString() + "-" + day.toString();
   let daily = DailyServiceFunds.load(id);
   if (daily == null) {
     daily = new DailyServiceFunds(id);
@@ -576,39 +592,23 @@ export function getOrCreateStakingContract(
   return sc;
 }
 
-// --- Phase 2a — TrackedSafe / TrackedEOA / Token / TokenBalance ------
+// --- Phase 2a — TrackedAddress / Token / TokenBalance ----------------
 
-// upsertTrackedSafe — idempotent. Called when a Master Safe or Agent
-// Safe is first created. `service` is null for Master Safes (one
-// Master Safe owns many services).
-export function upsertTrackedSafe(
-  address: Address,
-  role: string,
-  masterSafeId: Bytes,
-  serviceId: string | null
-): void {
-  let tracked = TrackedSafe.load(address);
-  if (tracked != null) return;
-  tracked = new TrackedSafe(address);
-  tracked.role = role;
-  tracked.masterSafe = masterSafeId;
-  if (serviceId !== null) tracked.service = serviceId;
-  tracked.save();
-}
-
-// upsertTrackedEOA — idempotent. Called for Master EOAs (via
-// getOrCreateMasterSafe) and agent EOAs (via RegisterInstance /
-// agent-safe creation).
-export function upsertTrackedEOA(
+// upsertTrackedAddress — idempotent, write-once. The single tracked-address
+// table behind classifyTransfer's hot path. `role` is MASTER | AGENT |
+// MASTER_EOA | AGENT_EOA | STAKING. `masterSafeId` is null for STAKING;
+// `serviceId` is null for MASTER / MASTER_EOA / STAKING. Both ids are Bytes
+// (the related entity's id).
+export function upsertTrackedAddress(
   address: Address,
   role: string,
   masterSafeId: Bytes | null,
-  serviceId: string | null,
+  serviceId: Bytes | null,
   blockNumber: BigInt
 ): void {
-  let tracked = TrackedEOA.load(address);
+  let tracked = TrackedAddress.load(address);
   if (tracked != null) return;
-  tracked = new TrackedEOA(address);
+  tracked = new TrackedAddress(address);
   tracked.role = role;
   if (masterSafeId !== null) tracked.masterSafe = masterSafeId;
   if (serviceId !== null) tracked.service = serviceId;
@@ -693,15 +693,15 @@ export function upsertTokenBalance(
 
 // ClassifyResult — output of classifyTransfer. Carries category +
 // resolved service/masterSafe/agentSafe IDs so the OLAS handler
-// doesn't repeat the lookup.
+// doesn't repeat the lookup. `service` is the Service.id (Bytes) or null.
 export class ClassifyResult {
   category: string;
-  service: string | null;
+  service: Bytes | null;
   masterSafeId: Bytes | null;
   agentSafeId: Bytes | null;
   constructor(
     category: string,
-    service: string | null,
+    service: Bytes | null,
     masterSafeId: Bytes | null,
     agentSafeId: Bytes | null
   ) {
@@ -712,69 +712,49 @@ export class ClassifyResult {
   }
 }
 
-// classifyTransfer — route an ERC-20 / native Transfer's (from, to) to
-// a FundsCategory. Returns null only if NEITHER side is a tracked
-// address (TrackedSafe / TrackedEOA / StakingContract / SRTU). If one
-// side is tracked but no specific pattern matches, returns OTHER so
-// the row is recorded for forensic view (plan §10 explicit
-// requirement: "Master EOA → unrelated EOA classified OTHER, not
-// silently dropped").
+// classifyTransfer — route an ERC-20 / native Transfer's (from, to) to a
+// FundsCategory. Hot path: two TrackedAddress loads (from + to) instead of the
+// old six (TrackedSafe×2 / TrackedEOA×2 / StakingContract×2). Returns null only
+// if NEITHER side is tracked (TrackedAddress or SRTU) — the ~99.99% chain-wide
+// noise case exits at the first guard. If one side is tracked but no specific
+// pattern matches, returns OTHER so the row is kept for the forensic view
+// (plan §10: "Master EOA → unrelated EOA classified OTHER, not silently
+// dropped"). `masterSafePtr` is unused (kept for call-site compatibility).
 export function classifyTransfer(
   from: Address,
   to: Address,
   masterSafePtr: MasterSafe | null
 ): ClassifyResult | null {
-  const fromMaster = TrackedSafe.load(from);
-  const toMaster = TrackedSafe.load(to);
-  const fromEOA = TrackedEOA.load(from);
-  const toEOA = TrackedEOA.load(to);
-  const fromIsStaking = StakingContract.load(from) != null;
-  const toIsStaking = StakingContract.load(to) != null;
   const srtuAddr = getSrtuAddress(currentNetwork());
   const fromIsSrtu = from.equals(srtuAddr);
   const toIsSrtu = to.equals(srtuAddr);
-  const registryAddr = getServiceRegistryAddress(currentNetwork());
 
-  // Most-specific patterns first.
+  const fromT = TrackedAddress.load(from);
+  const toT = TrackedAddress.load(to);
 
-  // Master Safe ↔ SRTU OLAS transfers are the on-chain bond movement.
-  // The SRTU handler (handleTokenDeposit / handleTokenRefund) already
-  // books the canonical SEMANTIC bond row and the consumer backfills
-  // serviceId + bondType + masterSafe + agentSafe onto it, so that one
-  // row is the complete record. Emitting a second RAW_TRANSFER row here
-  // would double-count the bond in any masterSafe-filtered wallet query,
-  // so we drop it (return null). The OLAS TokenBalance delta is updated
-  // separately in handleErc20Transfer and is unaffected.
-  if (
-    fromMaster != null &&
-    fromMaster.role == "MASTER" &&
-    toIsSrtu
-  ) {
+  // Fast exit: neither side tracked (and not SRTU) → not ours.
+  if (fromT == null && toT == null && !fromIsSrtu && !toIsSrtu) {
     return null;
   }
-  if (
-    fromIsSrtu &&
-    toMaster != null &&
-    toMaster.role == "MASTER"
-  ) {
-    return null;
-  }
+
+  const fromRole = fromT != null ? fromT.role : "";
+  const toRole = toT != null ? toT.role : "";
+
+  // Master Safe ↔ SRTU OLAS transfers are the on-chain bond movement, already
+  // booked as the canonical SEMANTIC BondMovement row (and backfilled by the
+  // consumer). A second RAW_TRANSFER row here would double-count in any
+  // masterSafe-filtered wallet query, so drop it. The OLAS TokenBalance delta
+  // is updated separately in handleErc20Transfer and is unaffected.
+  if (fromRole == "MASTER" && toIsSrtu) return null;
+  if (fromIsSrtu && toRole == "MASTER") return null;
 
   // Master Safe → Agent Safe / Agent EOA → MASTER_TO_AGENT (grouped).
-  if (
-    fromMaster != null &&
-    fromMaster.role == "MASTER" &&
-    ((toMaster != null && toMaster.role == "AGENT") ||
-      (toEOA != null && toEOA.role == "AGENT_EOA"))
-  ) {
-    let serviceId: string | null = null;
-    if (toMaster != null) serviceId = toMaster.service;
-    else if (toEOA != null) serviceId = toEOA.service;
+  if (fromRole == "MASTER" && (toRole == "AGENT" || toRole == "AGENT_EOA")) {
     return new ClassifyResult(
       "MASTER_TO_AGENT",
-      serviceId,
-      fromMaster.masterSafe,
-      toMaster != null ? toMaster.id : null
+      toT!.service,
+      fromT!.masterSafe,
+      toRole == "AGENT" ? toT!.id : null
     );
   }
 
@@ -782,112 +762,74 @@ export function classifyTransfer(
   // manual OLAS returns) is re-tagged AGENT_OLAS_TO_MASTER in
   // handleErc20Transfer after classification (the token isn't visible here);
   // native / non-OLAS stays AGENT_TO_MASTER.
-  if (
-    fromMaster != null &&
-    fromMaster.role == "AGENT" &&
-    toMaster != null &&
-    toMaster.role == "MASTER"
-  ) {
+  if (fromRole == "AGENT" && toRole == "MASTER") {
     return new ClassifyResult(
       "AGENT_TO_MASTER",
-      fromMaster.service,
-      toMaster.id,
-      fromMaster.id
+      fromT!.service,
+      toT!.id,
+      fromT!.id
     );
   }
 
-  // Staking proxy → Agent Safe — already booked semantically in
-  // Phase 1b (STAKING_REWARD_CLAIM). The raw OLAS Transfer is
-  // reconciled with source=RAW_TRANSFER.
-  if (
-    fromIsStaking &&
-    toMaster != null &&
-    toMaster.role == "AGENT"
-  ) {
+  // Staking proxy → Agent Safe — STAKING_REWARD_CLAIM (RAW_TRANSFER reconcile
+  // of the semantically-booked Phase-1b row).
+  if (fromRole == "STAKING" && toRole == "AGENT") {
     return new ClassifyResult(
       "STAKING_REWARD_CLAIM",
-      toMaster.service,
-      toMaster.masterSafe,
-      toMaster.id
+      toT!.service,
+      toT!.masterSafe,
+      toT!.id
     );
   }
 
   // EOA (Master EOA / other) → Master Safe.
-  if (toMaster != null && toMaster.role == "MASTER") {
-    // The ServiceRegistryL2 contract itself sends tiny native dust to the
-    // Master Safe during terminate / unbond (observed: 1-wei xDAI refunds
-    // sharing a tx with SERVICE_BOND_REFUND). That is protocol
-    // bookkeeping, not a user deposit, so classify it OTHER (kept for the
-    // forensic view, hidden from the wallet) rather than MASTER_FUNDING_IN.
-    if (from.equals(registryAddr)) {
-      return new ClassifyResult(CATEGORY_OTHER, null, toMaster.masterSafe, null);
+  if (toRole == "MASTER") {
+    // ServiceRegistryL2 sends tiny native dust to the Master Safe during
+    // terminate / unbond (1-wei xDAI refunds sharing a tx with a bond refund).
+    // Protocol bookkeeping, not a user deposit → OTHER. The registry address is
+    // resolved only here, in the one branch that needs it.
+    if (from.equals(getServiceRegistryAddress(currentNetwork()))) {
+      return new ClassifyResult(CATEGORY_OTHER, null, toT!.id, null);
     }
-    const ms = MasterSafe.load(toMaster.masterSafe);
-    if (ms != null && !ms.setupTransferSeen && fromEOA != null && fromEOA.role == "MASTER_EOA") {
+    const ms = MasterSafe.load(toT!.id);
+    if (ms != null && !ms.setupTransferSeen && fromRole == "MASTER_EOA") {
       // First Master EOA → Master Safe hop after creation.
-      return new ClassifyResult(
-        "SAFE_SETUP_TRANSFER",
-        null,
-        toMaster.masterSafe,
-        null
-      );
+      return new ClassifyResult("SAFE_SETUP_TRANSFER", null, toT!.id, null);
     }
-    return new ClassifyResult(
-      "MASTER_FUNDING_IN",
-      null,
-      toMaster.masterSafe,
-      null
-    );
+    return new ClassifyResult("MASTER_FUNDING_IN", null, toT!.id, null);
   }
 
   // Master Safe → EOA.
-  if (fromMaster != null && fromMaster.role == "MASTER") {
-    return new ClassifyResult(
-      "MASTER_WITHDRAWAL",
-      null,
-      fromMaster.masterSafe,
-      null
-    );
+  if (fromRole == "MASTER") {
+    return new ClassifyResult("MASTER_WITHDRAWAL", null, fromT!.id, null);
   }
 
   // Agent Safe ↔ unknown (treated as app-contract interactions).
-  if (fromMaster != null && fromMaster.role == "AGENT") {
+  if (fromRole == "AGENT") {
     return new ClassifyResult(
       "AGENT_TO_APP",
-      fromMaster.service,
-      fromMaster.masterSafe,
-      fromMaster.id
+      fromT!.service,
+      fromT!.masterSafe,
+      fromT!.id
     );
   }
-  if (toMaster != null && toMaster.role == "AGENT") {
+  if (toRole == "AGENT") {
     return new ClassifyResult(
       "APP_TO_AGENT",
-      toMaster.service,
-      toMaster.masterSafe,
-      toMaster.id
+      toT!.service,
+      toT!.masterSafe,
+      toT!.id
     );
   }
 
-  // Fallback: if ANY side is a tracked address (EOA or staking
-  // proxy that didn't match a more-specific pattern), tag as OTHER.
-  // The classifier returns null only when neither side is tracked
-  // at all (chain-wide OLAS noise).
-  const fromIsTracked =
-    fromMaster != null || fromEOA != null || fromIsStaking || fromIsSrtu;
-  const toIsTracked =
-    toMaster != null || toEOA != null || toIsStaking || toIsSrtu;
-  if (fromIsTracked || toIsTracked) {
-    // Pick whichever tracked-side EOA can carry the masterSafe ref.
-    let masterRef: Bytes | null = null;
-    if (fromEOA != null && fromEOA.masterSafe !== null) {
-      masterRef = fromEOA.masterSafe;
-    } else if (toEOA != null && toEOA.masterSafe !== null) {
-      masterRef = toEOA.masterSafe;
-    }
-    return new ClassifyResult(CATEGORY_OTHER, null, masterRef, null);
+  // Fallback: a tracked side that didn't match a specific pattern → OTHER.
+  let masterRef: Bytes | null = null;
+  if (fromT != null && fromT.masterSafe !== null) {
+    masterRef = fromT.masterSafe;
+  } else if (toT != null && toT.masterSafe !== null) {
+    masterRef = toT.masterSafe;
   }
-
-  return null;
+  return new ClassifyResult(CATEGORY_OTHER, null, masterRef, null);
 }
 
 // markSetupTransferSeen — flip the MasterSafe flag after the first
@@ -905,11 +847,9 @@ export function markSetupTransferSeen(masterSafeId: Bytes): void {
 export function agentFundingEventId(
   txHash: Bytes,
   masterSafeId: Bytes,
-  serviceId: string
+  serviceId: Bytes
 ): Bytes {
-  return txHash
-    .concat(masterSafeId)
-    .concat(Bytes.fromUTF8(serviceId));
+  return txHash.concat(masterSafeId).concat(serviceId);
 }
 
 // getOrCreateAgentFundingEvent — one per (txHash, masterSafe,
@@ -917,7 +857,7 @@ export function agentFundingEventId(
 export function getOrCreateAgentFundingEvent(
   txHash: Bytes,
   masterSafeId: Bytes,
-  serviceId: string,
+  serviceId: Bytes,
   event: ethereum.Event
 ): AgentFundingEvent {
   const id = agentFundingEventId(txHash, masterSafeId, serviceId);

--- a/subgraphs/pearl-transactions/src/utils.ts
+++ b/subgraphs/pearl-transactions/src/utils.ts
@@ -732,7 +732,7 @@ export class ClassifyResult {
 // noise case exits at the first guard. If one side is tracked but no specific
 // pattern matches, returns OTHER so the row is kept for the forensic view
 // (plan §10: "Master EOA → unrelated EOA classified OTHER, not silently
-// dropped"). `masterSafePtr` is unused (kept for call-site compatibility).
+// dropped").
 export function classifyTransfer(
   from: Address,
   to: Address

--- a/subgraphs/pearl-transactions/subgraph.base.yaml
+++ b/subgraphs/pearl-transactions/subgraph.base.yaml
@@ -1,4 +1,4 @@
-specVersion: 1.0.0
+specVersion: 1.3.0
 indexerHints:
   prune: auto
 schema:
@@ -13,12 +13,13 @@ dataSources:
       startBlock: 10827380
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         - Service
         - AgentSafe
         - MasterSafe
+        - TrackedAddress
         - ServiceIndex
         - PendingRegistration
         - PendingBondCounter
@@ -26,6 +27,7 @@ dataSources:
         - AgentBondAttributionGuard
         - ServiceNftCustodyChange
         - FundsMovement
+        - BondMovement
       abis:
         - name: ServiceRegistryL2
           file: ../../abis/ServiceRegistryL2.json
@@ -56,10 +58,10 @@ dataSources:
       startBlock: 10827475
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
-        - FundsMovement
+        - BondMovement
         - PendingBondCounter
         - PendingBondRow
       abis:
@@ -80,10 +82,11 @@ dataSources:
       startBlock: 17310019
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         - StakingContract
+        - TrackedAddress
       abis:
         - name: StakingFactory
           file: ../../abis/StakingFactory.json
@@ -102,7 +105,7 @@ dataSources:
       startBlock: 10827380
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         - FundsMovement
@@ -125,7 +128,7 @@ dataSources:
       startBlock: 10827380
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         - FundsMovement
@@ -173,11 +176,13 @@ templates:
       abi: StakingProxy
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         - Service
         - MasterSafe
+        - AgentSafe
+        - TrackedAddress
         - FundsMovement
         - DailyServiceFunds
       abis:
@@ -209,7 +214,7 @@ templates:
       abi: GnosisSafe
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         - FundsMovement

--- a/subgraphs/pearl-transactions/subgraph.gnosis.yaml
+++ b/subgraphs/pearl-transactions/subgraph.gnosis.yaml
@@ -1,4 +1,4 @@
-specVersion: 1.0.0
+specVersion: 1.3.0
 indexerHints:
   prune: auto
 schema:
@@ -13,12 +13,13 @@ dataSources:
       startBlock: 27871084
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         - Service
         - AgentSafe
         - MasterSafe
+        - TrackedAddress
         - ServiceIndex
         - PendingRegistration
         - PendingBondCounter
@@ -26,6 +27,7 @@ dataSources:
         - AgentBondAttributionGuard
         - ServiceNftCustodyChange
         - FundsMovement
+        - BondMovement
       abis:
         - name: ServiceRegistryL2
           file: ../../abis/ServiceRegistryL2.json
@@ -56,10 +58,10 @@ dataSources:
       startBlock: 30095874
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
-        - FundsMovement
+        - BondMovement
         - PendingBondCounter
         - PendingBondRow
       abis:
@@ -80,10 +82,11 @@ dataSources:
       startBlock: 35206806
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         - StakingContract
+        - TrackedAddress
       abis:
         - name: StakingFactory
           file: ../../abis/StakingFactory.json
@@ -102,7 +105,7 @@ dataSources:
       startBlock: 27871084
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         - FundsMovement
@@ -125,7 +128,7 @@ dataSources:
       startBlock: 27871084
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         - FundsMovement
@@ -196,11 +199,13 @@ templates:
       abi: StakingProxy
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         - Service
         - MasterSafe
+        - AgentSafe
+        - TrackedAddress
         - FundsMovement
         - DailyServiceFunds
       abis:
@@ -232,7 +237,7 @@ templates:
       abi: GnosisSafe
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         - FundsMovement

--- a/subgraphs/pearl-transactions/subgraph.matic.yaml
+++ b/subgraphs/pearl-transactions/subgraph.matic.yaml
@@ -1,4 +1,4 @@
-specVersion: 1.0.0
+specVersion: 1.3.0
 indexerHints:
   prune: auto
 schema:
@@ -13,12 +13,13 @@ dataSources:
       startBlock: 80360433
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         - Service
         - AgentSafe
         - MasterSafe
+        - TrackedAddress
         - ServiceIndex
         - PendingRegistration
         - PendingBondCounter
@@ -26,6 +27,7 @@ dataSources:
         - AgentBondAttributionGuard
         - ServiceNftCustodyChange
         - FundsMovement
+        - BondMovement
       abis:
         - name: ServiceRegistryL2
           file: ../../abis/ServiceRegistryL2.json
@@ -56,10 +58,10 @@ dataSources:
       startBlock: 80360433
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
-        - FundsMovement
+        - BondMovement
         - PendingBondCounter
         - PendingBondRow
       abis:
@@ -80,10 +82,11 @@ dataSources:
       startBlock: 80360433
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         - StakingContract
+        - TrackedAddress
       abis:
         - name: StakingFactory
           file: ../../abis/StakingFactory.json
@@ -102,7 +105,7 @@ dataSources:
       startBlock: 80360433
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         - FundsMovement
@@ -125,7 +128,7 @@ dataSources:
       startBlock: 80360433
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         - FundsMovement
@@ -219,11 +222,13 @@ templates:
       abi: StakingProxy
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         - Service
         - MasterSafe
+        - AgentSafe
+        - TrackedAddress
         - FundsMovement
         - DailyServiceFunds
       abis:
@@ -255,7 +260,7 @@ templates:
       abi: GnosisSafe
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         - FundsMovement

--- a/subgraphs/pearl-transactions/subgraph.optimism.yaml
+++ b/subgraphs/pearl-transactions/subgraph.optimism.yaml
@@ -1,4 +1,4 @@
-specVersion: 1.0.0
+specVersion: 1.3.0
 indexerHints:
   prune: auto
 schema:
@@ -13,12 +13,13 @@ dataSources:
       startBlock: 116423039
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         - Service
         - AgentSafe
         - MasterSafe
+        - TrackedAddress
         - ServiceIndex
         - PendingRegistration
         - PendingBondCounter
@@ -26,6 +27,7 @@ dataSources:
         - AgentBondAttributionGuard
         - ServiceNftCustodyChange
         - FundsMovement
+        - BondMovement
       abis:
         - name: ServiceRegistryL2
           file: ../../abis/ServiceRegistryL2.json
@@ -56,10 +58,10 @@ dataSources:
       startBlock: 116423237
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
-        - FundsMovement
+        - BondMovement
         - PendingBondCounter
         - PendingBondRow
       abis:
@@ -80,10 +82,11 @@ dataSources:
       startBlock: 124618633
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         - StakingContract
+        - TrackedAddress
       abis:
         - name: StakingFactory
           file: ../../abis/StakingFactory.json
@@ -102,7 +105,7 @@ dataSources:
       startBlock: 116423039
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         - FundsMovement
@@ -125,7 +128,7 @@ dataSources:
       startBlock: 116423039
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         - FundsMovement
@@ -196,11 +199,13 @@ templates:
       abi: StakingProxy
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         - Service
         - MasterSafe
+        - AgentSafe
+        - TrackedAddress
         - FundsMovement
         - DailyServiceFunds
       abis:
@@ -232,7 +237,7 @@ templates:
       abi: GnosisSafe
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         - FundsMovement

--- a/subgraphs/pearl-transactions/subgraph.template.yaml
+++ b/subgraphs/pearl-transactions/subgraph.template.yaml
@@ -19,6 +19,7 @@ dataSources:
         - Service
         - AgentSafe
         - MasterSafe
+        - TrackedAddress
         - ServiceIndex
         - PendingRegistration
         - PendingBondCounter
@@ -26,6 +27,7 @@ dataSources:
         - AgentBondAttributionGuard
         - ServiceNftCustodyChange
         - FundsMovement
+        - BondMovement
       abis:
         - name: ServiceRegistryL2
           file: ../../abis/ServiceRegistryL2.json
@@ -59,7 +61,7 @@ dataSources:
       apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
-        - FundsMovement
+        - BondMovement
         - PendingBondCounter
         - PendingBondRow
       abis:
@@ -84,6 +86,7 @@ dataSources:
       language: wasm/assemblyscript
       entities:
         - StakingContract
+        - TrackedAddress
       abis:
         - name: StakingFactory
           file: ../../abis/StakingFactory.json
@@ -156,6 +159,8 @@ templates:
       entities:
         - Service
         - MasterSafe
+        - AgentSafe
+        - TrackedAddress
         - FundsMovement
         - DailyServiceFunds
       abis:

--- a/subgraphs/pearl-transactions/subgraph.template.yaml
+++ b/subgraphs/pearl-transactions/subgraph.template.yaml
@@ -1,4 +1,4 @@
-specVersion: 1.0.0
+specVersion: 1.3.0
 indexerHints:
   prune: auto
 schema:
@@ -13,7 +13,7 @@ dataSources:
       startBlock: {{ ServiceRegistryL2.startBlock }}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         - Service
@@ -56,7 +56,7 @@ dataSources:
       startBlock: {{ ServiceRegistryTokenUtility.startBlock }}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         - FundsMovement
@@ -80,7 +80,7 @@ dataSources:
       startBlock: {{ StakingFactory.startBlock }}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         - StakingContract
@@ -102,7 +102,7 @@ dataSources:
       startBlock: {{ OLAS.startBlock }}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         - FundsMovement
@@ -125,7 +125,7 @@ dataSources:
       startBlock: {{ WrappedNative.startBlock }}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         - FundsMovement
@@ -151,7 +151,7 @@ templates:
       abi: StakingProxy
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         - Service
@@ -187,7 +187,7 @@ templates:
       abi: GnosisSafe
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         - FundsMovement

--- a/subgraphs/pearl-transactions/tests/phase-2a.test.ts
+++ b/subgraphs/pearl-transactions/tests/phase-2a.test.ts
@@ -17,6 +17,7 @@ import {
   RemovedOwner,
   SafeReceived,
 } from "../generated/templates/Safe/GnosisSafe";
+import { TokenDeposit } from "../generated/ServiceRegistryTokenUtility/ServiceRegistryTokenUtility";
 import { MasterSafe, TrackedAddress } from "../generated/schema";
 import { handleErc20Transfer } from "../src/erc20";
 import {
@@ -25,6 +26,7 @@ import {
   handleSafeReceived,
   handleSafeRemovedOwner,
 } from "../src/safe";
+import { handleTokenDeposit } from "../src/service-registry-token-utility";
 
 // ----------------- Fixtures -----------------
 
@@ -52,6 +54,9 @@ const RANDOM_EOA = Address.fromString(
 );
 const OLAS_GNOSIS = Address.fromString(
   "0xcE11e14225575945b8E6Dc0D4F2dD4C570f79d9f"
+);
+const SRTU_GNOSIS = Address.fromString(
+  "0xa45E64d13A30a51b91ae0eb182e88a40e9b18eD8"
 );
 const AMOUNT = BigInt.fromString("5000000000000000000"); // 5 OLAS
 const SERVICE_ID = "42";
@@ -108,6 +113,43 @@ function newOlasTransfer(
     )
   );
   return setMockEventBoilerplate(e, txHash, logIndex, OLAS_GNOSIS);
+}
+
+// newTokenDeposit — SRTU TokenDeposit(account, token, amount). Used to
+// verify the bond legs' TokenBalance booking (the raw Master ↔ SRTU
+// Transfer is suppressed; the SRTU handler owns the balance delta).
+function newTokenDeposit(
+  account: Address,
+  token: Address,
+  amount: BigInt,
+  txHash: Bytes,
+  logIndex: i32
+): TokenDeposit {
+  const mock = newMockEvent();
+  const e = new TokenDeposit(
+    mock.address,
+    mock.logIndex,
+    mock.transactionLogIndex,
+    mock.logType,
+    mock.block,
+    mock.transaction,
+    mock.parameters,
+    mock.receipt
+  );
+  e.parameters = new Array();
+  e.parameters.push(
+    new ethereum.EventParam("account", ethereum.Value.fromAddress(account))
+  );
+  e.parameters.push(
+    new ethereum.EventParam("token", ethereum.Value.fromAddress(token))
+  );
+  e.parameters.push(
+    new ethereum.EventParam(
+      "amount",
+      ethereum.Value.fromUnsignedBigInt(amount)
+    )
+  );
+  return setMockEventBoilerplate(e, txHash, logIndex, SRTU_GNOSIS);
 }
 
 // newErc20TransferAt — a Transfer event whose `event.address` is an
@@ -690,6 +732,151 @@ describe("pearl-transactions / Phase 2a — raw OLAS + Safe template", () => {
       id.toHexString(),
       "balance",
       AMOUNT.plus(AMOUNT).toString()
+    );
+  });
+
+  test("Master Safe → SRTU bond leg debits the OLAS TokenBalance exactly once", () => {
+    // Review #149 finding 3: the raw Master ↔ SRTU Transfer is suppressed in
+    // classifyTransfer (deduped against the SEMANTIC BondMovement row), so
+    // handleErc20Transfer applies NO balance delta for it — the SRTU handler
+    // books the bond's balance effect instead. Without that, the Master
+    // Safe's balance overstates by the bonded amount for the whole staking
+    // period. On-chain both events fire in the same tx; mirror that here.
+    seedMasterSafe(true);
+    const balId = MASTER_SAFE.concat(OLAS_GNOSIS);
+
+    // Fund the Master Safe with 5 OLAS.
+    const tx1 = mockTx(280);
+    handleErc20Transfer(newOlasTransfer(MASTER_EOA, MASTER_SAFE, AMOUNT, tx1, 0));
+    assert.fieldEquals(
+      "TokenBalance",
+      balId.toHexString(),
+      "balance",
+      AMOUNT.toString()
+    );
+
+    // Post a 1 OLAS bond: raw Transfer (suppressed) + TokenDeposit (booked).
+    const bond = BigInt.fromString("1000000000000000000");
+    const tx2 = mockTx(281);
+    handleErc20Transfer(newOlasTransfer(MASTER_SAFE, SRTU_GNOSIS, bond, tx2, 0));
+    handleTokenDeposit(
+      newTokenDeposit(MASTER_SAFE, OLAS_GNOSIS, bond, tx2, 1)
+    );
+
+    // The raw leg produced no FundsMovement (deduped)…
+    assert.notInStore("FundsMovement", tx2.concatI32(0).toHexString());
+    // …the SEMANTIC bond row exists…
+    assert.fieldEquals(
+      "BondMovement",
+      tx2.concatI32(1).toHexString(),
+      "category",
+      "SERVICE_BOND_DEPOSIT"
+    );
+    // …and the balance reflects the bond debit exactly once.
+    assert.fieldEquals(
+      "TokenBalance",
+      balId.toHexString(),
+      "balance",
+      AMOUNT.minus(bond).toString()
+    );
+  });
+
+  test("Master Safe A → Master Safe B credits B and debits A", () => {
+    // Review #149 finding 4: master→master (funds migration between Pearl
+    // installs) classifies as MASTER_FUNDING_IN for the recipient; the
+    // sender's debit rides on ClassifyResult.senderMasterId. (A's
+    // masterSafe-filtered HISTORY intentionally shows no outgoing row —
+    // documented limitation, same shape as the native-out gap.)
+    seedMasterSafe(true); // A = MASTER_SAFE
+
+    const MASTER_B = Address.fromString(
+      "0x9999999999999999999999999999999999999999"
+    );
+    const msB = new MasterSafe(MASTER_B);
+    msB.network = "gnosis";
+    msB.masterEoa = NEW_OWNER;
+    msB.owners = [NEW_OWNER];
+    msB.threshold = BigInt.fromI32(1);
+    msB.firstSeenTimestamp = BigInt.fromI32(1);
+    msB.firstSeenBlock = BigInt.fromI32(1);
+    msB.historyFloorBlock = BigInt.fromI32(1);
+    msB.historyFloorTimestamp = BigInt.fromI32(1);
+    msB.lastActivityTimestamp = BigInt.fromI32(1);
+    msB.setupTransferSeen = true;
+    msB.save();
+    seedTrackedAddress(MASTER_B, "MASTER", MASTER_B, null);
+
+    // Fund A with 5 OLAS, then migrate all of it to B.
+    const tx1 = mockTx(282);
+    handleErc20Transfer(newOlasTransfer(MASTER_EOA, MASTER_SAFE, AMOUNT, tx1, 0));
+    const tx2 = mockTx(283);
+    handleErc20Transfer(newOlasTransfer(MASTER_SAFE, MASTER_B, AMOUNT, tx2, 0));
+
+    // The row belongs to the recipient.
+    assert.fieldEquals(
+      "FundsMovement",
+      tx2.concatI32(0).toHexString(),
+      "category",
+      "MASTER_FUNDING_IN"
+    );
+    // B is credited…
+    assert.fieldEquals(
+      "TokenBalance",
+      MASTER_B.concat(OLAS_GNOSIS).toHexString(),
+      "balance",
+      AMOUNT.toString()
+    );
+    // …and A is debited (senderMasterId path).
+    assert.fieldEquals(
+      "TokenBalance",
+      MASTER_SAFE.concat(OLAS_GNOSIS).toHexString(),
+      "balance",
+      "0"
+    );
+  });
+
+  test("same-tx OLAS + USDC Master → Agent funding keeps totalOlasAmount OLAS-only", () => {
+    // Review #149 finding 5: handleErc20Transfer serves every ERC-20 data
+    // source, and AgentFundingEvent groups per (tx, masterSafe, service) —
+    // not per token. totalOlasAmount is documented OLAS-only, so the bump is
+    // gated on the token; non-OLAS legs still link via `transfers`.
+    seedMasterSafe(true);
+    seedAgentSafe(SERVICE_ID);
+    const usdc = Address.fromString(
+      "0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83" // gnosis USDC, 6 dec
+    );
+
+    const tx = mockTx(284);
+    const olasLeg = BigInt.fromString("1000000000000000000"); // 1 OLAS (1e18)
+    const usdcLeg = BigInt.fromString("100000000"); // 100 USDC (1e8)
+    handleErc20Transfer(newOlasTransfer(MASTER_SAFE, AGENT_SAFE, olasLeg, tx, 0));
+    handleErc20Transfer(
+      newErc20TransferAt(usdc, MASTER_SAFE, AGENT_SAFE, usdcLeg, tx, 1)
+    );
+
+    // Both legs group under one event…
+    assert.entityCount("AgentFundingEvent", 1);
+    const afeId = tx.concat(MASTER_SAFE).concat(serviceBytes(SERVICE_ID));
+    // …both rows link to it…
+    assert.fieldEquals(
+      "FundsMovement",
+      tx.concatI32(0).toHexString(),
+      "agentFundingEvent",
+      afeId.toHexString()
+    );
+    assert.fieldEquals(
+      "FundsMovement",
+      tx.concatI32(1).toHexString(),
+      "agentFundingEvent",
+      afeId.toHexString()
+    );
+    // …but the OLAS total contains ONLY the OLAS leg, not mixed-decimal raw
+    // units (1e18 + 1e8 summed across tokens).
+    assert.fieldEquals(
+      "AgentFundingEvent",
+      afeId.toHexString(),
+      "totalOlasAmount",
+      olasLeg.toString()
     );
   });
 

--- a/subgraphs/pearl-transactions/tests/phase-2a.test.ts
+++ b/subgraphs/pearl-transactions/tests/phase-2a.test.ts
@@ -17,12 +17,7 @@ import {
   RemovedOwner,
   SafeReceived,
 } from "../generated/templates/Safe/GnosisSafe";
-import {
-  MasterSafe,
-  StakingContract,
-  TrackedEOA,
-  TrackedSafe,
-} from "../generated/schema";
+import { MasterSafe, TrackedAddress } from "../generated/schema";
 import { handleErc20Transfer } from "../src/erc20";
 import {
   handleSafeAddedOwner,
@@ -292,31 +287,33 @@ function seedMasterSafe(setupTransferSeen: boolean): void {
   ms.setupTransferSeen = setupTransferSeen;
   ms.save();
 
-  const trackedSafe = new TrackedSafe(MASTER_SAFE);
-  trackedSafe.role = "MASTER";
-  trackedSafe.masterSafe = MASTER_SAFE;
-  trackedSafe.save();
+  seedTrackedAddress(MASTER_SAFE, "MASTER", MASTER_SAFE, null);
+  seedTrackedAddress(MASTER_EOA, "MASTER_EOA", MASTER_SAFE, null);
+}
 
-  const trackedEoa = new TrackedEOA(MASTER_EOA);
-  trackedEoa.role = "MASTER_EOA";
-  trackedEoa.masterSafe = MASTER_SAFE;
-  trackedEoa.firstTrackedBlock = BigInt.fromI32(1);
-  trackedEoa.save();
+// serviceEntityId equivalent for tests — Service.id is the serviceId as Bytes.
+function serviceBytes(serviceId: string): Bytes {
+  return Bytes.fromByteArray(Bytes.fromBigInt(BigInt.fromString(serviceId)));
+}
+
+function seedTrackedAddress(
+  address: Address,
+  role: string,
+  masterSafe: Address | null,
+  service: Bytes | null
+): void {
+  const tracked = new TrackedAddress(address);
+  tracked.role = role;
+  if (masterSafe !== null) tracked.masterSafe = masterSafe;
+  if (service !== null) tracked.service = service;
+  tracked.firstTrackedBlock = BigInt.fromI32(1);
+  tracked.save();
 }
 
 function seedAgentSafe(serviceId: string): void {
-  const trackedSafe = new TrackedSafe(AGENT_SAFE);
-  trackedSafe.role = "AGENT";
-  trackedSafe.masterSafe = MASTER_SAFE;
-  trackedSafe.service = serviceId;
-  trackedSafe.save();
-
-  const trackedEoa = new TrackedEOA(AGENT_EOA);
-  trackedEoa.role = "AGENT_EOA";
-  trackedEoa.masterSafe = MASTER_SAFE;
-  trackedEoa.service = serviceId;
-  trackedEoa.firstTrackedBlock = BigInt.fromI32(1);
-  trackedEoa.save();
+  const svc = serviceBytes(serviceId);
+  seedTrackedAddress(AGENT_SAFE, "AGENT", MASTER_SAFE, svc);
+  seedTrackedAddress(AGENT_EOA, "AGENT_EOA", MASTER_SAFE, svc);
 }
 
 // ----------------- Tests -----------------
@@ -617,20 +614,12 @@ describe("pearl-transactions / Phase 2a — raw OLAS + Safe template", () => {
   test("StakingProxy → Agent Safe OLAS Transfer = STAKING_REWARD_CLAIM raw reconciliation", () => {
     seedMasterSafe(true);
     seedAgentSafe("42");
-    // Seed a StakingContract entity at STAKING_PROXY (any Bytes works
-    // for the classify lookup).
+    // Seed the staking proxy as a TrackedAddress(STAKING) — classifyTransfer
+    // now keys the reward-claim path on the merged tracked-address table.
     const STAKING_PROXY = Address.fromString(
       "0x9999999999999999999999999999999999999999"
     );
-    const sc = new StakingContract(STAKING_PROXY);
-    sc.implementation = Address.fromString(
-      "0xEa00be6690a871827fAfD705440D20dd75e67AB1"
-    );
-    sc.minStakingDeposit = BigInt.fromI32(10);
-    sc.numAgentInstances = BigInt.fromI32(1);
-    sc.createdBlock = BigInt.fromI32(1);
-    sc.createdTimestamp = BigInt.fromI32(1);
-    sc.save();
+    seedTrackedAddress(STAKING_PROXY, "STAKING", null, null);
 
     const tx = mockTx(23);
     handleErc20Transfer(newOlasTransfer(STAKING_PROXY, AGENT_SAFE, AMOUNT, tx, 0));

--- a/subgraphs/pearl-transactions/tests/service-registry.test.ts
+++ b/subgraphs/pearl-transactions/tests/service-registry.test.ts
@@ -74,6 +74,11 @@ const PEARL_AGENT_ID = BigInt.fromI32(25); // Gnosis omenstrat
 const OTHER_AGENT_ID = BigInt.fromI32(99); // any non-Pearl agent
 const SERVICE_ID = BigInt.fromI32(42);
 const OTHER_SERVICE_ID = BigInt.fromI32(43);
+// Service.id is the serviceId as Bytes — compute it the mapping's way so
+// assertions match the stored id regardless of byte layout.
+const SERVICE_ID_HEX = Bytes.fromByteArray(
+  Bytes.fromBigInt(SERVICE_ID)
+).toHexString();
 
 const SECURITY_DEPOSIT = BigInt.fromString("10000000000000000000"); // 10 OLAS
 const AGENT_BOND = BigInt.fromString("30000000000000000000"); // 30 OLAS
@@ -413,18 +418,18 @@ describe("pearl-transactions / Phase 1a — registry + Master EOA + SRTU bonds",
     );
 
     assert.entityCount("Service", 1);
-    assert.fieldEquals("Service", "42", "serviceId", "42");
-    assert.fieldEquals("Service", "42", "agentIds", "[25]");
+    assert.fieldEquals("Service", SERVICE_ID_HEX, "serviceId", "42");
+    assert.fieldEquals("Service", SERVICE_ID_HEX, "agentIds", "[25]");
     assert.fieldEquals(
       "Service",
-      "42",
+      SERVICE_ID_HEX,
       "operators",
       "[" + OPERATOR.toHexString() + "]"
     );
-    assert.fieldEquals("Service", "42", "state", "DEPLOYED");
+    assert.fieldEquals("Service", SERVICE_ID_HEX, "state", "DEPLOYED");
     assert.fieldEquals(
       "Service",
-      "42",
+      SERVICE_ID_HEX,
       "agentSafe",
       AGENT_SAFE.toHexString()
     );
@@ -451,7 +456,7 @@ describe("pearl-transactions / Phase 1a — registry + Master EOA + SRTU bonds",
     // The non-Pearl service is fully indexed; cohort filtering is the
     // consumer's job (Service.agentIds is queryable).
     assert.entityCount("Service", 1);
-    assert.fieldEquals("Service", "42", "agentIds", "[99]");
+    assert.fieldEquals("Service", SERVICE_ID_HEX, "agentIds", "[99]");
   });
 
   test("Multiple RegisterInstance events dedupe agentIds + operators", () => {
@@ -480,10 +485,10 @@ describe("pearl-transactions / Phase 1a — registry + Master EOA + SRTU bonds",
       newCreateMultisig(SERVICE_ID, AGENT_SAFE, tx, 2)
     );
 
-    assert.fieldEquals("Service", "42", "agentIds", "[25]");
+    assert.fieldEquals("Service", SERVICE_ID_HEX, "agentIds", "[25]");
     assert.fieldEquals(
       "Service",
-      "42",
+      SERVICE_ID_HEX,
       "operators",
       "[" + OPERATOR.toHexString() + "]"
     );
@@ -577,7 +582,7 @@ describe("pearl-transactions / Phase 1a — registry + Master EOA + SRTU bonds",
       assert.entityCount("FundsMovement", 1);
       assert.fieldEquals(
         "Service",
-        "42",
+        SERVICE_ID_HEX,
         "masterSafe",
         MASTER_SAFE.toHexString()
       );
@@ -592,7 +597,7 @@ describe("pearl-transactions / Phase 1a — registry + Master EOA + SRTU bonds",
       assert.entityCount("FundsMovement", 1);
       assert.fieldEquals(
         "Service",
-        "42",
+        SERVICE_ID_HEX,
         "masterSafe",
         MASTER_SAFE.toHexString()
       );
@@ -600,7 +605,7 @@ describe("pearl-transactions / Phase 1a — registry + Master EOA + SRTU bonds",
       assert.entityCount("ServiceNftCustodyChange", 2);
       assert.fieldEquals(
         "Service",
-        "42",
+        SERVICE_ID_HEX,
         "nftCustodian",
         STAKING_PROXY.toHexString()
       );
@@ -643,13 +648,13 @@ describe("pearl-transactions / Phase 1a — registry + Master EOA + SRTU bonds",
 
       // Exactly the two SRTU deposit rows (no SAFE_DEPLOYED here —
       // CreateMultisigWithAgents doesn't touch getOrCreateMasterSafe).
-      assert.entityCount("FundsMovement", 2);
+      assert.entityCount("BondMovement", 2);
       assertBondRow(
         tx,
         1,
         "SERVICE_BOND_DEPOSIT",
         "SECURITY_DEPOSIT",
-        "42",
+        SERVICE_ID_HEX,
         SECURITY_DEPOSIT.toString()
       );
       assertBondRow(
@@ -657,7 +662,7 @@ describe("pearl-transactions / Phase 1a — registry + Master EOA + SRTU bonds",
         3,
         "SERVICE_BOND_DEPOSIT",
         "AGENT_BOND",
-        "42",
+        SERVICE_ID_HEX,
         AGENT_BOND.toString()
       );
     }
@@ -697,13 +702,13 @@ describe("pearl-transactions / Phase 1a — registry + Master EOA + SRTU bonds",
         )
       );
 
-      assert.entityCount("FundsMovement", 1);
+      assert.entityCount("BondMovement", 1);
       assertBondRow(
         tx,
         0,
         "SERVICE_BOND_DEPOSIT",
         "AGENT_BOND",
-        "42",
+        SERVICE_ID_HEX,
         AGENT_BOND.toString()
       );
     }
@@ -730,13 +735,13 @@ describe("pearl-transactions / Phase 1a — registry + Master EOA + SRTU bonds",
         newOperatorUnbond(OPERATOR, SERVICE_ID, tx, 3)
       );
 
-      assert.entityCount("FundsMovement", 2);
+      assert.entityCount("BondMovement", 2);
       assertBondRow(
         tx,
         0,
         "SERVICE_BOND_REFUND",
         "SECURITY_DEPOSIT",
-        "42",
+        SERVICE_ID_HEX,
         SECURITY_DEPOSIT.toString()
       );
       assertBondRow(
@@ -744,7 +749,7 @@ describe("pearl-transactions / Phase 1a — registry + Master EOA + SRTU bonds",
         2,
         "SERVICE_BOND_REFUND",
         "AGENT_BOND",
-        "42",
+        SERVICE_ID_HEX,
         AGENT_BOND.toString()
       );
     }
@@ -783,17 +788,17 @@ describe("pearl-transactions / Phase 1a — registry + Master EOA + SRTU bonds",
         0,
         "SERVICE_BOND_REFUND",
         "AGENT_BOND",
-        "42",
+        SERVICE_ID_HEX,
         AGENT_BOND.toString()
       );
       assert.fieldEquals(
-        "FundsMovement",
+        "BondMovement",
         id.toHexString(),
         "masterSafe",
         MASTER_SAFE.toHexString()
       );
       assert.fieldEquals(
-        "FundsMovement",
+        "BondMovement",
         id.toHexString(),
         "agentSafe",
         AGENT_SAFE.toHexString()
@@ -813,16 +818,16 @@ describe("pearl-transactions / Phase 1a — registry + Master EOA + SRTU bonds",
         newTokenDeposit(MASTER_SAFE, OLAS_GNOSIS, SECURITY_DEPOSIT, tx, 0)
       );
 
-      assert.entityCount("FundsMovement", 1);
+      assert.entityCount("BondMovement", 1);
       const id = tx.concatI32(0);
       assert.fieldEquals(
-        "FundsMovement",
+        "BondMovement",
         id.toHexString(),
         "category",
         "SERVICE_BOND_DEPOSIT"
       );
       assert.fieldEquals(
-        "FundsMovement",
+        "BondMovement",
         id.toHexString(),
         "amount",
         SECURITY_DEPOSIT.toString()
@@ -858,13 +863,13 @@ describe("pearl-transactions / Phase 1a — registry + Master EOA + SRTU bonds",
         newActivateRegistration(SERVICE_ID, txA, 1)
       );
 
-      assert.entityCount("FundsMovement", 1);
+      assert.entityCount("BondMovement", 1);
       assertBondRow(
         txA,
         0,
         "SERVICE_BOND_DEPOSIT",
         "SECURITY_DEPOSIT",
-        "42",
+        SERVICE_ID_HEX,
         SECURITY_DEPOSIT.toString()
       );
     }
@@ -882,26 +887,29 @@ function assertBondRow(
   expectedAmount: string
 ): void {
   const id = txHash.concatI32(logIndex);
+  // Bond rows live in BondMovement now (split out so FundsMovement is immutable).
   assert.fieldEquals(
-    "FundsMovement",
+    "BondMovement",
     id.toHexString(),
     "category",
     expectedCategory
   );
   assert.fieldEquals(
-    "FundsMovement",
+    "BondMovement",
     id.toHexString(),
     "bondType",
     expectedBondType
   );
+  // Service.id is Bytes now — caller passes the already-computed hex
+  // (SERVICE_ID_HEX) so the width matches the event-derived serviceId.
   assert.fieldEquals(
-    "FundsMovement",
+    "BondMovement",
     id.toHexString(),
     "service",
     expectedServiceId
   );
   assert.fieldEquals(
-    "FundsMovement",
+    "BondMovement",
     id.toHexString(),
     "amount",
     expectedAmount

--- a/subgraphs/pearl-transactions/tests/service-registry.test.ts
+++ b/subgraphs/pearl-transactions/tests/service-registry.test.ts
@@ -874,6 +874,130 @@ describe("pearl-transactions / Phase 1a — registry + Master EOA + SRTU bonds",
       );
     }
   );
+
+  test(
+    "a Safe first seen as operator of a masterless service can still become a Master Safe",
+    () => {
+      // Review #149 finding 2 (role poisoning): the registry is
+      // permissionless, so an address operating a non-Pearl (masterless)
+      // service today may become a Pearl Master Safe tomorrow. TrackedAddress
+      // is write-once + immutable — if the operator loop wrote it AGENT_EOA
+      // first, the later MASTER upsert would no-op and the user's entire
+      // wallet history would classify OTHER forever. The fix: operator rows
+      // are only written for services WITH a masterSafe link.
+      const POISONED_SAFE = Address.fromString(
+        "0x1234123412341234123412341234123412341234"
+      );
+      const OTHER_MULTISIG = Address.fromString(
+        "0xffffffffffffffffffffffffffffffffffffffff"
+      );
+
+      // 1. Masterless service: operator-first write order.
+      const tx1 = mockTx(701);
+      handleRegisterInstance(
+        newRegisterInstance(
+          POISONED_SAFE,
+          SERVICE_ID,
+          AGENT_INSTANCE_1,
+          PEARL_AGENT_ID,
+          tx1,
+          0
+        )
+      );
+      handleCreateMultisigWithAgents(
+        newCreateMultisig(SERVICE_ID, OTHER_MULTISIG, tx1, 1)
+      );
+      // The masterless service's operator must NOT be pre-claimed.
+      assert.notInStore("TrackedAddress", POISONED_SAFE.toHexString());
+
+      // 2. The same Safe later onboards Pearl: service #2's NFT mints to it.
+      mockGetOwners(POISONED_SAFE, [MASTER_EOA, BACKUP_EOA]);
+      mockGetThreshold(POISONED_SAFE, 1);
+      const tx2 = mockTx(702);
+      handleServiceNftTransfer(
+        newNftTransfer(ZERO, POISONED_SAFE, OTHER_SERVICE_ID, tx2, 0)
+      );
+
+      assert.fieldEquals(
+        "MasterSafe",
+        POISONED_SAFE.toHexString(),
+        "setupTransferSeen",
+        "false"
+      );
+      // The MASTER role lands — classification for this wallet works.
+      assert.fieldEquals(
+        "TrackedAddress",
+        POISONED_SAFE.toHexString(),
+        "role",
+        "MASTER"
+      );
+    }
+  );
+
+  test(
+    "NFT transfer to an existing Agent Safe reaches the shared template guard",
+    () => {
+      // Review #149 finding 1: SafeTemplate.create was guarded on MasterSafe
+      // in one path and AgentSafe in the other, so an Agent Safe receiving a
+      // service NFT (it passes the getOwners() probe) got a SECOND template
+      // instance — every SafeReceived would then be processed twice, and the
+      // duplicate FundsMovement save is a deterministic halt now that the
+      // entity is immutable. The fix is the cross-entity guard in
+      // getOrCreateMasterSafe / getOrCreateAgentSafe.
+      //
+      // NB: matchstick counts UNIQUE created data-source addresses, so a
+      // duplicate create on the SAME address is invisible to
+      // assert.dataSourceCount — this test drives the exact scenario and
+      // asserts the state that makes the guard load-bearing: the address
+      // ends up in BOTH MasterSafe and AgentSafe tables (i.e. the second
+      // create WOULD have fired without the guard).
+      mockGetOwners(MASTER_SAFE, [MASTER_EOA, BACKUP_EOA]);
+      mockGetThreshold(MASTER_SAFE, 1);
+
+      // Full Pearl flow: mint to the Master Safe, then deploy the agent
+      // multisig.
+      const tx1 = mockTx(703);
+      handleServiceNftTransfer(
+        newNftTransfer(ZERO, MASTER_SAFE, SERVICE_ID, tx1, 0)
+      );
+      handleRegisterInstance(
+        newRegisterInstance(
+          OPERATOR,
+          SERVICE_ID,
+          AGENT_INSTANCE_1,
+          PEARL_AGENT_ID,
+          tx1,
+          1
+        )
+      );
+      handleCreateMultisigWithAgents(
+        newCreateMultisig(SERVICE_ID, AGENT_SAFE, tx1, 2)
+      );
+      assert.entityCount("AgentSafe", 1);
+
+      // Permissionless oddity: the service NFT is transferred to the Agent
+      // Safe. It IS a Gnosis Safe, so getOrCreateMasterSafe proceeds and the
+      // address lands in both tables — the guard must keep the template
+      // single-instance.
+      mockGetOwners(AGENT_SAFE, [MASTER_EOA]);
+      mockGetThreshold(AGENT_SAFE, 1);
+      const tx2 = mockTx(704);
+      handleServiceNftTransfer(
+        newNftTransfer(MASTER_SAFE, AGENT_SAFE, SERVICE_ID, tx2, 0)
+      );
+
+      // The collision scenario is real: AGENT_SAFE is now BOTH an AgentSafe
+      // and a MasterSafe — exactly the state where the old per-entity guards
+      // spawned a second template.
+      assert.entityCount("AgentSafe", 1);
+      assert.fieldEquals(
+        "MasterSafe",
+        AGENT_SAFE.toHexString(),
+        "setupTransferSeen",
+        "false"
+      );
+    }
+  );
 });
 
 // ----------------- Helpers -----------------

--- a/subgraphs/pearl-transactions/tests/staking.test.ts
+++ b/subgraphs/pearl-transactions/tests/staking.test.ts
@@ -59,6 +59,11 @@ const DISALLOWED_IMPL = Address.fromString(
 );
 
 const SERVICE_ID = BigInt.fromI32(42);
+// Service.id is the serviceId as Bytes — compute it the same way the mapping
+// does so assertions match the stored id regardless of byte layout.
+const SERVICE_ID_HEX = Bytes.fromByteArray(
+  Bytes.fromBigInt(SERVICE_ID)
+).toHexString();
 const SERVICE_ID_2 = BigInt.fromI32(43);
 const EPOCH = BigInt.fromI32(7);
 const REWARD = BigInt.fromString("1500000000000000000"); // 1.5 OLAS
@@ -462,22 +467,22 @@ describe("pearl-transactions / Phase 1b — staking", () => {
       newServiceStaked(SERVICE_ID, EPOCH, MASTER_SAFE, AGENT_SAFE, STAKING_PROXY, tx)
     );
 
-    assert.fieldEquals("Service", "42", "state", "STAKED");
+    assert.fieldEquals("Service", SERVICE_ID_HEX, "state", "STAKED");
     assert.fieldEquals(
       "Service",
-      "42",
+      SERVICE_ID_HEX,
       "masterSafe",
       MASTER_SAFE.toHexString()
     );
     assert.fieldEquals(
       "Service",
-      "42",
+      SERVICE_ID_HEX,
       "agentSafe",
       AGENT_SAFE.toHexString()
     );
     assert.fieldEquals(
       "Service",
-      "42",
+      SERVICE_ID_HEX,
       "currentStakingContract",
       STAKING_PROXY.toHexString()
     );
@@ -527,7 +532,7 @@ describe("pearl-transactions / Phase 1b — staking", () => {
 
     assert.fieldEquals(
       "Service",
-      "42",
+      SERVICE_ID_HEX,
       "totalOlasRewardsClaimed",
       REWARD.toString()
     );
@@ -553,7 +558,7 @@ describe("pearl-transactions / Phase 1b — staking", () => {
       )
     );
 
-    assert.fieldEquals("Service", "42", "state", "UNSTAKED");
+    assert.fieldEquals("Service", SERVICE_ID_HEX, "state", "UNSTAKED");
     // currentStakingContract should be cleared (null).
     const id = tx2.concatI32(0);
     assert.fieldEquals(
@@ -609,7 +614,7 @@ describe("pearl-transactions / Phase 1b — staking", () => {
     // Service still gets nftCustodian updated.
     assert.fieldEquals(
       "Service",
-      "42",
+      SERVICE_ID_HEX,
       "nftCustodian",
       STAKING_PROXY.toHexString()
     );
@@ -687,7 +692,7 @@ describe("pearl-transactions / Phase 1b — staking", () => {
     // Service.totalOlasRewardsClaimed = 2x reward.
     assert.fieldEquals(
       "Service",
-      "42",
+      SERVICE_ID_HEX,
       "totalOlasRewardsClaimed",
       REWARD.plus(REWARD).toString()
     );
@@ -698,7 +703,7 @@ describe("pearl-transactions / Phase 1b — staking", () => {
     handleServiceStaked(
       newServiceStaked(SERVICE_ID, EPOCH, MASTER_SAFE, AGENT_SAFE, STAKING_PROXY, tx1)
     );
-    assert.fieldEquals("Service", "42", "state", "STAKED");
+    assert.fieldEquals("Service", SERVICE_ID_HEX, "state", "STAKED");
 
     // Three reward claims across epochs.
     const tx2 = mockTx(14);
@@ -753,12 +758,12 @@ describe("pearl-transactions / Phase 1b — staking", () => {
     // Cumulative: 4 × REWARD.
     assert.fieldEquals(
       "Service",
-      "42",
+      SERVICE_ID_HEX,
       "totalOlasRewardsClaimed",
       REWARD.times(BigInt.fromI32(4)).toString()
     );
 
     // Final state.
-    assert.fieldEquals("Service", "42", "state", "UNSTAKED");
+    assert.fieldEquals("Service", SERVICE_ID_HEX, "state", "UNSTAKED");
   });
 });

--- a/subgraphs/pearl-transactions/tests/staking.test.ts
+++ b/subgraphs/pearl-transactions/tests/staking.test.ts
@@ -451,6 +451,18 @@ describe("pearl-transactions / Phase 1b — staking", () => {
       "numAgentInstances",
       NUM_AGENT_INSTANCES.toString()
     );
+    // The proxy must ALSO land in the merged tracked-address table —
+    // classifyTransfer keys the reward-claim path on TrackedAddress(STAKING),
+    // not on StakingContract. The classification tests seed TrackedAddress
+    // manually, so without this assertion the producer→classifier wiring is
+    // uncovered (dropping the upsert would leave every test green while
+    // breaking reward-claim classification in production).
+    assert.fieldEquals(
+      "TrackedAddress",
+      STAKING_PROXY.toHexString(),
+      "role",
+      "STAKING"
+    );
   });
 
   test("InstanceCreated with disallowed implementation is skipped", () => {
@@ -459,6 +471,7 @@ describe("pearl-transactions / Phase 1b — staking", () => {
       newInstanceCreated(MASTER_SAFE, STAKING_PROXY, DISALLOWED_IMPL, tx)
     );
     assert.entityCount("StakingContract", 0);
+    assert.entityCount("TrackedAddress", 0);
   });
 
   test("ServiceStaked sets masterSafe + agentSafe + state + currentStakingContract", () => {


### PR DESCRIPTION
Implements the code-only proposals from **#148** (`INDEXING-PERFORMANCE.md`), skipping #1 (token start-blocks). This is the single **clean-sync release** the doc recommends — flipping `immutable` and changing entity shapes can't graft.

> Stacked on `feat/pearl-olas-sweep-category` (#147) so it keeps the `AGENT_OLAS_TO_MASTER` split, and **merges #145** (`fix/pearl-evicted-id-and-token-decimals`): with `FundsMovement` now immutable, the old eviction-id collision (`logIndex + i`) would be a **deterministic indexing halt** instead of a silent overwrite, so #145's two-segment id is a hard prerequisite of this release. Retarget to `main` once #147/#145 land.

## What's in it

**#2 — `TrackedAddress` merge.** Collapsed `TrackedSafe` / `TrackedEOA` / `StakingContract` lookups into one **immutable** `TrackedAddress` table (`role = MASTER | AGENT | MASTER_EOA | AGENT_EOA | STAKING`). `classifyTransfer`'s hot path now does **2 loads (from + to) instead of 6** with a fast exit for the ~99.99% untracked case; `getServiceRegistryAddress` resolves only in the dust branch; `getSrtuAddress` is memoized (it ran `Address.fromString` on every indexed transfer). Staking proxies get their `TrackedAddress(STAKING)` row in `handleInstanceCreated` — covered by a new producer→classifier wiring test.

**#3 — Immutable write-once entities.** `TrackedAddress`, `Token`, `StakingContract` → `@entity(immutable: true)`. graph-node skips block-range versioning → cheaper writes *and* cheaper reads.

**#4 — `BondMovement` split + `Service` Bytes id.** The only backfilled rows (SRTU bond deposit/refund) moved from `FundsMovement` into a small mutable `BondMovement`, letting the high-cardinality `FundsMovement` go **immutable**. `Service.id` is now **Bytes** (serviceId as Bytes), halving every `FundsMovement.service` FK.

**#5 — Spec bump + cleanups.** `specVersion 1.0.0 → 1.3.0`, `apiVersion 0.0.7 → 0.0.9` across the template **and the four committed per-network manifests** (the deploy workflow builds those as-is). No declared eth_calls — would turn the one-shot `getOwners`/`getThreshold` into per-event RPC. Removed redundant double-saves (pending-bond counter; the two `Service` saves). The `getOrCreateMasterSafe` re-sighting save is intentionally kept — it maintains `lastActivityTimestamp` (a real consumer field) and only fires on low-volume registry/staking events.

**Docs:** README + STEP5 queries rewritten for the union (`bondType` selected on `fundsMovements` would now be a GraphQL validation error); category table marks `SERVICE_BOND_*` as `BondMovement` rows; manifest `entities:` lists refreshed; the load-bearing write-order invariant in `getOrCreateAgentSafe` (Master Safe doubles as service operator) is documented in-code.

## ⚠️ Consumer-facing breaks (complete list — FE must update before deploy)
1. **Union required:** a complete ledger is `fundsMovements` **∪** `bondMovements` — bond rows are no longer in `fundsMovements`.
2. **`FundsMovement.bondType` is deleted** — any query selecting it hard-errors at GraphQL validation (the old README example did).
3. `SERVICE_BOND_DEPOSIT` / `SERVICE_BOND_REFUND` never appear as `FundsMovement.category` values.
4. `Service.id` is Bytes — read **`service.serviceId`** (numeric) for display, and any **id filters** (`where: { service: … }` on FundsMovement/BondMovement/DailyServiceFunds/AgentFundingEvent/AgentSafe) must use the `Bytes.fromBigInt` hex form (e.g. service 42 → `0x2a000000`), not `"42"`.
5. `TrackedSafe` / `TrackedEOA` entity types removed from the API; `TrackedAddress` added (internal-by-design, but previously queryable).
6. `AgentFundingEvent.id` derivation changed (serviceId bytes instead of UTF-8 string) — opaque ids, matters only if persisted client-side.
7. Unchanged, for the record: `FundsMovement.id` scheme and the `DailyServiceFunds.id` string format (`"42-<day>"`).

I'll do the FE union in lockstep with the deploy.

## Validation
- 48 Matchstick tests green (47 + #145's eviction-collision regression test); `codegen` + `build` clean on graph-cli 0.98.1 / graph-ts 0.38.2.
- Adversarial self-review (agent) ran against the #148 plan; all confirmed findings addressed in `530f25c` (manifests regenerated, README/STEP5 union queries, STAKING wiring test, SRTU memoization, invariant comment).
- Skipped #1 (token start-blocks) — needs the per-chain `MIN(firstSeenBlock)` query + a graft; deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)