### PR TITLE
fix(babydegen-base): index AERO gauge rewards + value staked V2 positions (＋ CL verification plan)

### DIFF
--- a/abis/defi/VeloV2Gauge.json
+++ b/abis/defi/VeloV2Gauge.json
@@ -1,0 +1,30 @@
+[
+  {
+    "type": "function",
+    "name": "balanceOf",
+    "stateMutability": "view",
+    "inputs": [{ "name": "account", "type": "address" }],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "type": "function",
+    "name": "earned",
+    "stateMutability": "view",
+    "inputs": [{ "name": "account", "type": "address" }],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "type": "function",
+    "name": "rewardToken",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "address" }]
+  },
+  {
+    "type": "function",
+    "name": "stakingToken",
+    "stateMutability": "view",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "address" }]
+  }
+]

--- a/abis/defi/VeloVoter.json
+++ b/abis/defi/VeloVoter.json
@@ -1,0 +1,9 @@
+[
+  {
+    "type": "function",
+    "name": "gauges",
+    "stateMutability": "view",
+    "inputs": [{ "name": "pool", "type": "address" }],
+    "outputs": [{ "name": "", "type": "address" }]
+  }
+]

--- a/subgraphs/babydegen/babydegen-base/AERO-REWARDS-PLAN.md
+++ b/subgraphs/babydegen/babydegen-base/AERO-REWARDS-PLAN.md
@@ -1,0 +1,147 @@
+# AERO gauge-reward indexing — verification & implementation plan
+
+**Status:** code path is **built and shipped** (in `#156`), but **unverified end-to-end**
+because no Basius CL position has been staked in an Aerodrome gauge on Base yet. This doc
+captures exactly what the path does, which assumptions are still unproven, and the concrete
+steps to confirm (and, if needed, fix) it once the first real staked position exists.
+
+This is deliberately a docs-first PR: there is **no Basius gauge state on-chain to test
+against today**, so we describe the plan and add self-reporting instrumentation rather than
+guess at fixes.
+
+---
+
+## 1. What the path does today
+
+For every **active Aerodrome Slipstream (CL)** position, `refreshVeloCLPosition`
+(`src/veloCLShared.ts`) reads unclaimed staking rewards from the position's gauge and folds
+them into the portfolio value:
+
+```ts
+// src/veloCLShared.ts  (reward block, ~L332–375)
+const gauge = VeloCLGauge.bind(gaugeAddress)
+const earnedResult = gauge.try_earned(nftOwner, tokenId)   // earned(address account, uint256 tokenId)
+
+if (!earnedResult.reverted) {
+  rewardAmount = earnedResult.value.toBigDecimal().div(BigDecimal.fromString("1e18"))  // AERO is 18-dec
+  const aeroPrice = getTokenPriceUSD(AERO, block.timestamp, false)                     // AERO/USDC pool
+  rewardUSD = rewardAmount.times(aeroPrice)
+} else {
+  log.warning(...)  // self-reporting — see §4
+}
+
+position.claimableReward       = rewardAmount
+position.claimableRewardUSD    = rewardUSD
+position.usdCurrent            = usd                 // base liquidity only
+position.usdCurrentWithRewards = usd.plus(rewardUSD) // base + rewards
+```
+
+`gaugeAddress` comes from `position.rewardsContract` if cached, else from the CL pool's
+`gauge()` getter (`pool.try_gauge()`), which is then cached on the position.
+
+### Why it matters
+
+`usdCurrentWithRewards` feeds `refreshPortfolio` → the portfolio snapshots → the **APR/ROI
+KPIs** surfaced on the website:
+
+- `DailyPopulationMetric.sma7dAPR` — "APR relative to USDC – MA7D"
+- `DailyPopulationMetric.sma7dEthAdjustedAPR` — "APR relative to ETH – MA7D"
+- `AgentPortfolioSnapshot.roi` — explorer per-day heatmap
+
+So a wrong reward value isn't cosmetic — it understates realized agent performance.
+
+---
+
+## 2. What is already verified (offline)
+
+- **`earned` ABI shape.** `abis/defi/VeloCLGauge.json` declares
+  `earned(address account, uint256 tokenId) → uint256`. The bound call matches the ABI.
+- **Gauge getters exist.** The same ABI exposes `rewardToken()`, `stakedContains(depositor,
+  tokenId)`, `stakedByIndex`, `stakedValues(depositor)` and `getReward` — the getters the
+  verification in §3 relies on.
+- **AERO token.** 18 decimals (so the `/1e18` is correct), address
+  `0x940181a94A35A4569E4529A3CDfB74e38FD98631`.
+- **AERO pricing.** Priced off the Aerodrome **AERO/USDC volatile** pool
+  `0x6cdcb1c4…` via the `velodrome_v2` adapter (`src/tokenConfig.ts`), Divya-confirmed.
+- **Contracts deployed.** Slipstream NFPM / factory and the CL pool `gauge()` getter all
+  return live bytecode on Base.
+
+## 3. What is NOT yet verified (needs a live staked position)
+
+Three assumptions can only be confirmed against real gauge state:
+
+1. **The gauge selector actually resolves.** Aerodrome's *deployed* CL gauge must implement
+   `earned(address,uint256)` with the same selector. If it differs, `try_earned` **reverts
+   silently** and reward records as **0** — no crash, no error. This is the dangerous mode:
+   the data looks healthy while undercounting.
+2. **The `account` argument is right.** We pass the **service safe** (`nftOwner`) as
+   `account`. Aerodrome credits `earned` to whoever **staked the NFT** (called
+   `gauge.deposit(tokenId)`). If Basius stakes directly from the safe → correct. If it stakes
+   through a relayer/intermediary → `earned(safe, tokenId)` returns 0 for the safe.
+3. **The full wei → AERO → USD product.** Each factor is individually checked; the
+   end-to-end number (`earned` wei → human AERO → USD → `usdCurrentWithRewards`) has never
+   been compared against a real, non-zero value.
+
+---
+
+## 4. Instrumentation added in this PR
+
+To convert "deferred unknown" into "self-reporting", the `else` branch of the `earned` call
+now emits a `log.warning` whenever `earned()` reverts on an **active** CL position
+(`src/veloCLShared.ts`). When the first real Basius position is staked, the indexer logs will
+immediately show whether the path works:
+
+- **No warning + non-zero `claimableRewardUSD`** → path is working; close this out.
+- **Warning fires** → assumption (1) or (2) is wrong; follow §5 to fix.
+
+No behavior change for the (correct) happy path; this only makes the failure visible.
+
+---
+
+## 5. Verification runbook (run once a Basius CL position is staked)
+
+Prereq: identify a staked position — a Basius service safe (607/610/611/612) that has called
+`gauge.deposit(tokenId)` on an Aerodrome Slipstream gauge. Use a **Base archive RPC**
+(`base.drpc.org`) so historical `eth_call` works.
+
+1. **Find the gauge.** From the position's pool: `eth_call pool.gauge()` → `gaugeAddress`.
+2. **Confirm reward token is AERO.** `eth_call gauge.rewardToken()` →
+   should equal `0x940181a9…`. (If not, the `/1e18` + AERO pricing assumptions change.)
+3. **Confirm the staker.** `eth_call gauge.stakedContains(safe, tokenId)` → must be `true`.
+   - `true` → assumption (2) holds; `account = safe` is correct.
+   - `false` → find the real depositor (check the `Deposit` event / `stakedValues`), and the
+     `account` passed to `earned` must be that address, not the safe. **Fix:** thread the
+     depositor through instead of `nftOwner`.
+4. **Confirm `earned` resolves and is non-zero.**
+   `eth_call gauge.earned(safe, tokenId)` at a recent block.
+   - Reverts → assumption (1): the deployed gauge's `earned` selector differs from
+     `abis/defi/VeloCLGauge.json`. **Fix:** regenerate the ABI from the deployed Aerodrome CL
+     gauge (Sourcify/Basescan), re-`codegen`, re-build.
+   - Returns 0 while the Aerodrome UI shows pending rewards → re-check (2)/(3).
+5. **Cross-check the indexed value.** Once indexing past the stake block, query the subgraph's
+   `ProtocolPosition.claimableRewardUSD` and compare to
+   `earned_wei / 1e18 × AERO/USDC price` at the same block (and against the Aerodrome
+   UI / `RewardsSugar`). Expect a match within rounding / price-source skew.
+
+If all five pass: the path is confirmed — delete the `log.warning`, flip the status line at
+the top of this doc to "verified", and update `CLAUDE.md`'s gauge note.
+
+---
+
+## 6. Likely fixes, by symptom
+
+| Symptom at first staked position | Root cause | Fix |
+|---|---|---|
+| `log.warning` fires; `earned` reverts | Wrong gauge `earned` selector/ABI | Regenerate `VeloCLGauge.json` from deployed Aerodrome gauge → `codegen` → build |
+| `earned(safe, …)` returns 0 but UI shows rewards | NFT staked by a non-safe depositor | Pass the actual depositor as `account` (derive from `Deposit` event / `stakedContains`) |
+| Reward USD wrong by orders of magnitude | Decimals / price source | Confirm `rewardToken()` decimals; confirm AERO/USDC pool liquidity is non-trivial at the block |
+
+---
+
+## 7. Scope
+
+- **In scope:** the CL-gauge `earned` reward path described above and its effect on
+  `usdCurrentWithRewards` / APR / ROI.
+- **Out of scope (already settled):** AERO *spot* pricing (done, `tokenConfig.ts`), Aerodrome
+  v2 bootstrap (done, `forSwaps`), and per-day transactions / DAA (live in the
+  `service-registry` subgraph, not here). See `CLAUDE.md`.

