### PR TITLE
chore(supply-chain): bump undici to ^7.28.0 (3 HIGH advisories)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "follow-redirects": "^1.16.0",
     "ejs": "^3.1.10",
     "tmp": "^0.2.6",
-    "undici": "^7.24.0",
+    "undici": "^7.28.0",
     "apisauce": "^3.2.2",
     "form-data": "^4.0.6",
     "uuid": "^11.1.1",

--- a/subgraphs/babydegen/babydegen-optimism/package.json
+++ b/subgraphs/babydegen/babydegen-optimism/package.json
@@ -22,7 +22,7 @@
     "follow-redirects": "^1.16.0",
     "ejs": "^3.1.10",
     "tmp": "^0.2.6",
-    "undici": "^7.24.0",
+    "undici": "^7.28.0",
     "apisauce": "^3.2.2",
     "form-data": "^4.0.6",
     "uuid": "^11.1.1",

--- a/subgraphs/babydegen/babydegen-optimism/yarn.lock
+++ b/subgraphs/babydegen/babydegen-optimism/yarn.lock
@@ -2944,10 +2944,10 @@ unbzip2-stream@^1.0.9:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.24.6.tgz#61275b485d7fd4e9d269c7cf04ec2873c9cc0f91"
   integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
 
-undici@7.16.0, undici@^7.24.0:
-  version "7.26.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-7.26.0.tgz#d413a2b5752e3e71e003bb268dec32b9a0ad0ce7"
-  integrity sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==
+undici@7.16.0, undici@^7.28.0:
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.28.0.tgz#97d64564198b285bc281f0e8e29597e3d11fe7ec"
+  integrity sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==
 
 universalify@^2.0.0:
   version "2.0.1"

--- a/subgraphs/governance/package.json
+++ b/subgraphs/governance/package.json
@@ -22,7 +22,7 @@
     "follow-redirects": "^1.16.0",
     "ejs": "^3.1.10",
     "tmp": "^0.2.6",
-    "undici": "^7.24.0",
+    "undici": "^7.28.0",
     "apisauce": "^3.2.2",
     "form-data": "^4.0.6",
     "uuid": "^11.1.1",

--- a/subgraphs/governance/yarn.lock
+++ b/subgraphs/governance/yarn.lock
@@ -2944,10 +2944,10 @@ unbzip2-stream@^1.0.9:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.24.6.tgz#61275b485d7fd4e9d269c7cf04ec2873c9cc0f91"
   integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
 
-undici@7.16.0, undici@^7.24.0:
-  version "7.26.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-7.26.0.tgz#d413a2b5752e3e71e003bb268dec32b9a0ad0ce7"
-  integrity sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==
+undici@7.16.0, undici@^7.28.0:
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.28.0.tgz#97d64564198b285bc281f0e8e29597e3d11fe7ec"
+  integrity sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==
 
 universalify@^2.0.0:
   version "2.0.1"

--- a/subgraphs/legacy-mech-fees/package.json
+++ b/subgraphs/legacy-mech-fees/package.json
@@ -22,7 +22,7 @@
     "follow-redirects": "^1.16.0",
     "ejs": "^3.1.10",
     "tmp": "^0.2.6",
-    "undici": "^7.24.0",
+    "undici": "^7.28.0",
     "apisauce": "^3.2.2",
     "form-data": "^4.0.6",
     "uuid": "^11.1.1",

--- a/subgraphs/legacy-mech-fees/yarn.lock
+++ b/subgraphs/legacy-mech-fees/yarn.lock
@@ -2944,10 +2944,10 @@ unbzip2-stream@^1.0.9:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.24.6.tgz#61275b485d7fd4e9d269c7cf04ec2873c9cc0f91"
   integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
 
-undici@7.16.0, undici@^7.24.0:
-  version "7.26.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-7.26.0.tgz#d413a2b5752e3e71e003bb268dec32b9a0ad0ce7"
-  integrity sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==
+undici@7.16.0, undici@^7.28.0:
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.28.0.tgz#97d64564198b285bc281f0e8e29597e3d11fe7ec"
+  integrity sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==
 
 universalify@^2.0.0:
   version "2.0.1"

--- a/subgraphs/liquidity-l2/package.json
+++ b/subgraphs/liquidity-l2/package.json
@@ -23,7 +23,7 @@
     "follow-redirects": "^1.16.0",
     "ejs": "^3.1.10",
     "tmp": "^0.2.6",
-    "undici": "^7.24.0",
+    "undici": "^7.28.0",
     "apisauce": "^3.2.2",
     "form-data": "^4.0.6",
     "uuid": "^11.1.1",

--- a/subgraphs/liquidity-l2/yarn.lock
+++ b/subgraphs/liquidity-l2/yarn.lock
@@ -2944,10 +2944,10 @@ unbzip2-stream@^1.0.9:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.24.6.tgz#61275b485d7fd4e9d269c7cf04ec2873c9cc0f91"
   integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
 
