### PR TITLE
docs(pearl-transactions): move IMPLEMENTATION-PLAN.md out of orphaned pearl-funds/ + refresh status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ subgraphs/
   liquidity/                   # Protocol Owned Liquidity — Ethereum mainnet (OLAS-ETH + bridged L2 LP tokens)
   liquidity-l2/                # Protocol Owned Liquidity — L2 pools (6 networks; template pattern with manual overrides for Base dual-pool and Celo Ubeswap)
   new-mech-fees/               # Multi-network mech fees (Gnosis, Base, Polygon, Optimism, Arbitrum, Celo, Ethereum — 7 networks)
-  pearl-transactions/          # Pearl Master/Agent Safe funds movement → wallet transaction history, VLOP-73 (Gnosis, Polygon, Optimism, Base — template pattern). Phases 1a/1b/2a/2b shipped; Gnosis+Polygon deployed. Design: subgraphs/pearl-funds/IMPLEMENTATION-PLAN.md.
+  pearl-transactions/          # Pearl Master/Agent Safe funds movement → wallet transaction history, VLOP-73 (Gnosis, Polygon, Optimism, Base — template pattern). Phases 1a/1b/2a/2b shipped; Gnosis+Polygon deployed. Design: subgraphs/pearl-transactions/IMPLEMENTATION-PLAN.md.
   predict/                     # Prediction markets (Omen on Gnosis, Polymarket on Polygon)
   service-registry/            # Service registry (8 networks; hybrid: hand-crafted mainnet manifest + L2 template)
   staking/                     # Staking contracts (7 networks, template pattern)

--- a/subgraphs/pearl-transactions/CLAUDE.md
+++ b/subgraphs/pearl-transactions/CLAUDE.md
@@ -4,10 +4,10 @@ Funds-movement subgraph for Pearl **Master Safe / Agent Safe** accounts on
 Gnosis, Polygon, Optimism, Base. Powers the Pearl wallet transaction-history
 view (VLOP-73): every fund movement in/out of the Master Safe, classified
 into wallet-history rows. Design-of-record:
-[`IMPLEMENTATION-PLAN.md`](../pearl-funds/IMPLEMENTATION-PLAN.md).
+[`IMPLEMENTATION-PLAN.md`](./IMPLEMENTATION-PLAN.md).
 
 (Directory was renamed from `pearl-funds` per PR #129 review §11 #5 to match
-the consumer.)
+the consumer; the plan doc moved here with it.)
 
 ## Status — all phases implemented; deployed to Studio
 
@@ -19,13 +19,22 @@ the consumer.)
 | 2b | #138 | Per-chain stablecoin `Transfer` data sources — USDC / USDC.e / pUSD |
 
 **Deployed:** `pearl-gnosis-transactions` + `pearl-polygon-transactions`
-**v0.0.5** (Studio account `1716136`). Optimism/Base manifests build but
-aren't deployed on the company account yet (validated on a personal Studio
-account first; the 3-subgraph cap is the blocker).
+**v0.0.5** (Studio account `1716136`); Optimism/Base validated on a
+personal Studio account (the 3-subgraph cap is the company-account
+blocker). All four networks are queryable as **published** subgraphs via
+the Graph gateway (`gateway.thegraph.com/api/subgraphs/id/<ID>`):
+gnosis `29C7oxkMpkE5Pt1LPLLa5HkcAZchCFEd1pHGVTDMsZHT`, polygon
+`FAhPh2M5JXjGysCHG1RzABKXr9efmh92w9bARk5DJ5iV`, optimism
+`JDUWGET5wYQufGsk3VqV9pwDjx7gPDpeGYeWn4pRR9H3`, base
+`77FkWBy4o1LpXkFAQb1hTqzBvaYb4VXYxxYeChih4RmY`. Sync as of 2026-06-12:
+Gnosis at chain head; Optimism ≈1 day out; Base ≈11 days; Polygon ≈15
+days — it indexes ~5 blk/s through the USDC.e-dense range (the §2.2 cost
+hotspot; remediation in
+[`INDEXING-PERFORMANCE.md`](./INDEXING-PERFORMANCE.md)).
 
 **Remaining (Step 5 / 9):** on-Studio verification against real services
 (see [`STEP5-VERIFICATION.md`](./STEP5-VERIFICATION.md)); Optimism/Base
-deploy; watch Polygon USDC.e sync (the §2.2 cost hotspot).
+company-account deploy; watch Polygon USDC.e sync.
 
 ## Entities (`schema.graphql`)
 

--- a/subgraphs/pearl-transactions/IMPLEMENTATION-PLAN.md
+++ b/subgraphs/pearl-transactions/IMPLEMENTATION-PLAN.md
@@ -1,9 +1,9 @@
 # Pearl Funds-Movement Subgraph — Implementation Plan
 