--- a/subgraphs/babydegen/babydegen-base/AERO-REWARDS-PLAN.md
+++ b/subgraphs/babydegen/babydegen-base/AERO-REWARDS-PLAN.md
@@ -159,7 +159,9 @@ the top of this doc to "verified", and update `CLAUDE.md`'s gauge note.
 |---|---|---|
 | `log.warning` fires; `earned` reverts | Wrong gauge `earned` selector/ABI | Regenerate `VeloCLGauge.json` from deployed Aerodrome gauge → `codegen` → build |
 | `earned(safe, …)` returns 0 but UI shows rewards | NFT staked by a non-safe depositor | Pass the actual depositor as `account` (derive from `Deposit` event / `stakedContains`) |
+| `earned` returns a sane non-zero number but `claimableRewardUSD` indexes as **0** | **AERO price source returning 0** (not the gauge ABI) — `getTokenPriceUSD(AERO)` failed, e.g. AERO/USDC pool reserves unreadable at that block | Check the `velodrome_v2` adapter / pool reserves snapshot in `tokenConfig.ts`; confirm the AERO/USDC pool `0x6cdcb1c4…` has non-trivial liquidity at the block. The gauge read is fine here. |
 | Reward USD wrong by orders of magnitude | Decimals / price source | Confirm `rewardToken()` decimals; confirm AERO/USDC pool liquidity is non-trivial at the block |
+| `rewardToken()` is **not** AERO (`0x940181a9…`) | Gauge emits a different reward token | Not just an ABI regen: the hardcoded `/1e18` (decimals) **and** `getTokenPriceUSD(AERO, …)` (pricing) both break together — rework both for the actual reward token. Aerodrome has standardized on AERO, so this is low-risk, but step 2 of §5 is the gate. |
 
 ---
 
@@ -209,9 +211,17 @@ LP) stays `isActive` with `liquidity` = staked amount; and `gauge.earned` folds 
 
 - **In scope (this PR):** documenting the CL-gauge `earned` reward path + Divya's verification,
   the CL `log.warning` silent-zero guard, **and** the V2 staked-position fix (§7) with tests.
-- **Follow-up (not here):** the same staked-position gap likely exists in `babydegen-optimism`
-  — mirror §7 there. And the **CL** end-to-end confirmation (§3/§5), event-gated on a real
-  Slipstream stake (the `log.warning` is the trigger).
+- **Follow-up (not here):** the same staked-position gap **is confirmed present in
+  `babydegen-optimism`** — Divya verified Optimus stakes V2 LP into Velodrome gauges
+  (`evaluate_strategy.py` `_build_stake_lp_tokens_action` → `velodrome.py` `stake_lp_tokens`,
+  chain-parameterised), so optimism has the same KPI bug today. Mirror §7 there in a separate
+  PR. And the **CL** end-to-end confirmation (§3/§5), event-gated on a real Slipstream stake
+  (the `log.warning` is the trigger).
+
+> **Release-notes callout:** unlike the CL change (instrumentation only), the V2 fix is a real
+> **KPI change** — gauge-staked V2 positions now contribute their value *and* AERO rewards to
+> `usdCurrentWithRewards`, which feeds the website APR/ROI. Previously they read as $0 while
+> staked. Call this out when the subgraph ships.
 - **Out of scope (already settled):** AERO *spot* pricing (done, `tokenConfig.ts`), Aerodrome
   v2 bootstrap (done, `forSwaps`), and per-day transactions / DAA (live in the
   `service-registry` subgraph, not here). See `CLAUDE.md`.

--- a/subgraphs/babydegen/babydegen-base/AERO-REWARDS-PLAN.md
+++ b/subgraphs/babydegen/babydegen-base/AERO-REWARDS-PLAN.md
@@ -1,9 +1,13 @@
 # AERO gauge-reward indexing — verification & implementation plan
 
-**Status:** code path is **built and shipped** (in `#156`), but **unverified end-to-end**
-because no Basius CL position has been staked in an Aerodrome gauge on Base yet. This doc
-captures exactly what the path does, which assumptions are still unproven, and the concrete
-steps to confirm (and, if needed, fix) it once the first real staked position exists.
+**Status:** CL reward path is **built and shipped** (in `#156`). Most assumptions are now
+**verified on-chain** via a real Basius **V2** stake (Divya, block 47702491 — §2): depositor
+identity, `rewardToken = AERO`, and `earned(safe)` resolving non-zero all hold. The **one
+strictly-open gap is the CL `earned(address,uint256)` selector** (a different gauge ABI than
+the V2 `earned(address)` that was exercised) — unverifiable until a Basius position lands in a
+Slipstream pool. Divya's example also surfaced a **separate, larger V2 gap** (§7): staked V2
+positions currently vanish from the portfolio. This doc captures the path, the verification
+status, and the runbook to close CL out once a real staked CL position exists.
 
 This is deliberately a docs-first PR: there is **no Basius gauge state on-chain to test
 against today**, so we describe the plan and add self-reporting instrumentation rather than
@@ -52,7 +56,9 @@ So a wrong reward value isn't cosmetic — it understates realized agent perform
 
 ---
 
-## 2. What is already verified (offline)
+## 2. What is already verified
+
+### Offline (ABI / token / contracts)
 
 - **`earned` ABI shape.** `abis/defi/VeloCLGauge.json` declares
   `earned(address account, uint256 tokenId) → uint256`. The bound call matches the ABI.
@@ -66,21 +72,39 @@ So a wrong reward value isn't cosmetic — it understates realized agent perform
 - **Contracts deployed.** Slipstream NFPM / factory and the CL pool `gauge()` getter all
   return live bytecode on Base.
 
-## 3. What is NOT yet verified (needs a live staked position)
+### On-chain (Divya, PR #159, against a real Basius **V2** stake)
 
-Three assumptions can only be confirmed against real gauge state:
+A Basius test agent (`0xcb9a…fc45`) staked into an Aerodrome **V2 stable** gauge
+(`0x793f…733e`, pool USDC/eUSD `0x7A03…1f4F`), verified at block **47702491**:
 
-1. **The gauge selector actually resolves.** Aerodrome's *deployed* CL gauge must implement
-   `earned(address,uint256)` with the same selector. If it differs, `try_earned` **reverts
-   silently** and reward records as **0** — no crash, no error. This is the dangerous mode:
-   the data looks healthy while undercounting.
-2. **The `account` argument is right.** We pass the **service safe** (`nftOwner`) as
-   `account`. Aerodrome credits `earned` to whoever **staked the NFT** (called
-   `gauge.deposit(tokenId)`). If Basius stakes directly from the safe → correct. If it stakes
-   through a relayer/intermediary → `earned(safe, tokenId)` returns 0 for the safe.
-3. **The full wei → AERO → USD product.** Each factor is individually checked; the
-   end-to-end number (`earned` wei → human AERO → USD → `usdCurrentWithRewards`) has never
-   been compared against a real, non-zero value.
+- ✅ **Depositor identity = the service safe.** The gauge `Deposit` log carries the safe as
+  the depositor (no operator/proxy in between). This is structural to Aerodrome and applies
+  **universally to V2 *and* CL** → settles assumption (2) below.
+- ✅ **`rewardToken() = 0x940181a9…` (AERO)** confirmed live.
+- ✅ **`earned(safe)` resolves and is non-zero** (`0.0098155476 AERO` live on that position) —
+  for the **V2** gauge, which uses `earned(address)`.
+- ✅ **Deposited LP matches our record.** On-chain `7157236262142` wei == the agent's internal
+  `current_liquidity`, so our view of the position lines up with the gauge's.
+
+## 3. What is NOT yet verified (needs a live **CL/Slipstream** staked position)
+
+After Divya's V2 verification, only the **CL-selector** gap remains strictly open:
+
+1. **The CL gauge selector actually resolves.** Aerodrome's *deployed* CL gauge must implement
+   `earned(address,uint256)` — a **different selector on a different gauge ABI** than the V2
+   `earned(address)` Divya exercised. If it differs, `try_earned` **reverts silently** and
+   reward records as **0** — no crash, no error. This is the dangerous mode: the data looks
+   healthy while undercounting. **Still the one thing we cannot claim until a Basius position
+   lands in a Slipstream pool.** The `log.warning` guard (§4) exists precisely to surface it.
+2. ~~The `account` argument is right.~~ **✅ Settled by Divya** — the safe is the depositor,
+   universally (V2 + CL). We pass the safe; that's correct.
+3. **The full wei → AERO → USD product.** Verified for the **V2** path (Divya's liquidity +
+   `earned` cross-check). The **CL** product still rides on (1) resolving; once it does, do the
+   §5 cross-check to confirm the end-to-end number.
+
+> **Strongly suggested, not proven:** because depositor identity, `rewardToken`, and the
+> account argument all hold on V2, CL is very likely to work too. But the selector difference
+> means we keep CL marked *unverified* until a real Slipstream stake confirms it.
 
 ---
 