-undici@7.16.0, undici@^7.24.0:
-  version "7.26.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-7.26.0.tgz#d413a2b5752e3e71e003bb268dec32b9a0ad0ce7"
-  integrity sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==
+undici@7.16.0, undici@^7.28.0:
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.28.0.tgz#97d64564198b285bc281f0e8e29597e3d11fe7ec"
+  integrity sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==
 
 universalify@^2.0.0:
   version "2.0.1"

--- a/subgraphs/liquidity/package.json
+++ b/subgraphs/liquidity/package.json
@@ -22,7 +22,7 @@
     "follow-redirects": "^1.16.0",
     "ejs": "^3.1.10",
     "tmp": "^0.2.6",
-    "undici": "^7.24.0",
+    "undici": "^7.28.0",
     "apisauce": "^3.2.2",
     "form-data": "^4.0.6",
     "uuid": "^11.1.1",

--- a/subgraphs/liquidity/yarn.lock
+++ b/subgraphs/liquidity/yarn.lock
@@ -2944,10 +2944,10 @@ unbzip2-stream@^1.0.9:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.24.6.tgz#61275b485d7fd4e9d269c7cf04ec2873c9cc0f91"
   integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
 
-undici@7.16.0, undici@^7.24.0:
-  version "7.26.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-7.26.0.tgz#d413a2b5752e3e71e003bb268dec32b9a0ad0ce7"
-  integrity sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==
+undici@7.16.0, undici@^7.28.0:
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.28.0.tgz#97d64564198b285bc281f0e8e29597e3d11fe7ec"
+  integrity sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==
 
 universalify@^2.0.0:
   version "2.0.1"

--- a/subgraphs/new-mech-fees/package.json
+++ b/subgraphs/new-mech-fees/package.json
@@ -30,7 +30,7 @@
     "follow-redirects": "^1.16.0",
     "ejs": "^3.1.10",
     "tmp": "^0.2.6",
-    "undici": "^7.24.0",
+    "undici": "^7.28.0",
     "apisauce": "^3.2.2",
     "form-data": "^4.0.6",
     "uuid": "^11.1.1",

--- a/subgraphs/new-mech-fees/yarn.lock
+++ b/subgraphs/new-mech-fees/yarn.lock
@@ -2944,10 +2944,10 @@ unbzip2-stream@^1.0.9:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.24.6.tgz#61275b485d7fd4e9d269c7cf04ec2873c9cc0f91"
   integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
 
-undici@7.16.0, undici@^7.24.0:
-  version "7.26.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-7.26.0.tgz#d413a2b5752e3e71e003bb268dec32b9a0ad0ce7"
-  integrity sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==
+undici@7.16.0, undici@^7.28.0:
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.28.0.tgz#97d64564198b285bc281f0e8e29597e3d11fe7ec"
+  integrity sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==
 
 universalify@^2.0.0:
   version "2.0.1"

--- a/subgraphs/pearl-transactions/package.json
+++ b/subgraphs/pearl-transactions/package.json
@@ -27,7 +27,7 @@
     "follow-redirects": "^1.16.0",
     "ejs": "^3.1.10",
     "tmp": "^0.2.6",
-    "undici": "^7.24.0",
+    "undici": "^7.28.0",
     "apisauce": "^3.2.2",
     "uuid": "^11.1.1",
     "form-data": "^4.0.6",

--- a/subgraphs/pearl-transactions/yarn.lock
+++ b/subgraphs/pearl-transactions/yarn.lock
@@ -2944,10 +2944,10 @@ unbzip2-stream@^1.0.9:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.24.6.tgz#61275b485d7fd4e9d269c7cf04ec2873c9cc0f91"
   integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
 
-undici@7.16.0, undici@^7.24.0:
-  version "7.26.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-7.26.0.tgz#d413a2b5752e3e71e003bb268dec32b9a0ad0ce7"
-  integrity sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==
+undici@7.16.0, undici@^7.28.0:
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.28.0.tgz#97d64564198b285bc281f0e8e29597e3d11fe7ec"
+  integrity sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==
 
 universalify@^2.0.0:
   version "2.0.1"

--- a/subgraphs/predict/predict-omen/package.json
+++ b/subgraphs/predict/predict-omen/package.json
@@ -22,7 +22,7 @@
     "follow-redirects": "^1.16.0",
     "ejs": "^3.1.10",
     "tmp": "^0.2.6",
-    "undici": "^7.24.0",
+    "undici": "^7.28.0",
     "apisauce": "^3.2.2",
     "form-data": "^4.0.6",
     "uuid": "^11.1.1",

