### PR TITLE
fix(pearl-transactions): align stablecoin data-source apiVersion to 0.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "undici": "^7.24.0",
     "apisauce": "^3.2.2",
     "uuid": "^11.1.1",
+    "form-data": "^4.0.6",
     "**/micromatch/picomatch": "2.3.2",
     "**/@graphprotocol/graph-cli/glob": "^11.1.0",
     "**/@graphprotocol/graph-cli/yaml": "^2.8.3"

--- a/scripts/generate-manifests.js
+++ b/scripts/generate-manifests.js
@@ -89,7 +89,7 @@ function renderErc20TokenDataSources(graphNetwork, networkData) {
       startBlock: ${startBlock}
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         - FundsMovement

--- a/subgraphs/pearl-transactions/subgraph.base.yaml
+++ b/subgraphs/pearl-transactions/subgraph.base.yaml
@@ -154,7 +154,7 @@ dataSources:
       startBlock: 10827380
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         - FundsMovement

--- a/subgraphs/pearl-transactions/subgraph.gnosis.yaml
+++ b/subgraphs/pearl-transactions/subgraph.gnosis.yaml
@@ -154,7 +154,7 @@ dataSources:
       startBlock: 27871084
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         - FundsMovement
@@ -177,7 +177,7 @@ dataSources:
       startBlock: 27871084
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         - FundsMovement

--- a/subgraphs/pearl-transactions/subgraph.matic.yaml
+++ b/subgraphs/pearl-transactions/subgraph.matic.yaml
@@ -154,7 +154,7 @@ dataSources:
       startBlock: 80360433
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         - FundsMovement
@@ -177,7 +177,7 @@ dataSources:
       startBlock: 80360433
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         - FundsMovement
@@ -200,7 +200,7 @@ dataSources:
       startBlock: 80360433
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         - FundsMovement

--- a/subgraphs/pearl-transactions/subgraph.optimism.yaml
+++ b/subgraphs/pearl-transactions/subgraph.optimism.yaml
@@ -154,7 +154,7 @@ dataSources:
       startBlock: 116423039
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         - FundsMovement
@@ -177,7 +177,7 @@ dataSources:
       startBlock: 116423039
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
         - FundsMovement

--- a/yarn.lock
+++ b/yarn.lock
@@ -1718,16 +1718,16 @@ foreground-child@^3.3.1:
     cross-spawn "^7.0.6"
     signal-exit "^4.0.1"
 
-form-data@^4.0.5:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.5.tgz#b49e48858045ff4cbf6b03e1805cebcad3679053"
-  integrity sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==
+form-data@^4.0.5, form-data@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.6.tgz#28e864e1b786dbebb68db1f452f9635278665827"
+  integrity sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     es-set-tostringtag "^2.1.0"
-    hasown "^2.0.2"
-    mime-types "^2.1.12"
+    hasown "^2.0.4"
+    mime-types "^2.1.35"
 
 fs-constants@^1.0.0:
   version "1.0.0"
@@ -1964,6 +1964,13 @@ hasown@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.3.tgz#5e5c2b15b60370a4c7930c383dfb76bf17bc403c"
   integrity sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==
+  dependencies:
+    function-bind "^1.1.2"
+
+hasown@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.4.tgz#8c62d8cb90beb2aad5d0a5b67581ad9854c3f003"
+  integrity sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==
   dependencies:
     function-bind "^1.1.2"
 
@@ -2676,7 +2683,7 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.1.12:
+mime-types@^2.1.35:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==


### PR DESCRIPTION
## Problem

The v0.0.7 deploy failed on **all four networks** with:

```
subgraph validation error: [subgraph must use a single apiVersion across
its data sources. Found: 0.0.7, 0.0.9]
```

## Cause

`scripts/generate-manifests.js` injects the per-network ERC-20 stablecoin
data sources with mapping `apiVersion: 0.0.7`, but the rest of
`subgraph.template.yaml` (and every hand-written data source) is on `0.0.9`.
The deploy workflow builds the **committed** manifest as-is, so the mismatch
reached Studio validation.

## Fix

- Bump the injected erc20 block to `apiVersion: 0.0.9`.
- Regenerate the four committed manifests (only apiVersion lines change:
  base 1, gnosis 2, matic 3, optimism 2 stablecoin sources).

Build is unaffected (0.0.9 is already the apiVersion used by all other
sources in the same build); this only unblocks Studio deploy validation.

After merge, re-trigger the v0.0.7 Deploy Subgraph runs for the four
`pearl-*-transactions` slugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)