@@ -138,10 +162,37 @@ the top of this doc to "verified", and update `CLAUDE.md`'s gauge note.
 
 ---
 
-## 7. Scope
+## 7. Separate, larger gap surfaced by Divya's V2 example — staked V2 positions vanish
 
-- **In scope:** the CL-gauge `earned` reward path described above and its effect on
-  `usdCurrentWithRewards` / APR / ROI.
+Divya's verification used a **V2-gauge** stake, which incidentally exposes a real correctness
+gap in the **V2** path that is *bigger* than missing rewards:
+
+- V2 position value is computed from **`pool.balanceOf(safe)`** (`src/veloV2Shared.ts`).
+- Staking LP into an Aerodrome V2 gauge **transfers the LP ERC20 out of the safe into the
+  gauge**, so `balanceOf(safe)` becomes **0**.
+- `handleVeloV2Transfer` refreshes the `from` address on that transfer, and the refresh hits
+  the `userBalance == 0` branch → marks the position **`isActive = false`** and zeroes
+  `usdCurrent`.
+
+**Net effect:** the moment a Basius agent stakes a V2 position, the subgraph treats it as
+**closed and worthless** — dropping both principal value *and* AERO rewards from the portfolio
+while it's actually staked and earning. (`usdCurrentWithRewards = usdCurrent` with a
+`// TODO: Calculate V2 fees later` only compounds it.) This code is **inherited verbatim from
+`babydegen-optimism`**, so the same gap likely exists there.
+
+This is **out of scope for this docs PR** (it's a behavioral fix with its own design — read
+the gauge's `stakedValues`/`balanceOf` for the safe to value staked LP, add V2 `earned`
+rewards, and possibly mirror the fix to optimism). It is flagged here so it isn't lost. If
+prioritized, it should be a separate implementation PR with its own tests. The CL `log.warning`
+guard does **not** cover this — V2 uses no such code path.
+
+## 8. Scope
+
+- **In scope (this PR):** documenting the CL-gauge `earned` reward path, folding in Divya's
+  on-chain verification, and the `log.warning` silent-zero guard for the CL path.
+- **Tracked but not in this PR:** the **V2 staked-position** gap (§7) — value + rewards for
+  gauge-staked V2 positions; needs its own PR (likely affects optimism too). And the **CL**
+  end-to-end confirmation (§3/§5), which is event-gated on a real Slipstream stake.
 - **Out of scope (already settled):** AERO *spot* pricing (done, `tokenConfig.ts`), Aerodrome
   v2 bootstrap (done, `forSwaps`), and per-day transactions / DAA (live in the
   `service-registry` subgraph, not here). See `CLAUDE.md`.

--- a/subgraphs/babydegen/babydegen-base/AERO-REWARDS-PLAN.md
+++ b/subgraphs/babydegen/babydegen-base/AERO-REWARDS-PLAN.md
@@ -5,9 +5,10 @@
 identity, `rewardToken = AERO`, and `earned(safe)` resolving non-zero all hold. The **one
 strictly-open gap is the CL `earned(address,uint256)` selector** (a different gauge ABI than
 the V2 `earned(address)` that was exercised) — unverifiable until a Basius position lands in a
-Slipstream pool. Divya's example also surfaced a **separate, larger V2 gap** (§7): staked V2
-positions currently vanish from the portfolio. This doc captures the path, the verification
-status, and the runbook to close CL out once a real staked CL position exists.
+Slipstream pool. Divya's example also surfaced a **separate, larger V2 gap** (§7) — staked V2
+positions vanished from the portfolio — which **this PR fixes** (gauge-aware V2 valuation +
+rewards, with tests). This doc captures the path, the verification status, and the runbook to
+close CL out once a real staked CL position exists.
 
 This is deliberately a docs-first PR: there is **no Basius gauge state on-chain to test
 against today**, so we describe the plan and add self-reporting instrumentation rather than
@@ -162,37 +163,55 @@ the top of this doc to "verified", and update `CLAUDE.md`'s gauge note.
 
 ---
 
-## 7. Separate, larger gap surfaced by Divya's V2 example — staked V2 positions vanish
+## 7. Staked V2 positions — the gap Divya's example surfaced (FIXED in this PR)
 
-Divya's verification used a **V2-gauge** stake, which incidentally exposes a real correctness
-gap in the **V2** path that is *bigger* than missing rewards:
+Divya's verification used a **V2-gauge** stake, which exposed a correctness gap in the **V2**
+path that was *bigger* than missing rewards:
 
 - V2 position value is computed from **`pool.balanceOf(safe)`** (`src/veloV2Shared.ts`).
 - Staking LP into an Aerodrome V2 gauge **transfers the LP ERC20 out of the safe into the
   gauge**, so `balanceOf(safe)` becomes **0**.
-- `handleVeloV2Transfer` refreshes the `from` address on that transfer, and the refresh hits
-  the `userBalance == 0` branch → marks the position **`isActive = false`** and zeroes
-  `usdCurrent`.
+- `handleVeloV2Transfer` refreshes the `from` address on that transfer, the refresh hit the
+  `userBalance == 0` branch → marked the position **`isActive = false`** and zeroed
+  `usdCurrent`. The position **vanished** from the portfolio while staked and earning.
 
-**Net effect:** the moment a Basius agent stakes a V2 position, the subgraph treats it as
-**closed and worthless** — dropping both principal value *and* AERO rewards from the portfolio
-while it's actually staked and earning. (`usdCurrentWithRewards = usdCurrent` with a
-`// TODO: Calculate V2 fees later` only compounds it.) This code is **inherited verbatim from
-`babydegen-optimism`**, so the same gap likely exists there.
+This code was inherited verbatim from `babydegen-optimism`, so the same gap likely exists
+there (worth a follow-up on optimism).
 