--- a/subgraphs/predict/predict-omen/yarn.lock
+++ b/subgraphs/predict/predict-omen/yarn.lock
@@ -2944,10 +2944,10 @@ unbzip2-stream@^1.0.9:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.24.6.tgz#61275b485d7fd4e9d269c7cf04ec2873c9cc0f91"
   integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
 
-undici@7.16.0, undici@^7.24.0:
-  version "7.26.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-7.26.0.tgz#d413a2b5752e3e71e003bb268dec32b9a0ad0ce7"
-  integrity sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==
+undici@7.16.0, undici@^7.28.0:
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.28.0.tgz#97d64564198b285bc281f0e8e29597e3d11fe7ec"
+  integrity sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==
 
 universalify@^2.0.0:
   version "2.0.1"

--- a/subgraphs/predict/predict-polymarket/package.json
+++ b/subgraphs/predict/predict-polymarket/package.json
@@ -22,7 +22,7 @@
     "follow-redirects": "^1.16.0",
     "ejs": "^3.1.10",
     "tmp": "^0.2.6",
-    "undici": "^7.24.0",
+    "undici": "^7.28.0",
     "apisauce": "^3.2.2",
     "form-data": "^4.0.6",
     "uuid": "^11.1.1",

--- a/subgraphs/predict/predict-polymarket/yarn.lock
+++ b/subgraphs/predict/predict-polymarket/yarn.lock
@@ -2944,10 +2944,10 @@ unbzip2-stream@^1.0.9:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.24.6.tgz#61275b485d7fd4e9d269c7cf04ec2873c9cc0f91"
   integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
 
-undici@7.16.0, undici@^7.24.0:
-  version "7.26.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-7.26.0.tgz#d413a2b5752e3e71e003bb268dec32b9a0ad0ce7"
-  integrity sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==
+undici@7.16.0, undici@^7.28.0:
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.28.0.tgz#97d64564198b285bc281f0e8e29597e3d11fe7ec"
+  integrity sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==
 
 universalify@^2.0.0:
   version "2.0.1"

--- a/subgraphs/service-registry/package.json
+++ b/subgraphs/service-registry/package.json
@@ -30,7 +30,7 @@
     "follow-redirects": "^1.16.0",
     "ejs": "^3.1.10",
     "tmp": "^0.2.6",
-    "undici": "^7.24.0",
+    "undici": "^7.28.0",
     "apisauce": "^3.2.2",
     "form-data": "^4.0.6",
     "uuid": "^11.1.1",

--- a/subgraphs/service-registry/yarn.lock
+++ b/subgraphs/service-registry/yarn.lock
@@ -2944,10 +2944,10 @@ unbzip2-stream@^1.0.9:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.24.6.tgz#61275b485d7fd4e9d269c7cf04ec2873c9cc0f91"
   integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
 
-undici@7.16.0, undici@^7.24.0:
-  version "7.26.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-7.26.0.tgz#d413a2b5752e3e71e003bb268dec32b9a0ad0ce7"
-  integrity sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==
+undici@7.16.0, undici@^7.28.0:
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.28.0.tgz#97d64564198b285bc281f0e8e29597e3d11fe7ec"
+  integrity sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==
 
 universalify@^2.0.0:
   version "2.0.1"

--- a/subgraphs/staking/package.json
+++ b/subgraphs/staking/package.json
@@ -30,7 +30,7 @@
     "follow-redirects": "^1.16.0",
     "ejs": "^3.1.10",
     "tmp": "^0.2.6",
-    "undici": "^7.24.0",
+    "undici": "^7.28.0",
     "apisauce": "^3.2.2",
     "form-data": "^4.0.6",
     "uuid": "^11.1.1",

--- a/subgraphs/staking/yarn.lock
+++ b/subgraphs/staking/yarn.lock
@@ -2944,10 +2944,10 @@ unbzip2-stream@^1.0.9:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.24.6.tgz#61275b485d7fd4e9d269c7cf04ec2873c9cc0f91"
   integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
 
-undici@7.16.0, undici@^7.24.0:
-  version "7.26.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-7.26.0.tgz#d413a2b5752e3e71e003bb268dec32b9a0ad0ce7"
-  integrity sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==
+undici@7.16.0, undici@^7.28.0:
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.28.0.tgz#97d64564198b285bc281f0e8e29597e3d11fe7ec"
+  integrity sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==
 
 universalify@^2.0.0:
   version "2.0.1"

--- a/subgraphs/tokenomics-eth/package.json
+++ b/subgraphs/tokenomics-eth/package.json
@@ -22,7 +22,7 @@
     "follow-redirects": "^1.16.0",
     "ejs": "^3.1.10",
     "tmp": "^0.2.6",
-    "undici": "^7.24.0",
+    "undici": "^7.28.0",
     "apisauce": "^3.2.2",
     "form-data": "^4.0.6",
     "uuid": "^11.1.1",

