### PR TITLE
fix(governance): backfill proposal quorum on VoteCast

### DIFF
--- a/subgraphs/governance/CLAUDE.md
+++ b/subgraphs/governance/CLAUDE.md
@@ -97,7 +97,7 @@ Same as VoteCast but includes `params: Bytes!` for extended voting parameters. D
 | `ProposalCanceled` | `handleProposalCanceled` | Creates event entity, sets `isCancelled = true`, calls `updateProposalQuorum()` |
 | `ProposalExecuted` | `handleProposalExecuted` | Creates event entity, sets `isExecuted = true`, calls `updateProposalQuorum()` |
 | `ProposalQueued` | `handleProposalQueued` | Creates event entity with `eta`, sets `isQueued = true`, calls `updateProposalQuorum()` |
-| `VoteCast` | `handleVoteCast` | Creates VoteCast entity, **accumulates votes**: support=0 → `votesAgainst`, support=1 → `votesFor`, support=2 → neither |
+| `VoteCast` | `handleVoteCast` | Creates VoteCast entity, **accumulates votes**: support=0 → `votesAgainst`, support=1 → `votesFor`, support=2 → neither; also calls `updateProposalQuorum()` to backfill quorum |
 | `VoteCastWithParams` | `handleVoteCastWithParams` | Creates event entity only, does **not** update vote counts on proposal |
 | `ProposalThresholdSet` | `handleProposalThresholdSet` | Creates event entity |
 | `QuorumNumeratorUpdated` | `handleQuorumNumeratorUpdated` | Creates event entity |
@@ -115,9 +115,10 @@ Same as VoteCast but includes `params: Bytes!` for extended voting parameters. D
 - Abstain votes (support=2) do not increment either counter
 
 ### Quorum Calculation (`src/utils.ts`)
-- `updateProposalQuorum(proposalId, blockNumber, contractAddress)` is called by lifecycle handlers (canceled, executed, queued)
+- `updateProposalQuorum(proposalId, blockNumber, contractAddress)` is called by lifecycle handlers (canceled, executed, queued) **and by `handleVoteCast`**
 - Only calculates if: proposal exists, quorum is null, current block > proposal's start block
-- Uses on-chain call: `contract.quorum(proposalCreated.startBlock)` to get historical quorum at the proposal's voting start
+- Uses `contract.try_quorum(proposalCreated.startBlock)` to get historical quorum at the proposal's voting start. `try_quorum` (not `quorum`) is used so a reverting call (e.g. an unexpected governor change) leaves quorum null instead of halting the whole subgraph
+- Backfilling on `VoteCast` ensures proposals that receive votes but are never queued/executed/cancelled (e.g. defeated ones) still get a quorum, instead of keeping `null` forever
 - Enables accurate retroactive quorum display for older proposals
 
 ### Entity ID Patterns
@@ -133,7 +134,7 @@ cd subgraphs/governance
 yarn install
 yarn codegen                # Generate types from schema + ABIs
 yarn build                  # Compile to WASM