-This is **out of scope for this docs PR** (it's a behavioral fix with its own design — read
-the gauge's `stakedValues`/`balanceOf` for the safe to value staked LP, add V2 `earned`
-rewards, and possibly mirror the fix to optimism). It is flagged here so it isn't lost. If
-prioritized, it should be a separate implementation PR with its own tests. The CL `log.warning`
-guard does **not** cover this — V2 uses no such code path.
+### The fix (this PR)
+
+`refreshVeloV2Position` now resolves the pool's gauge and counts the staked LP + rewards:
+
+1. **Resolve the gauge** via the Aerodrome **Voter** — `Voter.gauges(pool)` (`VELO_VOTER =
+   0x16613524…`, verified on-chain), cached on `ProtocolPosition.rewardsContract`. If a pool
+   has no gauge, we don't cache the zero so a later-gauged pool is still picked up.
+2. **Count staked LP** — `effectiveBalance = pool.balanceOf(safe) + gauge.balanceOf(safe)`.
+   `pool.totalSupply` already includes the staked LP (staking is a transfer, not a burn), so
+   the reserve-share math stays correct. A staked-only position is no longer misread as closed.
+3. **Add rewards** — `gauge.earned(safe)` (AERO, 18-dec) priced off the AERO/USDC pool →
+   `claimableReward` / `claimableRewardUSD`, and `usdCurrentWithRewards = usdCurrent + rewardUSD`.
+   (Replaces the old `// TODO: Calculate V2 fees later`.)
+
+All on-chain selectors verified against Divya's live position (gauge `0x793f…`, block
+47702491): `Voter.gauges(pool)`, `gauge.stakingToken()`, `gauge.balanceOf(safe)` =
+`7157236262142` (matches the agent's record), `gauge.rewardToken()` = AERO. New ABIs:
+`abis/defi/VeloVoter.json`, `abis/defi/VeloV2Gauge.json`.
+
+**Tests** (`tests/mapping.test.ts`): a staked position (`pool.balanceOf == 0`, gauge holds the
+LP) stays `isActive` with `liquidity` = staked amount; and `gauge.earned` folds into
+`usdCurrentWithRewards`.
+
+> **Note on CL vs V2 reward selectors:** V2 gauges use `earned(address)`; CL/Slipstream gauges
+> use `earned(address, uint256)` (§1/§3). This PR's V2 fix exercises the V2 selector; the CL
+> selector remains the one item still gated on a live Slipstream stake.
 
 ## 8. Scope
 
-- **In scope (this PR):** documenting the CL-gauge `earned` reward path, folding in Divya's
-  on-chain verification, and the `log.warning` silent-zero guard for the CL path.
-- **Tracked but not in this PR:** the **V2 staked-position** gap (§7) — value + rewards for
-  gauge-staked V2 positions; needs its own PR (likely affects optimism too). And the **CL**
-  end-to-end confirmation (§3/§5), which is event-gated on a real Slipstream stake.
+- **In scope (this PR):** documenting the CL-gauge `earned` reward path + Divya's verification,
+  the CL `log.warning` silent-zero guard, **and** the V2 staked-position fix (§7) with tests.
+- **Follow-up (not here):** the same staked-position gap likely exists in `babydegen-optimism`
+  — mirror §7 there. And the **CL** end-to-end confirmation (§3/§5), event-gated on a real
+  Slipstream stake (the `log.warning` is the trigger).
 - **Out of scope (already settled):** AERO *spot* pricing (done, `tokenConfig.ts`), Aerodrome
   v2 bootstrap (done, `forSwaps`), and per-day transactions / DAA (live in the
   `service-registry` subgraph, not here). See `CLAUDE.md`.

--- a/subgraphs/babydegen/babydegen-base/CLAUDE.md
+++ b/subgraphs/babydegen/babydegen-base/CLAUDE.md
@@ -71,6 +71,12 @@ axlUSDC. USDC+WETH price off Chainlink; stables resolve to ~$1 (referenced to th
 AERO/USDC volatile pool `0x6cdcb1c4…` via the `velodrome_v2` adapter (`tokenConfig.ts`).
 **OLAS is not tracked** — Basius holds none and it isn't a trading asset for this agent.
 
+> **AERO gauge rewards (`earned`) — built but unverified end-to-end.** The CL reward path
+> (`refreshVeloCLPosition` → `gauge.earned(safe, tokenId)` → `usdCurrentWithRewards` → APR/ROI)
+> ships in `#156` but has no live staked Basius position to test against yet. A `log.warning`
+> now fires if `earned()` reverts on an active position (silent-zero guard). Full verification
+> runbook + likely fixes: **`AERO-REWARDS-PLAN.md`**.
+
 ## Schema, core logic, KPIs
 
 Schema and the entire portfolio/ROI/APR/snapshot/population pipeline are **identical** to

--- a/subgraphs/babydegen/babydegen-base/CLAUDE.md
+++ b/subgraphs/babydegen/babydegen-base/CLAUDE.md
@@ -71,11 +71,16 @@ axlUSDC. USDC+WETH price off Chainlink; stables resolve to ~$1 (referenced to th
 AERO/USDC volatile pool `0x6cdcb1c4…` via the `velodrome_v2` adapter (`tokenConfig.ts`).
 **OLAS is not tracked** — Basius holds none and it isn't a trading asset for this agent.
 
-> **AERO gauge rewards (`earned`) — built but unverified end-to-end.** The CL reward path
-> (`refreshVeloCLPosition` → `gauge.earned(safe, tokenId)` → `usdCurrentWithRewards` → APR/ROI)
-> ships in `#156` but has no live staked Basius position to test against yet. A `log.warning`
-> now fires if `earned()` reverts on an active position (silent-zero guard). Full verification
-> runbook + likely fixes: **`AERO-REWARDS-PLAN.md`**.
+> **AERO gauge rewards.** Both DEX paths now read claimable AERO from the position's gauge
+> into `usdCurrentWithRewards` (→ APR/ROI):
+> - **V2** (`refreshVeloV2Position`): resolves the gauge via Aerodrome **Voter** (`gauges(pool)`,
+>   `VELO_VOTER`), counts `gauge.balanceOf(safe)` as **staked LP** (so a staked position isn't
+>   misread as closed — it had been; fix verified vs Divya's live stake) and adds
+>   `gauge.earned(safe)` (selector `earned(address)`). ABIs: `VeloVoter.json`, `VeloV2Gauge.json`.
+> - **CL** (`refreshVeloCLPosition`): `gauge.earned(safe, tokenId)` (selector `earned(address,
+>   uint256)`). Built in `#156` but **unverified end-to-end** — no live staked Basius Slipstream
+>   position yet; a `log.warning` fires if `earned()` reverts on an active position (silent-zero
+>   guard). Full runbook + likely fixes: **`AERO-REWARDS-PLAN.md`**.
 
 ## Schema, core logic, KPIs
 

--- a/subgraphs/babydegen/babydegen-base/src/constants.ts
+++ b/subgraphs/babydegen/babydegen-base/src/constants.ts
@@ -41,6 +41,7 @@ export const VELO_MANAGER = Address.fromString("0xe1f8cd9AC4e4A65F54f38a5CdAfCA4
 export const VELO_FACTORY = Address.fromString("0xf8f2eB4940CFE7d13603DDDD87f123820Fc061Ef")     // Aerodrome Slipstream (CL) factory
 export const VELO_V2_FACTORY = Address.fromString("0x420DD381b31aEf6683db6B902084cB0FFECe40Da")  // Aerodrome v2 PoolFactory (Divya-confirmed)
 export const VELO_V2_SUGAR = Address.fromString("0x69dD9db6d8f8E7d83887A704f447b1a584b599A1")     // Aerodrome LpSugar v3 (pool discovery / bootstrap)
+export const VELO_VOTER = Address.fromString("0x16613524e02ad97eDfeF371bC883F2F5d6C480A5")        // Aerodrome Voter — pool->gauge lookup (gauges(pool)); verified on-chain
 
 // ---- Olas service configuration (Base) --------------------------------------
 // Canonical ServiceRegistryL2 on Base = 0x3C1fF68f5aa342D296d4DEe4Bb1cACCA912D95fE (set in subgraph.yaml).

--- a/subgraphs/babydegen/babydegen-base/src/veloCLShared.ts
+++ b/subgraphs/babydegen/babydegen-base/src/veloCLShared.ts
@@ -345,12 +345,15 @@ export function refreshVeloCLPosition(
       gaugeAddress = gaugeResult.value
       position.rewardsContract = gaugeAddress
     } else {
+      // pool.gauge() reverted → this pool has no gauge (a legitimate pool state, unlike the
+      // earned()-revert case below). Value the position without rewards and return; do NOT
+      // log — a missing gauge is expected, not the silent-zero failure mode we guard against.
       position.usdCurrent = usd
       position.save()
       return
     }
   }
-  
+
   // Get claimable rewards from gauge
   const gauge = VeloCLGauge.bind(gaugeAddress)
   const earnedResult = gauge.try_earned(nftOwner, tokenId)

--- a/subgraphs/babydegen/babydegen-base/src/veloCLShared.ts
+++ b/subgraphs/babydegen/babydegen-base/src/veloCLShared.ts
@@ -360,6 +360,16 @@ export function refreshVeloCLPosition(
     // Aerodrome CL gauges emit AERO rewards, now priced off the AERO/USDC pool (tokenConfig.ts).
     const aeroPrice = getTokenPriceUSD(AERO, block.timestamp, false)
     rewardUSD = rewardAmount.times(aeroPrice)
+  } else {
+    // earned(account, tokenId) reverted on an active CL position. This is the silent-zero
+    // failure mode flagged in AERO-REWARDS-PLAN.md: if the gauge ABI or the `account`
+    // argument is wrong, rewards quietly record as 0 instead of erroring. Until a real
+    // staked Basius position confirms the path end-to-end, log it loudly so the first
+    // live position surfaces the problem in the indexer logs rather than as quietly-wrong KPIs.
+    log.warning(
+      "AERO rewards: gauge.earned() reverted for active CL position {} (gauge {}, account {}, tokenId {}) — recording 0 reward. See AERO-REWARDS-PLAN.md.",
+      [positionId.toHexString(), gaugeAddress.toHexString(), nftOwner.toHexString(), tokenId.toString()]
+    )
   }
 
   // Separate base position value from rewards to avoid double-counting

--- a/subgraphs/babydegen/babydegen-base/src/veloV2Shared.ts
+++ b/subgraphs/babydegen/babydegen-base/src/veloV2Shared.ts
@@ -9,13 +9,33 @@ import {
 
 import { ProtocolPosition, Service, AgentSwapBuffer } from "../generated/schema"
 import { VelodromeV2Pool } from "../generated/templates/VeloV2Pool/VelodromeV2Pool"
+import { VeloVoter } from "../generated/templates/VeloV2Pool/VeloVoter"
+import { VeloV2Gauge } from "../generated/templates/VeloV2Pool/VeloV2Gauge"
 import { VeloV2Pool as VeloV2PoolTemplate } from "../generated/templates"
 import { getTokenPriceUSD } from "./priceDiscovery"
 import { getServiceByAgent } from "./config"
 import { parseTotalSlippageFromBucket, associateSwapsWithPosition, calculatePortfolioMetrics } from "./helpers"
 import { getTokenDecimals, getTokenSymbol } from "./tokenUtils"
 import { calculatePositionROI } from "./roiCalculation"
-import { PROTOCOL_VELODROME_V2 } from "./constants"
+import { PROTOCOL_VELODROME_V2, AERO, VELO_VOTER } from "./constants"
+
+// Resolve the Aerodrome V2 gauge for a pool via the Voter (gauges(pool)), caching the result
+// on the position's rewardsContract. Returns Address.zero() if the pool has no gauge (or the
+// Voter call fails) — in that case we don't cache, so a pool that gets gauged later is picked
+// up on a subsequent refresh. See AERO-REWARDS-PLAN.md §7.
+function resolveV2Gauge(poolAddress: Address, pp: ProtocolPosition): Address {
+  const cached = pp.rewardsContract
+  if (cached) {
+    return Address.fromBytes(cached!)
+  }
+  const voter = VeloVoter.bind(VELO_VOTER)
+  const res = voter.try_gauges(poolAddress)
+  if (res.reverted || res.value.equals(Address.zero())) {
+    return Address.zero()
+  }
+  pp.rewardsContract = res.value
+  return res.value
+}
 
 // VelodromeV2 Router address on Optimism
 const VELODROME_V2_ROUTER = Address.fromString("0xa062ae8a9c5e11aaa026fc2670b0d65ccc8b2858")
@@ -330,23 +350,50 @@ export function refreshVeloV2Position(
     return
   }
   
-  const userBalance = balanceResult.value
+  const userBalanceInSafe = balanceResult.value
   const totalSupply = totalSupplyResult.value
   const reserves = reservesResult.value
-  
-  // User balance and total supply data retrieved successfully
-  
-  // If user has no LP tokens, mark position as inactive
+
+  // Aerodrome V2 LP can be staked into a gauge. Staking transfers the LP ERC20 out of the
+  // safe (balanceOf(safe) -> 0) into the gauge, but the agent still owns the position and
+  // earns AERO. Count the gauge-staked LP toward the position value, and read its claimable
+  // AERO rewards, so a staked position isn't misread as closed/zero. See AERO-REWARDS-PLAN.md §7.
+  let stakedBalance = BigInt.zero()
+  let rewardAmount = BigDecimal.zero()
+  let rewardUSD = BigDecimal.zero()
+  const gaugeAddr = resolveV2Gauge(poolAddress, pp)
+  if (!gaugeAddr.equals(Address.zero())) {
+    const gauge = VeloV2Gauge.bind(gaugeAddr)
+    const stakedRes = gauge.try_balanceOf(userAddress)
+    if (!stakedRes.reverted) {
+      stakedBalance = stakedRes.value
+    }
+    const earnedRes = gauge.try_earned(userAddress)
+    if (!earnedRes.reverted) {
+      // Aerodrome V2 gauges emit AERO (18-dec), priced off the AERO/USDC pool (tokenConfig.ts).
+      rewardAmount = earnedRes.value.toBigDecimal().div(BigDecimal.fromString("1e18"))
+      rewardUSD = rewardAmount.times(getTokenPriceUSD(AERO, block.timestamp, false))
+    }
+  }
+
+  // Effective LP balance = in-wallet + gauge-staked. pool.totalSupply already includes the
+  // staked LP (staking is a transfer, not a burn), so the share math stays correct.
+  const userBalance = userBalanceInSafe.plus(stakedBalance)
+
+  // If user has no LP tokens (neither in-wallet nor staked), mark position as inactive
   if (userBalance.equals(BigInt.zero())) {
     pp.isActive = false
-    
+
     // FIXED: Calculate position ROI when position closes (if exit data exists)
     if (pp.exitAmountUSD && pp.exitAmountUSD!.gt(BigDecimal.zero())) {
       calculatePositionROI(pp)
     }
-    
+
     // Zero out current amounts
     pp.usdCurrent = BigDecimal.zero()
+    pp.usdCurrentWithRewards = BigDecimal.zero()
+    pp.claimableReward = BigDecimal.zero()
+    pp.claimableRewardUSD = BigDecimal.zero()
     pp.amount0 = BigDecimal.zero()
     pp.amount0USD = BigDecimal.zero()
     pp.amount1 = BigDecimal.zero()
@@ -374,8 +421,11 @@ export function refreshVeloV2Position(
     pp.amount0USD = token0Price.times(pp.amount0!)
     pp.amount1USD = token1Price.times(pp.amount1!)
     pp.usdCurrent = pp.amount0USD.plus(pp.amount1USD)
-    pp.usdCurrentWithRewards = pp.usdCurrent  // TODO: Calculate V2 fees later
-    pp.liquidity = userBalance // Store LP token balance as liquidity
+    // Base liquidity value plus claimable AERO gauge rewards (0 if the LP isn't staked).
+    pp.claimableReward = rewardAmount
+    pp.claimableRewardUSD = rewardUSD
+    pp.usdCurrentWithRewards = pp.usdCurrent.plus(rewardUSD)
+    pp.liquidity = userBalance // Store LP token balance (in-wallet + gauge-staked) as liquidity
     
     pp.isActive = true
     

--- a/subgraphs/babydegen/babydegen-base/src/veloV2Shared.ts
+++ b/subgraphs/babydegen/babydegen-base/src/veloV2Shared.ts
@@ -373,6 +373,13 @@ export function refreshVeloV2Position(
       // Aerodrome V2 gauges emit AERO (18-dec), priced off the AERO/USDC pool (tokenConfig.ts).
       rewardAmount = earnedRes.value.toBigDecimal().div(BigDecimal.fromString("1e18"))
       rewardUSD = rewardAmount.times(getTokenPriceUSD(AERO, block.timestamp, false))
+    } else {
+      // Symmetric with the CL guard: earned(address) reverting on a staked position is the
+      // silent-zero failure mode (non-standard gauge ABI). Log it loudly. See AERO-REWARDS-PLAN.md.
+      log.warning(
+        "AERO rewards (V2): gauge.earned() reverted for staked position {} (gauge {}, account {}) — recording 0 reward. See AERO-REWARDS-PLAN.md.",
+        [positionId.toHexString(), gaugeAddr.toHexString(), userAddress.toHexString()]
+      )
     }
   }
 

--- a/subgraphs/babydegen/babydegen-base/src/veloV2Shared.ts
+++ b/subgraphs/babydegen/babydegen-base/src/veloV2Shared.ts
@@ -20,9 +20,11 @@ import { calculatePositionROI } from "./roiCalculation"
 import { PROTOCOL_VELODROME_V2, AERO, VELO_VOTER } from "./constants"
 
 // Resolve the Aerodrome V2 gauge for a pool via the Voter (gauges(pool)), caching the result
-// on the position's rewardsContract. Returns Address.zero() if the pool has no gauge (or the
-// Voter call fails) — in that case we don't cache, so a pool that gets gauged later is picked
-// up on a subsequent refresh. See AERO-REWARDS-PLAN.md §7.
+// on the position's rewardsContract. Returns Address.zero() when the pool has no gauge.
+// The "Voter reverted" (transient) and "no gauge" (legitimate) cases are kept distinct:
+// a revert is logged (it can silently undervalue a staked position) and never cached, so we
+// retry next refresh; a zero gauge is silent and not cached, so a later-gauged pool is picked up.
+// See AERO-REWARDS-PLAN.md §7.
 function resolveV2Gauge(poolAddress: Address, pp: ProtocolPosition): Address {
   const cached = pp.rewardsContract
   if (cached) {
@@ -30,8 +32,15 @@ function resolveV2Gauge(poolAddress: Address, pp: ProtocolPosition): Address {
   }
   const voter = VeloVoter.bind(VELO_VOTER)
   const res = voter.try_gauges(poolAddress)
-  if (res.reverted || res.value.equals(Address.zero())) {
+  if (res.reverted) {
+    log.warning(
+      "V2 gauge resolution: Voter.gauges() reverted for pool {} — treating as no gauge this refresh (not cached).",
+      [poolAddress.toHexString()]
+    )
     return Address.zero()
+  }
+  if (res.value.equals(Address.zero())) {
+    return Address.zero() // legitimate: pool has no gauge
   }
   pp.rewardsContract = res.value
   return res.value
@@ -367,6 +376,13 @@ export function refreshVeloV2Position(
     const stakedRes = gauge.try_balanceOf(userAddress)
     if (!stakedRes.reverted) {
       stakedBalance = stakedRes.value
+    } else {
+      // Same silent-zero guard: a reverting balanceOf on a staked position (where
+      // balanceOf(safe)==0 is the normal state) would flip it to closed/zero. Log it.
+      log.warning(
+        "AERO rewards (V2): gauge.balanceOf() reverted for staked position (pool {}, gauge {}, account {}) — staked LP read as 0.",
+        [poolAddress.toHexString(), gaugeAddr.toHexString(), userAddress.toHexString()]
+      )
     }
     const earnedRes = gauge.try_earned(userAddress)
     if (!earnedRes.reverted) {
@@ -377,8 +393,8 @@ export function refreshVeloV2Position(
       // Symmetric with the CL guard: earned(address) reverting on a staked position is the
       // silent-zero failure mode (non-standard gauge ABI). Log it loudly. See AERO-REWARDS-PLAN.md.
       log.warning(
-        "AERO rewards (V2): gauge.earned() reverted for staked position {} (gauge {}, account {}) — recording 0 reward. See AERO-REWARDS-PLAN.md.",
-        [positionId.toHexString(), gaugeAddr.toHexString(), userAddress.toHexString()]
+        "AERO rewards (V2): gauge.earned() reverted for staked position (pool {}, gauge {}, account {}) — recording 0 reward. See AERO-REWARDS-PLAN.md.",
+        [poolAddress.toHexString(), gaugeAddr.toHexString(), userAddress.toHexString()]
       )
     }
   }

--- a/subgraphs/babydegen/babydegen-base/subgraph.yaml
+++ b/subgraphs/babydegen/babydegen-base/subgraph.yaml
@@ -388,6 +388,10 @@ templates:
           file: ../../../abis/oracles/AggregatorV3Interface.json
         - name: VelodromeCLPool
           file: ../../../abis/defi/VelodromeCLPool.json
+        - name: VeloVoter
+          file: ../../../abis/defi/VeloVoter.json
+        - name: VeloV2Gauge
+          file: ../../../abis/defi/VeloV2Gauge.json
       eventHandlers:
         - event: Mint(indexed address,uint256,uint256)
           handler: handleVeloV2Mint

--- a/subgraphs/babydegen/babydegen-base/tests/mapping.test.ts
+++ b/subgraphs/babydegen/babydegen-base/tests/mapping.test.ts
@@ -14,8 +14,9 @@ import {
 import { getTokenConfig, TokenConfig } from "../src/tokenConfig"
 import { getVelodromeV2Price } from "../src/priceAdapters"
 import { calculatePositionROI } from "../src/roiCalculation"
-import { ProtocolPosition } from "../generated/schema"
-import { USDC_NATIVE, WETH, AERO, BOLD } from "../src/constants"
+import { refreshVeloV2Position, getVeloV2PositionId } from "../src/veloV2Shared"
+import { ProtocolPosition, Service } from "../generated/schema"
+import { USDC_NATIVE, WETH, AERO, BOLD, VELO_VOTER } from "../src/constants"
 import {
   createRegisterInstanceEvent,
   createCreateMultisigWithAgentsEvent
@@ -535,5 +536,169 @@ describe("calculatePositionROI", () => {
     // investment = 100 + 20 = 120; netGain = 150 - 120 = 30; ROI = 25%
     assert.stringEquals("25", roi.toString())
     assert.fieldEquals("ProtocolPosition", pos.id.toHexString(), "investmentUSD", "120")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Aerodrome V2 gauge-staked positions (veloV2Shared.ts)
+//
+// When a Basius agent stakes its V2 LP into a gauge, the LP ERC20 leaves the safe
+// (pool.balanceOf(safe) -> 0). Before the fix this marked the position closed/zero;
+// now we resolve the pool's gauge via the Voter and count gauge.balanceOf(safe) as
+// the staked LP, plus gauge.earned(safe) as claimable AERO. See AERO-REWARDS-PLAN.md §7.
+// ---------------------------------------------------------------------------
+const V2_POOL = Address.fromString("0x7a034374c89c463dd65d8c9bcfe63bcbced41f4f")
+const V2_GAUGE = Address.fromString("0x793f22ab88dc91793e5ce6adbd7e733b0bd4733e")
+// Two non-whitelisted dummy tokens → getTokenPriceUSD returns 0 with no chain calls,
+// so usdCurrent is 0 and the test isolates the gauge/staking behavior.
+const DUMMY0 = Address.fromString("0x00000000000000000000000000000000000000a0")
+const DUMMY1 = Address.fromString("0x00000000000000000000000000000000000000b0")
+
+function createService(safe: Address): void {
+  const s = new Service(safe)
+  s.serviceId = SERVICE_ID
+  s.operatorSafe = OPERATOR_SAFE
+  s.serviceSafe = safe
+  s.latestRegistrationBlock = BLOCK_NUMBER
+  s.latestRegistrationTimestamp = BLOCK_TIMESTAMP
+  s.latestRegistrationTxHash = TX_HASH
+  s.latestMultisigBlock = BLOCK_NUMBER
+  s.latestMultisigTimestamp = BLOCK_TIMESTAMP
+  s.latestMultisigTxHash = TX_HASH
+  s.isActive = true
+  s.createdAt = BLOCK_TIMESTAMP
+  s.updatedAt = BLOCK_TIMESTAMP
+  s.positionIds = []
+  s.save()
+}
+
+// Pre-create an existing V2 position so refreshVeloV2Position takes the "existing" path
+// (no token0/stable metadata fetch) and just refreshes current state.
+function makeOpenV2Position(token0: Address, token1: Address): Bytes {
+  const id = getVeloV2PositionId(SERVICE_SAFE, V2_POOL)
+  const p = new ProtocolPosition(id)
+  p.agent = SERVICE_SAFE
+  p.service = SERVICE_SAFE
+  p.protocol = "aerodrome-v2"
+  p.pool = V2_POOL
+  p.token0 = token0
+  p.token1 = token1
+  p.isActive = true
+  p.tokenId = BigInt.zero()
+  p.tickLower = 0
+  p.tickUpper = 0
+  p.tickSpacing = 0
+  p.usdCurrent = BigDecimal.zero()
+  p.usdCurrentWithRewards = BigDecimal.zero()
+  p.amount0USD = BigDecimal.zero()
+  p.amount1USD = BigDecimal.zero()
+  p.entryTxHash = TX_HASH
+  p.entryTimestamp = BLOCK_TIMESTAMP // non-zero → skip the new-position entry/swap block
+  p.entryAmount0 = BigDecimal.zero()
+  p.entryAmount0USD = BigDecimal.zero()
+  p.entryAmount1 = BigDecimal.zero()
+  p.entryAmount1USD = BigDecimal.zero()
+  p.entryAmountUSD = BigDecimal.fromString("100")
+  p.totalCostsUSD = BigDecimal.zero()
+  p.swapSlippageUSD = BigDecimal.zero()
+  p.investmentUSD = BigDecimal.fromString("100")
+  p.grossGainUSD = BigDecimal.zero()
+  p.netGainUSD = BigDecimal.zero()
+  p.positionROI = BigDecimal.zero()
+  p.save()
+  return id
+}
+
+function mockV2PoolState(): void {
+  // LP has left the safe (staked) → balanceOf(safe) == 0
+  createMockedFunction(V2_POOL, "balanceOf", "balanceOf(address):(uint256)")
+    .withArgs([ethereum.Value.fromAddress(SERVICE_SAFE)])
+    .returns([ethereum.Value.fromUnsignedBigInt(BigInt.zero())])
+  createMockedFunction(V2_POOL, "totalSupply", "totalSupply():(uint256)")
+    .withArgs([])
+    .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromString("1000"))])
+  createMockedFunction(V2_POOL, "getReserves", "getReserves():(uint256,uint256,uint256)")
+    .withArgs([])
+    .returns([
+      ethereum.Value.fromUnsignedBigInt(BigInt.fromString("1000")),
+      ethereum.Value.fromUnsignedBigInt(BigInt.fromString("1000")),
+      ethereum.Value.fromUnsignedBigInt(BigInt.zero())
+    ])
+  // Voter resolves the pool's gauge
+  createMockedFunction(VELO_VOTER, "gauges", "gauges(address):(address)")
+    .withArgs([ethereum.Value.fromAddress(V2_POOL)])
+    .returns([ethereum.Value.fromAddress(V2_GAUGE)])
+  // Gauge holds the staked LP for the safe
+  createMockedFunction(V2_GAUGE, "balanceOf", "balanceOf(address):(uint256)")
+    .withArgs([ethereum.Value.fromAddress(SERVICE_SAFE)])
+    .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromString("500"))])
+}
+
+function mockAeroUsdcPool(): void {
+  const AERO_POOL = Address.fromString("0x6cdcb1c4a4d1c3c6d054b27ac5b77e89eafb971d")
+  createMockedFunction(AERO_POOL, "token0", "token0():(address)")
+    .withArgs([])
+    .returns([ethereum.Value.fromAddress(AERO)])
+  createMockedFunction(AERO_POOL, "token1", "token1():(address)")
+    .withArgs([])
+    .returns([ethereum.Value.fromAddress(USDC_NATIVE)])
+  createMockedFunction(AERO_POOL, "getReserves", "getReserves():(uint256,uint256,uint256)")
+    .withArgs([])
+    .returns([
+      ethereum.Value.fromUnsignedBigInt(BigInt.fromString("1000000000000000000000000")), // 1e24 AERO
+      ethereum.Value.fromUnsignedBigInt(BigInt.fromString("1300000000000")),             // 1.3e12 USDC
+      ethereum.Value.fromUnsignedBigInt(BigInt.zero())
+    ])
+}
+
+function v2Block(): ethereum.Block {
+  const ev = createRegisterInstanceEvent(OPERATOR_SAFE, SERVICE_ID, AGENT_INSTANCE, BASIUS_AGENT_ID)
+  ev.block.number = BLOCK_NUMBER
+  ev.block.timestamp = BLOCK_TIMESTAMP
+  return ev.block
+}
+
+describe("Aerodrome V2 gauge-staked positions", () => {
+  afterEach(() => {
+    clearStore()
+  })
+
+  test("staked position (LP left the safe) stays active, valued by gauge balance", () => {
+    createService(SERVICE_SAFE)
+    const id = makeOpenV2Position(DUMMY0, DUMMY1)
+    mockV2PoolState()
+    // No claimable rewards this refresh → reward block is skipped (no AERO pricing needed)
+    createMockedFunction(V2_GAUGE, "earned", "earned(address):(uint256)")
+      .withArgs([ethereum.Value.fromAddress(SERVICE_SAFE)])
+      .reverts()
+
+    refreshVeloV2Position(SERVICE_SAFE, V2_POOL, v2Block(), TX_HASH, false)
+
+    // Despite pool.balanceOf(safe) == 0, the position is NOT closed: the gauge holds 500 LP.
+    assert.fieldEquals("ProtocolPosition", id.toHexString(), "isActive", "true")
+    assert.fieldEquals("ProtocolPosition", id.toHexString(), "liquidity", "500")
+    assert.fieldEquals("ProtocolPosition", id.toHexString(), "claimableRewardUSD", "0")
+  })
+
+  test("claimable AERO gauge rewards fold into usdCurrentWithRewards", () => {
+    createService(SERVICE_SAFE)
+    const id = makeOpenV2Position(DUMMY0, DUMMY1)
+    mockV2PoolState()
+    mockAeroUsdcPool()
+    // 2 AERO claimable (2e18 wei)
+    createMockedFunction(V2_GAUGE, "earned", "earned(address):(uint256)")
+      .withArgs([ethereum.Value.fromAddress(SERVICE_SAFE)])
+      .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromString("2000000000000000000"))])
+
+    refreshVeloV2Position(SERVICE_SAFE, V2_POOL, v2Block(), TX_HASH, false)
+
+    // claimableReward = 2e18 / 1e18 = 2 AERO; AERO ≈ $1.30 → rewardUSD ≈ $2.60.
+    assert.fieldEquals("ProtocolPosition", id.toHexString(), "claimableReward", "2")
+    const pos = ProtocolPosition.load(id)!
+    assert.assertTrue(pos.claimableRewardUSD!.gt(BigDecimal.fromString("2.59")))
+    assert.assertTrue(pos.claimableRewardUSD!.lt(BigDecimal.fromString("2.61")))
+    // usdCurrent is 0 (dummy tokens), so usdCurrentWithRewards == rewardUSD ≈ 2.60.
+    assert.assertTrue(pos.usdCurrentWithRewards.gt(BigDecimal.fromString("2.59")))
+    assert.assertTrue(pos.usdCurrentWithRewards.lt(BigDecimal.fromString("2.61")))
   })
 })

--- a/subgraphs/babydegen/babydegen-base/tests/mapping.test.ts
+++ b/subgraphs/babydegen/babydegen-base/tests/mapping.test.ts
@@ -634,21 +634,46 @@ function mockV2PoolState(): void {
     .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromString("500"))])
 }
 
+// AERO/USDC velodrome_v2 source from tokenConfig.ts. Must match the AERO price-source pool
+// there — if tokenConfig changes the source, update this address (see review nit #6).
+const AERO_PRICE_POOL = Address.fromString("0x6cdcb1c4a4d1c3c6d054b27ac5b77e89eafb971d")
+
 function mockAeroUsdcPool(): void {
-  const AERO_POOL = Address.fromString("0x6cdcb1c4a4d1c3c6d054b27ac5b77e89eafb971d")
-  createMockedFunction(AERO_POOL, "token0", "token0():(address)")
-    .withArgs([])
-    .returns([ethereum.Value.fromAddress(AERO)])
-  createMockedFunction(AERO_POOL, "token1", "token1():(address)")
+  // On-chain ordering (verified): USDC (0x8335…) < AERO (0x9401…), so USDC is token0. Mock it
+  // that way so the test exercises the same getVelodromeV2Price branch production hits.
+  createMockedFunction(AERO_PRICE_POOL, "token0", "token0():(address)")
     .withArgs([])
     .returns([ethereum.Value.fromAddress(USDC_NATIVE)])
-  createMockedFunction(AERO_POOL, "getReserves", "getReserves():(uint256,uint256,uint256)")
+  createMockedFunction(AERO_PRICE_POOL, "token1", "token1():(address)")
+    .withArgs([])
+    .returns([ethereum.Value.fromAddress(AERO)])
+  // reserve0 = 1.3e12 USDC (1.3M @6dec), reserve1 = 1e24 AERO (1M @18dec) → AERO ≈ $1.30
+  createMockedFunction(AERO_PRICE_POOL, "getReserves", "getReserves():(uint256,uint256,uint256)")
     .withArgs([])
     .returns([
-      ethereum.Value.fromUnsignedBigInt(BigInt.fromString("1000000000000000000000000")), // 1e24 AERO
-      ethereum.Value.fromUnsignedBigInt(BigInt.fromString("1300000000000")),             // 1.3e12 USDC
+      ethereum.Value.fromUnsignedBigInt(BigInt.fromString("1300000000000")),
+      ethereum.Value.fromUnsignedBigInt(BigInt.fromString("1000000000000000000000000")),
       ethereum.Value.fromUnsignedBigInt(BigInt.zero())
     ])
+}
+
+function mockV2PoolStateNoGauge(gaugeAddr: Address): void {
+  createMockedFunction(V2_POOL, "balanceOf", "balanceOf(address):(uint256)")
+    .withArgs([ethereum.Value.fromAddress(SERVICE_SAFE)])
+    .returns([ethereum.Value.fromUnsignedBigInt(BigInt.zero())])
+  createMockedFunction(V2_POOL, "totalSupply", "totalSupply():(uint256)")
+    .withArgs([])
+    .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromString("1000"))])
+  createMockedFunction(V2_POOL, "getReserves", "getReserves():(uint256,uint256,uint256)")
+    .withArgs([])
+    .returns([
+      ethereum.Value.fromUnsignedBigInt(BigInt.fromString("1000")),
+      ethereum.Value.fromUnsignedBigInt(BigInt.fromString("1000")),
+      ethereum.Value.fromUnsignedBigInt(BigInt.zero())
+    ])
+  createMockedFunction(VELO_VOTER, "gauges", "gauges(address):(address)")
+    .withArgs([ethereum.Value.fromAddress(V2_POOL)])
+    .returns([ethereum.Value.fromAddress(gaugeAddr)])
 }
 
 function v2Block(): ethereum.Block {
@@ -700,5 +725,78 @@ describe("Aerodrome V2 gauge-staked positions", () => {
     // usdCurrent is 0 (dummy tokens), so usdCurrentWithRewards == rewardUSD ≈ 2.60.
     assert.assertTrue(pos.usdCurrentWithRewards.gt(BigDecimal.fromString("2.59")))
     assert.assertTrue(pos.usdCurrentWithRewards.lt(BigDecimal.fromString("2.61")))
+  })
+
+  test("pool with no gauge (Voter returns 0x0) → position closes cleanly", () => {
+    createService(SERVICE_SAFE)
+    const id = makeOpenV2Position(DUMMY0, DUMMY1)
+    // Voter returns the zero address → pool has no gauge; no gauge calls are made.
+    mockV2PoolStateNoGauge(Address.zero())
+
+    refreshVeloV2Position(SERVICE_SAFE, V2_POOL, v2Block(), TX_HASH, false)
+
+    // No in-wallet LP and no gauge → genuinely closed.
+    assert.fieldEquals("ProtocolPosition", id.toHexString(), "isActive", "false")
+    assert.fieldEquals("ProtocolPosition", id.toHexString(), "liquidity", "0")
+  })
+
+  test("cached gauge (rewardsContract set) skips the Voter lookup", () => {
+    createService(SERVICE_SAFE)
+    const id = makeOpenV2Position(DUMMY0, DUMMY1)
+    // Pre-cache the gauge on the position. Voter.gauges is intentionally NOT mocked, so if the
+    // code ignored the cache and called it, matchstick would throw and fail this test.
+    const seed = ProtocolPosition.load(id)!
+    seed.rewardsContract = V2_GAUGE
+    seed.save()
+
+    createMockedFunction(V2_POOL, "balanceOf", "balanceOf(address):(uint256)")
+      .withArgs([ethereum.Value.fromAddress(SERVICE_SAFE)])
+      .returns([ethereum.Value.fromUnsignedBigInt(BigInt.zero())])
+    createMockedFunction(V2_POOL, "totalSupply", "totalSupply():(uint256)")
+      .withArgs([]).returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromString("1000"))])
+    createMockedFunction(V2_POOL, "getReserves", "getReserves():(uint256,uint256,uint256)")
+      .withArgs([]).returns([
+        ethereum.Value.fromUnsignedBigInt(BigInt.fromString("1000")),
+        ethereum.Value.fromUnsignedBigInt(BigInt.fromString("1000")),
+        ethereum.Value.fromUnsignedBigInt(BigInt.zero())
+      ])
+    createMockedFunction(V2_GAUGE, "balanceOf", "balanceOf(address):(uint256)")
+      .withArgs([ethereum.Value.fromAddress(SERVICE_SAFE)])
+      .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromString("500"))])
+    createMockedFunction(V2_GAUGE, "earned", "earned(address):(uint256)")
+      .withArgs([ethereum.Value.fromAddress(SERVICE_SAFE)]).reverts()
+
+    refreshVeloV2Position(SERVICE_SAFE, V2_POOL, v2Block(), TX_HASH, false)
+
+    // Used the cached gauge (no Voter call); staked LP counted → position stays active.
+    assert.fieldEquals("ProtocolPosition", id.toHexString(), "isActive", "true")
+    assert.fieldEquals("ProtocolPosition", id.toHexString(), "liquidity", "500")
+  })
+
+  test("genuinely exited staked position (pool & gauge balance 0) closes and clears rewards", () => {
+    createService(SERVICE_SAFE)
+    const id = makeOpenV2Position(DUMMY0, DUMMY1)
+    // Pre-seed stale reward fields to prove the close-out path clears them.
+    const seed = ProtocolPosition.load(id)!
+    seed.claimableReward = BigDecimal.fromString("5")
+    seed.claimableRewardUSD = BigDecimal.fromString("6")
+    seed.usdCurrentWithRewards = BigDecimal.fromString("6")
+    seed.save()
+
+    mockV2PoolStateNoGauge(V2_GAUGE)
+    // Nothing staked, and earned reverts → reward block skipped; userBalance = 0.
+    createMockedFunction(V2_GAUGE, "balanceOf", "balanceOf(address):(uint256)")
+      .withArgs([ethereum.Value.fromAddress(SERVICE_SAFE)])
+      .returns([ethereum.Value.fromUnsignedBigInt(BigInt.zero())])
+    createMockedFunction(V2_GAUGE, "earned", "earned(address):(uint256)")
+      .withArgs([ethereum.Value.fromAddress(SERVICE_SAFE)]).reverts()
+
+    refreshVeloV2Position(SERVICE_SAFE, V2_POOL, v2Block(), TX_HASH, false)
+
+    assert.fieldEquals("ProtocolPosition", id.toHexString(), "isActive", "false")
+    assert.fieldEquals("ProtocolPosition", id.toHexString(), "liquidity", "0")
+    assert.fieldEquals("ProtocolPosition", id.toHexString(), "claimableReward", "0")
+    assert.fieldEquals("ProtocolPosition", id.toHexString(), "claimableRewardUSD", "0")
+    assert.fieldEquals("ProtocolPosition", id.toHexString(), "usdCurrentWithRewards", "0")
   })
 })


