### PR TITLE
fix(babydegen-base): Aerodrome LpSugar v2 bootstrap + ABI-compat verification

### DIFF
--- a/abis/utils/AerodromeLpSugar.json
+++ b/abis/utils/AerodromeLpSugar.json
@@ -1,0 +1,26 @@
+[
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "_limit", "type": "uint256" },
+      { "internalType": "uint256", "name": "_offset", "type": "uint256" }
+    ],
+    "name": "forSwaps",
+    "outputs": [
+      {
+        "components": [
+          { "internalType": "address", "name": "lp", "type": "address" },
+          { "internalType": "int24", "name": "type", "type": "int24" },
+          { "internalType": "address", "name": "token0", "type": "address" },
+          { "internalType": "address", "name": "token1", "type": "address" },
+          { "internalType": "address", "name": "factory", "type": "address" },
+          { "internalType": "uint256", "name": "pool_fee", "type": "uint256" }
+        ],
+        "internalType": "struct LpSugar.SwapLp[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/subgraphs/babydegen/babydegen-base/IMPLEMENTATION-PLAN.md
+++ b/subgraphs/babydegen/babydegen-base/IMPLEMENTATION-PLAN.md
@@ -97,6 +97,26 @@ final definition of "transactions per day" is undecided — candidates: **swaps*
 Base mech-marketplace data source). DAA's "active" signal (currently = swapped that day) may
 also need broadening once the metric is confirmed.
 
+## Aerodrome contract compatibility (verified on-chain)
+
+The port reuses the repo's Velodrome ABIs on the assumption Aerodrome is a clean fork.
+Validated each against the deployed Base contracts:
+
+- **Live read path — compatible ✓.** Slipstream NFPM (all 41 fns match), CL pool
+  (`slot0`/`liquidity`/`tickSpacing`/`token0`/`token1`/`gauge`/`fee`), v2 pool
+  (`getReserves`/`token0`/`token1`/`stable`/`metadata`), CL factory `getPool`, and the v2
+  PoolFactory all respond with matching signatures. CL position tracking, v2 pool reads, and
+  pricing work as-is.
+- **LpSugar bootstrap — fixed in this PR.** Aerodrome's LpSugar v3 `all` takes 3 args with a
+  different struct, so `all(limit, offset)` reverted — silently disabling pre-existing
+  v2-pool template discovery (a Basius LP into an existing stable pool would be missed).
+  Switched the bootstrap to Aerodrome's `forSwaps(limit, offset)` → `{lp, type, token0,
+  token1, …}` via a Base-specific `abis/utils/AerodromeLpSugar.json` (the shared `Sugar.json`
+  stays for optimism). CL positions never needed this (NFPM-based).
+- **Follow-up:** the CL-gauge `earned(address,uint256)` reward read is the same Slipstream
+  fork and is wrapped in `try_` (degrades to reward=0 if it ever mismatched); worth a live
+  confirmation once a Basius CL position with staked rewards exists.
+
 ## Open questions for the team
 
 1. **Phase 2 definition** (Tatiana/Presh) — what counts as a "transaction per day" (swaps vs

--- a/subgraphs/babydegen/babydegen-base/src/veloCLShared.ts
+++ b/subgraphs/babydegen/babydegen-base/src/veloCLShared.ts
@@ -357,8 +357,7 @@ export function refreshVeloCLPosition(
   
   if (!earnedResult.reverted) {
     rewardAmount = earnedResult.value.toBigDecimal().div(BigDecimal.fromString("1e18"))
-    // Aerodrome CL gauges emit AERO rewards. TODO(divya): AERO has no price source
-    // configured yet (see tokenConfig.ts), so reward USD is 0 until an AERO pool is added.
+    // Aerodrome CL gauges emit AERO rewards, now priced off the AERO/USDC pool (tokenConfig.ts).
     const aeroPrice = getTokenPriceUSD(AERO, block.timestamp, false)
     rewardUSD = rewardAmount.times(aeroPrice)
   }

--- a/subgraphs/babydegen/babydegen-base/src/veloV2Bootstrap.ts
+++ b/subgraphs/babydegen/babydegen-base/src/veloV2Bootstrap.ts
@@ -62,16 +62,19 @@ export function handleVeloV2Bootstrap(block: ethereum.Block): void {
   let totalDiscovered = 0
   let whitelistedFound = 0
   
-  // Fetch pools in batches (Sugar contract MAX_LPS = 500)
+  // Fetch pools in batches via Aerodrome LpSugar v3 `forSwaps(limit, offset)`, which
+  // returns {lp, type, token0, token1, factory, pool_fee} — exactly the fields the
+  // bootstrap needs. (Aerodrome's `all` has a 3-arg signature + a different struct than
+  // Velodrome's `all`, so calling `all(limit, offset)` would revert.)
   let limit = 500
   let offset = 0
   let hasMore = true
-  
+
   while (hasMore) {
-    let poolsResult = sugar.try_all(BigInt.fromI32(limit), BigInt.fromI32(offset))
-    
+    let poolsResult = sugar.try_forSwaps(BigInt.fromI32(limit), BigInt.fromI32(offset))
+
     if (poolsResult.reverted) {
-      log.error("VELO V2: Sugar call reverted at offset {}", [offset.toString()])
+      log.error("VELO V2: Sugar forSwaps call reverted at offset {}", [offset.toString()])
       break
     }
     
@@ -93,9 +96,9 @@ export function handleVeloV2Bootstrap(block: ethereum.Block): void {
       // type 1 = concentrated liquidity pools (skip these)
       // Only track stable (0) and volatile (-1) pools
       if ([0,-1].includes(poolData.type) && isPoolRelevant(poolData.token0, poolData.token1)) {
-        // Note: isStable is true when type is -1 (this is correct per manual verification)
-        let isStable = poolData.type == -1
-        createPoolTemplate(poolData.id, poolData.token0, poolData.token1, isStable)
+        // type 0 = stable, -1 = volatile v2 pool; positive = CL tickSpacing (skipped above).
+        let isStable = poolData.type == 0
+        createPoolTemplate(poolData.lp, poolData.token0, poolData.token1, isStable)
         whitelistedFound++
       }
     }

--- a/subgraphs/babydegen/babydegen-base/subgraph.yaml
+++ b/subgraphs/babydegen/babydegen-base/subgraph.yaml
@@ -260,7 +260,11 @@ dataSources:
         - ProtocolPosition
       abis:
         - name: Sugar
-          file: ../../../abis/utils/Sugar.json
+          # Aerodrome LpSugar v3 — its `all` takes 3 args and returns a different
+          # struct than Velodrome's; we use `forSwaps(limit, offset)` which returns
+          # exactly {lp, type, token0, token1, ...}. Base-specific ABI (not the shared
+          # Velodrome Sugar.json, which babydegen-optimism still uses).
+          file: ../../../abis/utils/AerodromeLpSugar.json
         - name: PoolFactory
           file: ../../../abis/defi/PoolFactory.json
         - name: VelodromeV2Pool


### PR DESCRIPTION
**Stacked on #156** (base = `feat/babydegen-base-basius`) — review/merge #156 first.

## What

Continues babydegen-base implementation: validates the "Aerodrome is a clean Velodrome fork" assumption against the **deployed** Base contracts, and fixes the one real mismatch found.

## Verification (on-chain, deployed Aerodrome contracts)

The scaffold reuses the repo's Velodrome ABIs. I checked each against the live Base contracts:

- **Live read path — compatible ✓** (no change needed): Slipstream NFPM (all 41 fns match), CL pool (`slot0`/`liquidity`/`tickSpacing`/`token0`/`token1`/`gauge`/`fee`), v2 pool (`getReserves`/`token0`/`token1`/`stable`/`metadata`), CL factory `getPool`, v2 PoolFactory. So CL + v2 position tracking and pricing work as-is.
- **LpSugar bootstrap — broken, fixed here.**

## The fix

Aerodrome's **LpSugar v3 `all` takes 3 args** (`all(uint256,uint256,uint256)`) and returns a different struct, so the bootstrap's `sugar.all(limit, offset)` reverted. Effect: discovery of **pre-existing** whitelisted v2 pools was silently disabled — a Basius LP into an already-existing stable pool (e.g. USDC/BOLD) would go untracked. (CL positions are unaffected — they're NFPM-event-based, no bootstrap.)

Switched the bootstrap to Aerodrome's **`forSwaps(limit, offset)`**, which returns exactly `{lp, type, token0, token1, factory, pool_fee}` — the fields the bootstrap needs — via a new Base-specific `abis/utils/AerodromeLpSugar.json` (the shared `Sugar.json` is untouched, so babydegen-optimism keeps working). Also corrected the unused `isStable` mapping (`type == 0` = stable) and dropped the now-stale "AERO has no price" TODO (AERO is priced in #156).

## Not changed / follow-up

- CL-gauge `earned(address,uint256)` reward read is the same Slipstream fork and is wrapped in `try_` (degrades to reward=0 if it ever mismatched). Worth a live confirmation once a Basius CL position with staked rewards exists — noted in IMPLEMENTATION-PLAN.md. Couldn't validate against real data yet (Basius services are brand-new; only ~\$1.5 USDC each, no positions).

## Test plan

`yarn codegen` + `yarn build` + `yarn test` → **13/13 green**. The generated `Sugar` binding exposes `try_forSwaps` with `lp`/`type`/`token0`/`token1` getters.