-yarn test                   # Run Matchstick tests (no tests currently)
+yarn test                   # Run Matchstick tests (13 tests in tests/governor-olas.test.ts)
 ```
 
 ---
@@ -143,7 +144,7 @@ yarn test                   # Run Matchstick tests (no tests currently)
 ### Critical Points
 1. **Three contract versions**: V1 archived at block 17527057, V2 archived at block 25322326, V3 active from block 25322326. All use identical handlers and ABI.
 2. **Vote accumulation asymmetry**: `handleVoteCast` updates proposal vote tallies; `handleVoteCastWithParams` does not.
-3. **Lazy quorum**: Quorum is not set at proposal creation — it's backfilled on first lifecycle event (cancel/execute/queue) when `currentBlock > startBlock`.
+3. **Lazy quorum**: Quorum is not set at proposal creation — it's backfilled on the first VoteCast or lifecycle event (cancel/execute/queue) when `currentBlock > startBlock`. The call uses `try_quorum`, so a revert leaves quorum null rather than halting indexing.
 4. **Proposal entity is mutable**: Updated by VoteCast (tallies), ProposalCanceled/Executed/Queued (status flags), and quorum calculation.
 5. **All other entities are immutable**: Event log entities created once and never modified.
 6. **Indexer hints**: Prune mode set to `auto` in subgraph.yaml.

--- a/subgraphs/governance/src/governor-olas.ts
+++ b/subgraphs/governance/src/governor-olas.ts
@@ -217,6 +217,15 @@ export function handleVoteCast(event: VoteCastEvent): void {
     proposalCreated.save();
   }
 
+  // Backfill quorum once the proposal has started receiving votes. Without this,
+  // proposals that are never queued/executed/cancelled (e.g. defeated ones) keep
+  // a null quorum forever, since those were the only events that set it.
+  updateProposalQuorum(
+    event.params.proposalId,
+    event.block.number,
+    event.address
+  );
+
   entity.save();
 }
 

--- a/subgraphs/governance/src/utils.ts
+++ b/subgraphs/governance/src/utils.ts
@@ -19,8 +19,12 @@ export function updateProposalQuorum(
     blockNumber.gt(proposalCreated.startBlock)
   ) {
     const contract = GovernorOLAS.bind(contractAddress);
-    const quorum = contract.quorum(proposalCreated.startBlock);
-    proposalCreated.quorum = quorum;
-    proposalCreated.save();
+    // Use try_quorum so a reverting call (e.g. an unexpected governor change)
+    // leaves quorum null instead of halting the whole subgraph.
+    const quorumResult = contract.try_quorum(proposalCreated.startBlock);
+    if (!quorumResult.reverted) {
+      proposalCreated.quorum = quorumResult.value;
+      proposalCreated.save();
+    }
   }
 }

--- a/subgraphs/governance/tests/governor-olas.test.ts
+++ b/subgraphs/governance/tests/governor-olas.test.ts
@@ -165,6 +165,22 @@ describe("Governance handlers", () => {
     assert.fieldEquals("ProposalCreated", PROPOSAL_ID.toString(), "votesFor", "350")
   })
 
+  test("VoteCast backfills quorum once voting has started", () => {
+    createDefaultProposal()
+    mockQuorumCall(BigInt.fromI32(100))
+
+    let event = createVoteCastEvent(VOTER, PROPOSAL_ID, 1, BigInt.fromI32(500), "")
+    event.block.number = BigInt.fromI32(150)
+    handleVoteCast(event)
+
+    assert.fieldEquals(
+      "ProposalCreated",
+      PROPOSAL_ID.toString(),
+      "quorum",
+      QUORUM_VALUE.toString()
+    )
+  })
+
   test("VoteCastWithParams does not update vote tallies", () => {
     createDefaultProposal()
 


### PR DESCRIPTION
## What

Backfill a proposal's `quorum` when it receives votes, not only when it is cancelled/executed/queued.

## Why

`updateProposalQuorum()` was previously only called from the lifecycle handlers (`handleProposalCanceled`, `handleProposalExecuted`, `handleProposalQueued`). That means a proposal that receives votes but is **never finalized** — e.g. a defeated proposal that is never queued, executed, or cancelled — keeps `quorum = null` forever.

On the Govern frontend this surfaces as a proposal with no quorum record in the subgraph. The frontend then tries to backfill it on-chain via the current governor address, which can return `0`/revert for legacy proposals and previously crashed the proposals page (`Cannot convert undefined to a BigInt`). The frontend has a defensive null-safe fix; this PR fixes the root cause so the subgraph actually records the quorum.

## Changes

- **`src/governor-olas.ts`** — `handleVoteCast` now calls `updateProposalQuorum(...)` after tallying votes, so quorum is backfilled once voting has started (`currentBlock > startBlock`). The existing guard (proposal exists, quorum is null, block past start) makes this idempotent and cheap.
- **`src/utils.ts`** — switched `contract.quorum(...)` → `contract.try_quorum(...)`. A reverting on-chain call (e.g. an unexpected governor change, or a snapshot block the contract can't resolve) now leaves `quorum` null instead of halting the whole subgraph.
- **`tests/governor-olas.test.ts`** — added "VoteCast backfills quorum once voting has started".
- **`CLAUDE.md`** — documented the VoteCast backfill + `try_quorum` hardening, corrected the stale "no tests" note.

## Verification

- `yarn codegen` ✅
- `yarn build` ✅ (compiles to WASM)
- `yarn test` ✅ — all 13 tests pass, including the new one

🤖 Generated with [Claude Code](https://claude.com/claude-code)