### PR DESCRIPTION
## What & why

Started as a docs PR for the **CL** AERO-reward path; @DIvyaNautiyal07's on-chain verification (thank you!) turned it into a real fix. Her check used a live Basius **V2-gauge** stake, which confirmed most assumptions **and** surfaced a correctness gap in the V2 path. This PR now does three things:

1. **Fixes staked V2 positions vanishing from the portfolio** (the gap Divya's example exposed).
2. Adds a **silent-zero guard** on the CL reward path.
3. Documents the whole AERO-reward picture + the runbook to close out the one remaining CL gap (`AERO-REWARDS-PLAN.md`).

## 1. The V2 fix (main change)

V2 position value was read from `pool.balanceOf(safe)`. Staking LP into an Aerodrome V2 gauge **moves the LP out of the safe** → `balanceOf(safe) == 0` → the position was marked `isActive=false` and zeroed. So a staked, earning position **disappeared** from the portfolio. Inherited verbatim from `babydegen-optimism` (likely affects it too — follow-up).

`refreshVeloV2Position` now:
- **Resolves the gauge** via the Aerodrome **Voter** (`gauges(pool)`, `VELO_VOTER 0x16613524…`), cached on `rewardsContract`.
- Counts **staked LP**: `effectiveBalance = pool.balanceOf(safe) + gauge.balanceOf(safe)` (`pool.totalSupply` already includes staked LP, so share math is unchanged).
- Adds **rewards**: `gauge.earned(safe)` (AERO, priced off AERO/USDC) → `claimableReward/USD` and `usdCurrentWithRewards` (replaces the old `// TODO: Calculate V2 fees later`).

New ABIs: `abis/defi/VeloVoter.json`, `abis/defi/VeloV2Gauge.json`, wired into the `VeloV2Pool` template.

### Verified on-chain (Divya's live position, gauge `0x793f…`, block 47702491)
`Voter.gauges(pool)` → the gauge ✅ · `gauge.stakingToken()` == pool ✅ · `gauge.balanceOf(safe)` = `7157236262142` (== the agent's `current_liquidity`) ✅ · `gauge.rewardToken()` = AERO ✅ · `pool.balanceOf(safe)` = 0 (confirms the bug) ✅

## 2. CL silent-zero guard

CL gauges use a **different selector** (`earned(address,uint256)`) on a different gauge ABI than the V2 `earned(address)` Divya exercised. We can't claim CL is verified until a Basius position lands in a Slipstream pool, so `refreshVeloCLPosition` now emits a `log.warning` if `earned()` reverts on an active CL position — turning a silent 0 into a visible signal at the first real CL stake.

## 3. Verification status (`AERO-REWARDS-PLAN.md`)

- ✅ **Settled by Divya:** depositor == service safe (universal to V2+CL), `rewardToken` = AERO, `earned(safe)` resolves non-zero, deposited LP matches our record.
- ⏳ **Only strict gap left:** the CL `earned(address,uint256)` selector — event-gated on a real Slipstream stake; the `log.warning` is the trigger.

## Tests
`yarn codegen` + `build` + `test` green — **21/21** (＋2): a staked position (`pool.balanceOf==0`, gauge holds the LP) stays active with `liquidity` = staked amount; `gauge.earned` folds into `usdCurrentWithRewards` (~$2.60 for 2 AERO @ $1.30).

## Follow-ups (not here)
- Mirror the V2 staked-position fix to `babydegen-optimism` (same code).
- CL end-to-end confirmation once a Basius Slipstream position is staked.