--- a/subgraphs/tokenomics-eth/yarn.lock
+++ b/subgraphs/tokenomics-eth/yarn.lock
@@ -2944,10 +2944,10 @@ unbzip2-stream@^1.0.9:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.24.6.tgz#61275b485d7fd4e9d269c7cf04ec2873c9cc0f91"
   integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
 
-undici@7.16.0, undici@^7.24.0:
-  version "7.26.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-7.26.0.tgz#d413a2b5752e3e71e003bb268dec32b9a0ad0ce7"
-  integrity sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==
+undici@7.16.0, undici@^7.28.0:
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.28.0.tgz#97d64564198b285bc281f0e8e29597e3d11fe7ec"
+  integrity sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==
 
 universalify@^2.0.0:
   version "2.0.1"

--- a/subgraphs/tokenomics-l2/package.json
+++ b/subgraphs/tokenomics-l2/package.json
@@ -23,7 +23,7 @@
     "follow-redirects": "^1.16.0",
     "ejs": "^3.1.10",
     "tmp": "^0.2.6",
-    "undici": "^7.24.0",
+    "undici": "^7.28.0",
     "apisauce": "^3.2.2",
     "form-data": "^4.0.6",
     "uuid": "^11.1.1",

--- a/subgraphs/tokenomics-l2/yarn.lock
+++ b/subgraphs/tokenomics-l2/yarn.lock
@@ -2944,10 +2944,10 @@ unbzip2-stream@^1.0.9:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.24.6.tgz#61275b485d7fd4e9d269c7cf04ec2873c9cc0f91"
   integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
 
-undici@7.16.0, undici@^7.24.0:
-  version "7.26.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-7.26.0.tgz#d413a2b5752e3e71e003bb268dec32b9a0ad0ce7"
-  integrity sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==
+undici@7.16.0, undici@^7.28.0:
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.28.0.tgz#97d64564198b285bc281f0e8e29597e3d11fe7ec"
+  integrity sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==
 
 universalify@^2.0.0:
   version "2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3763,10 +3763,10 @@ unbzip2-stream@^1.0.9:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.24.6.tgz#61275b485d7fd4e9d269c7cf04ec2873c9cc0f91"
   integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
 
-undici@7.16.0, undici@^6.25.0, undici@^7.24.0:
-  version "7.26.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-7.26.0.tgz#d413a2b5752e3e71e003bb268dec32b9a0ad0ce7"
-  integrity sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==
+undici@7.16.0, undici@^6.25.0, undici@^7.28.0:
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.28.0.tgz#97d64564198b285bc281f0e8e29597e3d11fe7ec"
+  integrity sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==
 
 universalify@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
## What

Bumps the `undici` Yarn **resolution** from `^7.24.0` → `^7.28.0` across root + all 13 subgraphs (14 `package.json` + 14 regenerated `yarn.lock`).

## Why

`graph-cli` pulls `undici` transitively, and the repo force-pins it via a `resolutions` entry in every `package.json`. The pin resolved to **undici 7.26.0**, which is vulnerable to three **newly-published HIGH advisories** that the `yarn audit:prod` gate now flags on **every branch** (i.e. `main` and all open PRs fail this gate today — it's not specific to any feature branch):

| Advisory | Issue | Patched |
|---|---|---|
| GHSA-vmh5-mc38-953g | TLS cert validation bypass via dropped `requestTls` (SOCKS5 ProxyAgent) | 7.28.0 |
| GHSA-vxpw-j846-p89q | WebSocket client DoS via fragment count bypass | (≤7.x already covered) |
| GHSA-hm92-r4w5-c3mj | cross-origin request routing via SOCKS5 proxy pool reuse | 7.28.0 |

All three are resolved by **undici 7.28.0** — within the major the repo already forces, so low risk. This is a **real fix, not an allowlist suppression** (`.supply-chain/audit-allowlist.json` stays empty).

## Changes

- `resolutions.undici: ^7.24.0 → ^7.28.0` in 14 `package.json` (root + 13 subgraphs).
- Regenerated 14 `yarn.lock` — minimal diffs (undici version/resolved/integrity only); no `7.26.0` remains anywhere.
- Install-hook allowlist unchanged.

## Verification

- `yarn audit:prod` → **0 high/critical** (was: 3 unlisted HIGH).
- `yarn audit:install-hooks` → OK (allowlist unchanged).
- `yarn install --frozen-lockfile` consistent (root + new-mech-fees spot-checked).
- new-mech-fees `graph codegen` + `graph test` → green.

> Note: this is the upstream-advisory CI failure currently red on the open Basius PR (#156). That PR's failure is **inherited from main**, not introduced there; once this merges I'll rebase #156 so it goes green.