-**Status:** Implemented through Phase 2a (PRs #131/#132/#133 merged to `main`); Phase 2b (#138) in review. This plan is the design-of-record.
+**Status:** All phases implemented and merged to `main` (1a #131, 1b #132, 2a #133, 2b #138, plus follow-ups #143/#144/#147). All four networks are published on The Graph; as of 2026-06-12 Gnosis is at chain head, Optimism/Base/Polygon are still backfilling (Polygon slowest — the §6.3 USDC.e density cost; remediation proposals in [`INDEXING-PERFORMANCE.md`](./INDEXING-PERFORMANCE.md)). This plan is the design-of-record.
 **Subgraph:** `subgraphs/pearl-transactions/` (renamed from `pearl-funds` per §11 #5)
 **Target networks (v1):** Gnosis, Polygon, Optimism, Base
-**Last updated:** 2026-06-01 (Rev. 7 — Phase 2b token-set reconciliation: pUSD is a separate Polymarket contract `0xC011a7E1…`, not a USDC.e UI alias; §4.5 token table + §4.3 networks table rebuilt to the shipped per-chain set (USDC / USDC.e / pUSD); §6.3 records the ship-on-chain decision + Polygon USDC.e rollback condition; Polystrat funds in USDC + pUSD. Rev. 6 — back-propagated the PR #131/#132 producer/consumer fixes so the plan matches shipped code: §3.3 SRTU is indexed, §4.6 SRTU-before-SR event order, §5.1/§5.2 inverted bond-attribution entities + handlers, §5.1 FundsMovement/Token mutability, §5.2 dual NFT guard + handleServiceStaked null-check, §5.4/§7/§8 staleness, pearl-transactions path. Rev. 5 — product decisions finalised: OPENING_BALANCE rows removed, opening balances delegated to the frontend via historyFloorBlock; native → Agent EOA confirmed accepted gap; AC #3 = Path A. Rev. 4 addressed PR #130 review + §11 #6. Rev. 3 added §4.5/§4.6. Rev. 2 added SRTU bond indexing, agent-ID anti-hardcoding, Master EOA tracking. Rev. 1 addressed PR #129 feedback.)
+**Last updated:** 2026-06-12 (Rev. 8 — doc moved from `subgraphs/pearl-funds/` (the rename-orphaned directory) into `subgraphs/pearl-transactions/`; status refreshed to all-phases-shipped + four networks published; stale `pearl-funds` path/name references updated. Rev. 7 — Phase 2b token-set reconciliation: pUSD is a separate Polymarket contract `0xC011a7E1…`, not a USDC.e UI alias; §4.5 token table + §4.3 networks table rebuilt to the shipped per-chain set (USDC / USDC.e / pUSD); §6.3 records the ship-on-chain decision + Polygon USDC.e rollback condition; Polystrat funds in USDC + pUSD. Rev. 6 — back-propagated the PR #131/#132 producer/consumer fixes so the plan matches shipped code: §3.3 SRTU is indexed, §4.6 SRTU-before-SR event order, §5.1/§5.2 inverted bond-attribution entities + handlers, §5.1 FundsMovement/Token mutability, §5.2 dual NFT guard + handleServiceStaked null-check, §5.4/§7/§8 staleness, pearl-transactions path. Rev. 5 — product decisions finalised: OPENING_BALANCE rows removed, opening balances delegated to the frontend via historyFloorBlock; native → Agent EOA confirmed accepted gap; AC #3 = Path A. Rev. 4 addressed PR #130 review + §11 #6. Rev. 3 added §4.5/§4.6. Rev. 2 added SRTU bond indexing, agent-ID anti-hardcoding, Master EOA tracking. Rev. 1 addressed PR #129 feedback.)
 
 This document scopes a new subgraph that indexes **funds movement for the
 Master Safe and Agent Safe of Pearl predict services**. It covers Phase 1
@@ -189,7 +189,7 @@ This matches `staking` and `service-registry`.
 
 ### 4.1 New subgraph, template pattern
 
-`subgraphs/pearl-funds/` — `subgraph.template.yaml` + `networks.json` +
+`subgraphs/pearl-transactions/` — `subgraph.template.yaml` + `networks.json` +
 the shared `scripts/generate-manifests.js`, exactly like `staking`. All
 four target networks share identical data-source *shapes*; only addresses
 and start blocks differ. Per-network constants resolve via a
@@ -365,7 +365,7 @@ Notes:
 - **Other Pearl agent types (out of v1 scope) have different asset sets.**
   Optimus/babydegen on Optimism trades sDAI / MORPHO / DAI / USDC / WETH
   and is covered by `babydegen-optimism`. agents.fun and Modius have
-  their own asset sets, not enumerated here. Adding them to pearl-funds
+  their own asset sets, not enumerated here. Adding them to pearl-transactions
   in a later revision is a per-asset addition of a `Transfer` data source
   + `TrackedAddress` seeding, not a re-architecture.
 - **The service NFT (ERC-721)** is not an "asset" in the wallet-balance
@@ -375,7 +375,7 @@ Notes:
 ### 4.6 Funds-flow diagrams
 
 Three diagrams scoped to v1 (Pearl predict). All entities shown here are
-either indexed by `pearl-funds` (the boxed ones) or referenced by it
+either indexed by `pearl-transactions` (the boxed ones) or referenced by it
 (the dashed ones).
 
 #### A. Wallet hierarchy + ownership
@@ -513,7 +513,7 @@ flowchart LR
 
 The yellow/dashed `POLY` node is covered by `predict-polymarket`
 (joined on Agent Safe address); arrows entering/leaving it represent
-the boundary where pearl-funds' raw `Transfer` ledger ends and the
+the boundary where pearl-transactions' raw `Transfer` ledger ends and the
 in-market bet ledger begins. The same pattern holds for omenstrat on
 Gnosis (substitute Polymarket → Omen FPMM, USDC.e → WXDAI).
 
@@ -1215,9 +1215,9 @@ CI runs `yarn graph codegen` + `yarn graph test` via the `ci.yml` matrix.
    noting: `predict-omen` in *this* repo still has no agent-ID filter;
    the `PREDICT_AGENT_ID = 25` fix is stranded in the unmerged
    `valory-xyz/autonolas-subgraph` PR #89. Recommend porting it
-   independently. (Note: per §2.3, this `pearl-funds` subgraph
+   independently. (Note: per §2.3, this `pearl-transactions` subgraph
    deliberately does **not** gate on agent ID — so this open question
-   is orthogonal to pearl-funds and only affects the trade subgraph.)
+   is orthogonal to pearl-transactions and only affects the trade subgraph.)
 5. ~~**Subgraph name**~~ **Resolved:** renamed to `pearl-transactions`
    (PR #130 scaffold). Directory, CI matrix entry, and Studio slug all
    use `pearl-transactions`.

--- a/subgraphs/pearl-transactions/README.md
+++ b/subgraphs/pearl-transactions/README.md
@@ -4,12 +4,12 @@ Indexes **funds movement for Pearl Master Safe and Agent Safe accounts** on
 Gnosis, Polygon, Optimism, Base. The on-chain backend for the Pearl wallet
 transaction-history view (VLOP-73).
 
-> **Status — implemented (phases 1a/1b/2a/2b), deployed.** Gnosis + Polygon
-> are live on Studio (`pearl-gnosis-transactions`, `pearl-polygon-transactions`,
-> v0.0.5). Optimism/Base manifests build but aren't deployed on the company
-> account yet. See
+> **Status — implemented (phases 1a/1b/2a/2b); all four networks published
+> on The Graph.** As of 2026-06-12 Gnosis is at chain head; Optimism, Base
+> and Polygon are still backfilling (Polygon slowest — the USDC.e-dense
+> range; see [`INDEXING-PERFORMANCE.md`](./INDEXING-PERFORMANCE.md)). See
 > [`CLAUDE.md`](./CLAUDE.md) for architecture and
-> [`IMPLEMENTATION-PLAN.md`](../pearl-funds/IMPLEMENTATION-PLAN.md) for the design.
+> [`IMPLEMENTATION-PLAN.md`](./IMPLEMENTATION-PLAN.md) for the design.
 
 ## What it covers
 
@@ -113,7 +113,7 @@ verification checklist.
 
 ## Related
 
-- [`IMPLEMENTATION-PLAN.md`](../pearl-funds/IMPLEMENTATION-PLAN.md) — full design.
+- [`IMPLEMENTATION-PLAN.md`](./IMPLEMENTATION-PLAN.md) — full design.
 - [`subgraphs/staking`](../staking) — `StakingFactory`/`StakingProxy` source.
 - [`subgraphs/service-registry`](../service-registry) — `ServiceRegistryL2` source.
 - [`predict-polymarket`](../predict/predict-polymarket) / [`predict-omen`](../predict/predict-omen)


### PR DESCRIPTION
## What

`subgraphs/pearl-funds/` was left holding only `IMPLEMENTATION-PLAN.md` when the subgraph was renamed to `pearl-transactions` (PR #129 review §11 #5). This moves the plan next to the implementation it documents and deletes the orphan directory.

## Doc status refresh (Rev. 8)

While moving, the stale status surfaces were brought up to date:

- **Plan header**: all phases (1a #131, 1b #132, 2a #133, 2b #138 + follow-ups #143/#144/#147) merged; all four networks published on The Graph. Sync state as of 2026-06-12: Gnosis at chain head; Optimism ≈1 day out; Base ≈11 days; Polygon ≈15 days (≈5 blk/s through the USDC.e-dense range — the cost hotspot `INDEXING-PERFORMANCE.md` addresses).
- **Internal references**: remaining `pearl-funds` path/name mentions updated to `pearl-transactions` (the rename-provenance notes are kept).
- **README / subgraph CLAUDE.md**: status blocks updated (four published gateway IDs listed in CLAUDE.md), relative links now point at `./IMPLEMENTATION-PLAN.md`.
- **Root CLAUDE.md**: design-of-record pointer updated.

Docs-only — no schema/mapping/manifest changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)