### PR TITLE
fix(babydegen): restore v2 position tracking on Base

### DIFF
--- a/subgraphs/babydegen/babydegen-base/CLAUDE.md
+++ b/subgraphs/babydegen/babydegen-base/CLAUDE.md
@@ -96,6 +96,21 @@ AERO/USDC volatile pool `0x6cdcb1c4…` via the `velodrome_v2` adapter (`tokenCo
 >   position yet; a `log.warning` fires if `earned()` reverts on an active position (silent-zero
 >   guard). Full runbook + likely fixes: **`AERO-REWARDS-PLAN.md`**.
 
+> **V2 bootstrap pagination.** LpSugar `forSwaps(limit, offset)` walks **raw factory pool
+> indices** but returns a **filtered** page (zero-reserve pools dropped), so a page shorter
+> than `limit` does NOT mean end-of-list (this early-exit assumption once left ~27.6k of the
+> factory's ~28k pool indices unscanned and most Basius LP positions invisible). The bootstrap
+> pages up to the v2 factory's `allPoolsLength()` and aborts loudly if that call reverts.
+> Entries past the v2 range belong to CL factories and are skipped by the type filter
+> (0 = stable, -1 = volatile, positive = CL tickSpacing).
+
+> **V2 entry amounts.** `Transfer(0x0 → safe)` creates the position and stores a
+> `PendingMintPosition` keyed by `getVeloV2PositionId` (protocol string `aerodrome-v2`); the
+> same-tx `Mint` event then records the real entry amounts (entry USD feeds closed-position
+> ROI, so a dropped mint pins ROI/APR at 0). If entry amounts are still zero on a later
+> refresh, `refreshVeloV2Position` backfills them from current amounts — keyed on
+> `entryAmountUSD == 0` alone, since `entryTimestamp` is always set at creation.
+
 ## Schema, core logic, KPIs
 
 Schema and the entire portfolio/ROI/APR/snapshot/population pipeline are **identical** to

--- a/subgraphs/babydegen/babydegen-base/src/veloV2Bootstrap.ts
+++ b/subgraphs/babydegen/babydegen-base/src/veloV2Bootstrap.ts
@@ -57,42 +57,50 @@ function createPoolTemplate(poolAddress: Address, token0: Address, token1: Addre
 // Bootstrap handler - runs once at startup
 export function handleVeloV2Bootstrap(block: ethereum.Block): void {
   log.info("VELO V2: Starting pool discovery at block {}", [block.number.toString()])
-  
+
   let sugar = Sugar.bind(SUGAR_ADDRESS)
   let totalDiscovered = 0
   let whitelistedFound = 0
-  
+
+  // `forSwaps(limit, offset)` pages over raw factory pool indices but returns a
+  // FILTERED page (zero-reserve pools are dropped), so a page with fewer than
+  // `limit` entries does NOT mean the end of the list. The only reliable bound is
+  // the v2 factory's allPoolsLength(); the v2 factory occupies the first index
+  // range of the Sugar registry, and later ranges are CL factories whose entries
+  // the type filter below skips anyway.
+  let factory = PoolFactory.bind(FACTORY_ADDRESS)
+  let poolCountResult = factory.try_allPoolsLength()
+  if (poolCountResult.reverted) {
+    log.error("VELO V2: PoolFactory.allPoolsLength() reverted - bootstrap aborted", [])
+    return
+  }
+  let totalPools = poolCountResult.value
+
   // Fetch pools in batches via Aerodrome LpSugar v3 `forSwaps(limit, offset)`, which
   // returns {lp, type, token0, token1, factory, pool_fee} — exactly the fields the
   // bootstrap needs. (Aerodrome's `all` has a 3-arg signature + a different struct than
   // Velodrome's `all`, so calling `all(limit, offset)` would revert.)
   let limit = 500
-  let offset = 0
-  let hasMore = true
+  let offset = BigInt.zero()
 
-  while (hasMore) {
-    let poolsResult = sugar.try_forSwaps(BigInt.fromI32(limit), BigInt.fromI32(offset))
+  while (offset.lt(totalPools)) {
+    let poolsResult = sugar.try_forSwaps(BigInt.fromI32(limit), offset)
 
     if (poolsResult.reverted) {
       log.error("VELO V2: Sugar forSwaps call reverted at offset {}", [offset.toString()])
       break
     }
-    
+
     let pools = poolsResult.value
     totalDiscovered += pools.length
-    
-    if (pools.length == 0) {
-      hasMore = false
-      break
-    }
-    
+
     // Filter and create relevant pools
     for (let i = 0; i < pools.length; i++) {
       let poolData = pools[i]
-      
+
       // IMPORTANT: Pool type mapping for VelodromeV2 (confirmed manually)
       // type 0 = stable pools
-      // type -1 = volatile pools  
+      // type -1 = volatile pools
       // type 1 = concentrated liquidity pools (skip these)
       // Only track stable (0) and volatile (-1) pools
       if ([0,-1].includes(poolData.type) && isPoolRelevant(poolData.token0, poolData.token1)) {
@@ -102,18 +110,14 @@ export function handleVeloV2Bootstrap(block: ethereum.Block): void {
         whitelistedFound++
       }
     }
-    
-    // Check if we got fewer pools than requested (end of list)
-    if (pools.length < limit) {
-      hasMore = false
-    } else {
-      offset += limit
-    }
+
+    offset = offset.plus(BigInt.fromI32(limit))
   }
-  
-  log.info("VELO V2: Discovery complete - {} whitelisted pools from {} total", [
+
+  log.info("VELO V2: Discovery complete - {} whitelisted pools from {} total ({} factory pool indices scanned)", [
     whitelistedFound.toString(),
-    totalDiscovered.toString()
+    totalDiscovered.toString(),
+    totalPools.toString()
   ])
 }
 

--- a/subgraphs/babydegen/babydegen-base/src/veloV2Pool.ts
+++ b/subgraphs/babydegen/babydegen-base/src/veloV2Pool.ts
@@ -4,11 +4,10 @@ import {
   Transfer
 } from "../generated/templates/VeloV2Pool/VelodromeV2Pool"
 
-import { 
-  refreshVeloV2PositionWithEventAmounts,
+import {
   refreshVeloV2PositionWithBurnAmounts,
   refreshVeloV2Position,
-  ensureVeloV2PoolTemplate
+  getVeloV2PositionId
 } from "./veloV2Shared"
 
 import { BigInt, Bytes, store } from "@graphprotocol/graph-ts"
@@ -70,11 +69,10 @@ export function handleVeloV2Transfer(event: Transfer): void {
       refreshVeloV2Position(to, event.address, event.block, event.transaction.hash)
       
       // Store this position as pending mint data
-      const positionId = to.toHex() + "-velodromev2-" + event.address.toHex()
       storePendingPosition(
         event.transaction.hash,
         event.address,
-        Bytes.fromUTF8(positionId),
+        getVeloV2PositionId(to, event.address),
         to
       )
     }

--- a/subgraphs/babydegen/babydegen-base/src/veloV2Shared.ts
+++ b/subgraphs/babydegen/babydegen-base/src/veloV2Shared.ts
@@ -452,8 +452,10 @@ export function refreshVeloV2Position(
     
     pp.isActive = true
     
-    // If this is a new position (entry amounts not set), use current amounts as entry
-    if (pp.entryAmountUSD.equals(BigDecimal.zero()) && pp.entryTimestamp.equals(BigInt.zero())) {
+    // Entry amounts not recorded yet (the Mint handler may not have run, or its
+    // data was missed): fall back to current amounts as entry. Note entryTimestamp
+    // is set on creation, so it is never zero here and cannot signal a new position.
+    if (pp.entryAmountUSD.equals(BigDecimal.zero())) {
       pp.entryTxHash = txHash
       pp.entryTimestamp = block.timestamp
       pp.entryAmount0 = pp.amount0!

--- a/subgraphs/babydegen/babydegen-base/tests/mapping-utils.ts
+++ b/subgraphs/babydegen/babydegen-base/tests/mapping-utils.ts
@@ -4,6 +4,10 @@ import {
   RegisterInstance,
   CreateMultisigWithAgents
 } from "../generated/ServiceRegistryL2/ServiceRegistryL2"
+import {
+  Transfer as V2Transfer,
+  Mint as V2Mint
+} from "../generated/templates/VeloV2Pool/VelodromeV2Pool"
 
 /**
  * Creates a mock RegisterInstance event.
@@ -73,6 +77,64 @@ export function createCreateMultisigWithAgentsEvent(
       "multisig",
       ethereum.Value.fromAddress(multisig)
     )
+  )
+
+  return event
+}
+
+/**
+ * Creates a mock VelodromeV2Pool (Aerodrome v2) LP Transfer event.
+ *
+ * Solidity signature:
+ *   Transfer(indexed address from, indexed address to, uint256 value)
+ */
+export function createV2TransferEvent(
+  pool: Address,
+  from: Address,
+  to: Address,
+  value: BigInt
+): V2Transfer {
+  let event = changetype<V2Transfer>(newMockEvent())
+  event.address = pool
+  event.parameters = new Array()
+
+  event.parameters.push(
+    new ethereum.EventParam("from", ethereum.Value.fromAddress(from))
+  )
+  event.parameters.push(
+    new ethereum.EventParam("to", ethereum.Value.fromAddress(to))
+  )
+  event.parameters.push(
+    new ethereum.EventParam("value", ethereum.Value.fromUnsignedBigInt(value))
+  )
+
+  return event
+}
+
+/**
+ * Creates a mock VelodromeV2Pool (Aerodrome v2) Mint event.
+ *
+ * Solidity signature:
+ *   Mint(indexed address sender, uint256 amount0, uint256 amount1)
+ */
+export function createV2MintEvent(
+  pool: Address,
+  sender: Address,
+  amount0: BigInt,
+  amount1: BigInt
+): V2Mint {
+  let event = changetype<V2Mint>(newMockEvent())
+  event.address = pool
+  event.parameters = new Array()
+
+  event.parameters.push(
+    new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender))
+  )
+  event.parameters.push(
+    new ethereum.EventParam("amount0", ethereum.Value.fromUnsignedBigInt(amount0))
+  )
+  event.parameters.push(
+    new ethereum.EventParam("amount1", ethereum.Value.fromUnsignedBigInt(amount1))
   )
 
   return event

--- a/subgraphs/babydegen/babydegen-base/tests/mapping.test.ts
+++ b/subgraphs/babydegen/babydegen-base/tests/mapping.test.ts
@@ -15,11 +15,23 @@ import { getTokenConfig, TokenConfig } from "../src/tokenConfig"
 import { getVelodromeV2Price } from "../src/priceAdapters"
 import { calculatePositionROI } from "../src/roiCalculation"
 import { refreshVeloV2Position, getVeloV2PositionId } from "../src/veloV2Shared"
+import { handleVeloV2Bootstrap } from "../src/veloV2Bootstrap"
+import { handleVeloV2Transfer, handleVeloV2Mint } from "../src/veloV2Pool"
 import { ProtocolPosition, Service } from "../generated/schema"
-import { USDC_NATIVE, WETH, AERO, BOLD, VELO_VOTER } from "../src/constants"
+import {
+  USDC_NATIVE,
+  WETH,
+  AERO,
+  BOLD,
+  VELO_VOTER,
+  VELO_V2_SUGAR,
+  VELO_V2_FACTORY
+} from "../src/constants"
 import {
   createRegisterInstanceEvent,
-  createCreateMultisigWithAgentsEvent
+  createCreateMultisigWithAgentsEvent,
+  createV2TransferEvent,
+  createV2MintEvent
 } from "./mapping-utils"
 import {
   OPERATOR_SAFE,
@@ -798,5 +810,243 @@ describe("Aerodrome V2 gauge-staked positions", () => {
     assert.fieldEquals("ProtocolPosition", id.toHexString(), "claimableReward", "0")
     assert.fieldEquals("ProtocolPosition", id.toHexString(), "claimableRewardUSD", "0")
     assert.fieldEquals("ProtocolPosition", id.toHexString(), "usdCurrentWithRewards", "0")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// V2 bootstrap pagination (veloV2Bootstrap.ts)
+//
+// LpSugar forSwaps(limit, offset) walks RAW factory pool indices but returns a
+// FILTERED page (zero-reserve pools dropped), so a page shorter than `limit`
+// does NOT mean the end of the list. The loop must page up to the factory's
+// allPoolsLength() bound.
+// ---------------------------------------------------------------------------
+
+// Unique per-test pool addresses: the bootstrap's discoveredPools cache is
+// module-level and survives clearStore(), so reusing an address across tests
+// would silently skip template creation.
+const BOOT_POOL_PAGE1 = Address.fromString("0x00000000000000000000000000000000000000c1")
+const BOOT_POOL_PAGE2 = Address.fromString("0x00000000000000000000000000000000000000c2")
+const BOOT_POOL_CL = Address.fromString("0x00000000000000000000000000000000000000c3")
+const BOOT_POOL_NON_WL = Address.fromString("0x00000000000000000000000000000000000000c4")
+
+// forSwaps returns (address lp, int24 type, address token0, address token1,
+// address factory, uint256 pool_fee)[]
+function sugarPoolTuple(lp: Address, poolType: i32, token0: Address, token1: Address): ethereum.Tuple {
+  const t = new ethereum.Tuple()
+  t.push(ethereum.Value.fromAddress(lp))
+  t.push(ethereum.Value.fromI32(poolType))
+  t.push(ethereum.Value.fromAddress(token0))
+  t.push(ethereum.Value.fromAddress(token1))
+  t.push(ethereum.Value.fromAddress(VELO_V2_FACTORY))
+  t.push(ethereum.Value.fromUnsignedBigInt(BigInt.zero()))
+  return t
+}
+
+function mockForSwapsPage(offset: i32, pools: Array<ethereum.Tuple>): void {
+  createMockedFunction(
+    VELO_V2_SUGAR,
+    "forSwaps",
+    "forSwaps(uint256,uint256):((address,int24,address,address,address,uint256)[])"
+  )
+    .withArgs([
+      ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(500)),
+      ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(offset))
+    ])
+    .returns([ethereum.Value.fromTupleArray(pools)])
+}
+
+function mockAllPoolsLength(count: i32): void {
+  createMockedFunction(VELO_V2_FACTORY, "allPoolsLength", "allPoolsLength():(uint256)")
+    .withArgs([])
+    .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(count))])
+}
+
+describe("handleVeloV2Bootstrap pagination", () => {
+  afterEach(() => {
+    clearStore()
+  })
+
+  test("aborts without calling forSwaps when allPoolsLength reverts", () => {
+    createMockedFunction(VELO_V2_FACTORY, "allPoolsLength", "allPoolsLength():(uint256)")
+      .withArgs([])
+      .reverts()
+    // forSwaps is intentionally NOT mocked: if the bootstrap called it anyway,
+    // matchstick would throw on the unmocked call and fail this test.
+    handleVeloV2Bootstrap(v2Block())
+
+    assert.dataSourceCount("VeloV2Pool", 0)
+  })
+
+  test("continues past a short page up to allPoolsLength (filtered pages)", () => {
+    mockAllPoolsLength(1000)
+    // Page 1 returns 1 entry (< limit 500) — filtered, NOT the end of the list.
+    mockForSwapsPage(0, [sugarPoolTuple(BOOT_POOL_PAGE1, 0, USDC_NATIVE, BOLD)])
+    // Page 2 holds a whitelisted v2 pool, a CL pool (positive type = tickSpacing,
+    // must be skipped) and a pool with a non-whitelisted token (must be skipped).
+    mockForSwapsPage(500, [
+      sugarPoolTuple(BOOT_POOL_PAGE2, -1, USDC_NATIVE, WETH),
+      sugarPoolTuple(BOOT_POOL_CL, 100, USDC_NATIVE, WETH),
+      sugarPoolTuple(BOOT_POOL_NON_WL, 0, DUMMY0, USDC_NATIVE)
+    ])
+
+    handleVeloV2Bootstrap(v2Block())
+
+    // The regression: the old loop stopped after the short first page, so the
+    // second-page pool never got a template.
+    assert.dataSourceExists("VeloV2Pool", BOOT_POOL_PAGE2.toHexString())
+    assert.dataSourceExists("VeloV2Pool", BOOT_POOL_PAGE1.toHexString())
+    assert.dataSourceCount("VeloV2Pool", 2)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// V2 pending-mint entry amounts (veloV2Pool.ts)
+//
+// Transfer(0x0 → safe) creates the position and stores a PendingMintPosition;
+// the Mint event in the same tx then applies the real entry amounts. The
+// pending record must carry the same position id the position was created
+// under (getVeloV2PositionId), otherwise the Mint data is silently dropped.
+// ---------------------------------------------------------------------------
+const MINT_POOL = Address.fromString("0x00000000000000000000000000000000000000d1")
+const ROUTER = Address.fromString("0x00000000000000000000000000000000000000d2")
+
+// token0 = AERO (priced ~$1.30 via mockAeroUsdcPool) so the mint records a
+// non-zero entryAmountUSD; a $0 entry would keep the backfill fallback firing
+// on every refresh and mask the Mint override this test asserts.
+function mockMintPoolState(): void {
+  createMockedFunction(MINT_POOL, "token0", "token0():(address)")
+    .withArgs([])
+    .returns([ethereum.Value.fromAddress(AERO)])
+  createMockedFunction(MINT_POOL, "token1", "token1():(address)")
+    .withArgs([])
+    .returns([ethereum.Value.fromAddress(DUMMY1)])
+  createMockedFunction(MINT_POOL, "stable", "stable():(bool)")
+    .withArgs([])
+    .returns([ethereum.Value.fromBoolean(false)])
+  createMockedFunction(MINT_POOL, "balanceOf", "balanceOf(address):(uint256)")
+    .withArgs([ethereum.Value.fromAddress(SERVICE_SAFE)])
+    .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(500))])
+  createMockedFunction(MINT_POOL, "totalSupply", "totalSupply():(uint256)")
+    .withArgs([])
+    .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(1000))])
+  // 2 token0 / 4 token1 (18 dec) in reserves → current amounts 1 / 2 at 50% share
+  createMockedFunction(MINT_POOL, "getReserves", "getReserves():(uint256,uint256,uint256)")
+    .withArgs([])
+    .returns([
+      ethereum.Value.fromUnsignedBigInt(BigInt.fromString("2000000000000000000")),
+      ethereum.Value.fromUnsignedBigInt(BigInt.fromString("4000000000000000000")),
+      ethereum.Value.fromUnsignedBigInt(BigInt.zero())
+    ])
+  // No gauge for this pool → no gauge calls
+  createMockedFunction(VELO_VOTER, "gauges", "gauges(address):(address)")
+    .withArgs([ethereum.Value.fromAddress(MINT_POOL)])
+    .returns([ethereum.Value.fromAddress(Address.zero())])
+}
+
+describe("handleVeloV2Transfer + handleVeloV2Mint entry amounts", () => {
+  afterEach(() => {
+    clearStore()
+  })
+
+  test("pending position id matches the position, so Mint sets entry amounts", () => {
+    createService(SERVICE_SAFE)
+    mockChainlinkEthUsd()
+    mockMintPoolState()
+    mockAeroUsdcPool()
+
+    // 1. LP mint transfer: creates the position + the pending record
+    const transfer = createV2TransferEvent(MINT_POOL, Address.zero(), SERVICE_SAFE, BigInt.fromI32(500))
+    transfer.block.number = BLOCK_NUMBER
+    transfer.block.timestamp = BLOCK_TIMESTAMP
+    transfer.transaction.hash = TX_HASH
+    handleVeloV2Transfer(transfer)
+
+    const positionId = getVeloV2PositionId(SERVICE_SAFE, MINT_POOL)
+    const pendingId = TX_HASH.toHexString() + "-" + MINT_POOL.toHexString()
+    // The regression: the pending record used to carry a "-velodromev2-" id
+    // that matches no ProtocolPosition, so the Mint amounts were dropped.
+    assert.fieldEquals("PendingMintPosition", pendingId, "positionId", positionId.toHexString())
+
+    // 2. Mint event in the same tx applies the event amounts as entry amounts
+    const mint = createV2MintEvent(
+      MINT_POOL,
+      ROUTER,
+      BigInt.fromString("2000000000000000000"), // 2 token0
+      BigInt.fromString("6000000000000000000")  // 6 token1
+    )
+    mint.block.number = BLOCK_NUMBER
+    mint.block.timestamp = BLOCK_TIMESTAMP
+    mint.transaction.hash = TX_HASH
+    handleVeloV2Mint(mint)
+
+    // Entry amounts come from the Mint event (2/6), not from the current pool
+    // share (1/2) that the creation-time fallback recorded.
+    assert.fieldEquals("ProtocolPosition", positionId.toHexString(), "entryAmount0", "2")
+    assert.fieldEquals("ProtocolPosition", positionId.toHexString(), "entryAmount1", "6")
+    // Pending record is consumed
+    assert.entityCount("PendingMintPosition", 0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// V2 entry-amount fallback (veloV2Shared.ts)
+//
+// entryTimestamp is always set at position creation, so the fallback that
+// backfills missing entry amounts must key off entryAmountUSD alone.
+// ---------------------------------------------------------------------------
+function mockV2PoolInWallet(): void {
+  createMockedFunction(V2_POOL, "balanceOf", "balanceOf(address):(uint256)")
+    .withArgs([ethereum.Value.fromAddress(SERVICE_SAFE)])
+    .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(500))])
+  createMockedFunction(V2_POOL, "totalSupply", "totalSupply():(uint256)")
+    .withArgs([])
+    .returns([ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(1000))])
+  createMockedFunction(V2_POOL, "getReserves", "getReserves():(uint256,uint256,uint256)")
+    .withArgs([])
+    .returns([
+      ethereum.Value.fromUnsignedBigInt(BigInt.fromString("2000000000000000000")),
+      ethereum.Value.fromUnsignedBigInt(BigInt.fromString("4000000000000000000")),
+      ethereum.Value.fromUnsignedBigInt(BigInt.zero())
+    ])
+  createMockedFunction(VELO_VOTER, "gauges", "gauges(address):(address)")
+    .withArgs([ethereum.Value.fromAddress(V2_POOL)])
+    .returns([ethereum.Value.fromAddress(Address.zero())])
+}
+
+describe("refreshVeloV2Position entry-amount fallback", () => {
+  afterEach(() => {
+    clearStore()
+  })
+
+  test("backfills entry amounts when entryAmountUSD is 0 despite entryTimestamp set", () => {
+    createService(SERVICE_SAFE)
+    const id = makeOpenV2Position(DUMMY0, DUMMY1)
+    // Simulate a position whose Mint data was never applied: entry amounts are
+    // zero but entryTimestamp is set (as creation always does).
+    const seed = ProtocolPosition.load(id)!
+    seed.entryAmountUSD = BigDecimal.zero()
+    seed.save()
+    mockV2PoolInWallet()
+
+    refreshVeloV2Position(SERVICE_SAFE, V2_POOL, v2Block(), TX_HASH, false)
+
+    // Fallback fires: entry amounts = current amounts (50% share of 2/4 reserves)
+    assert.fieldEquals("ProtocolPosition", id.toHexString(), "entryAmount0", "1")
+    assert.fieldEquals("ProtocolPosition", id.toHexString(), "entryAmount1", "2")
+    assert.fieldEquals("ProtocolPosition", id.toHexString(), "isActive", "true")
+  })
+
+  test("does not overwrite entry amounts that were already recorded", () => {
+    createService(SERVICE_SAFE)
+    // makeOpenV2Position records entryAmountUSD = 100 and entryAmount0 = 0
+    const id = makeOpenV2Position(DUMMY0, DUMMY1)
+    mockV2PoolInWallet()
+
+    refreshVeloV2Position(SERVICE_SAFE, V2_POOL, v2Block(), TX_HASH, false)
+
+    // Fallback must NOT fire: recorded entry data stays untouched.
+    assert.fieldEquals("ProtocolPosition", id.toHexString(), "entryAmountUSD", "100")
+    assert.fieldEquals("ProtocolPosition", id.toHexString(), "entryAmount0", "0")
   })
 })

--- a/subgraphs/babydegen/babydegen-optimism/src/veloV2Pool.ts
+++ b/subgraphs/babydegen/babydegen-optimism/src/veloV2Pool.ts
@@ -4,11 +4,10 @@ import {
   Transfer
 } from "../generated/templates/VeloV2Pool/VelodromeV2Pool"
 
-import { 
-  refreshVeloV2PositionWithEventAmounts,
+import {
   refreshVeloV2PositionWithBurnAmounts,
   refreshVeloV2Position,
-  ensureVeloV2PoolTemplate
+  getVeloV2PositionId
 } from "./veloV2Shared"
 
 import { BigInt, Bytes, store } from "@graphprotocol/graph-ts"
@@ -70,11 +69,10 @@ export function handleVeloV2Transfer(event: Transfer): void {
       refreshVeloV2Position(to, event.address, event.block, event.transaction.hash)
       
       // Store this position as pending mint data
-      const positionId = to.toHex() + "-velodromev2-" + event.address.toHex()
       storePendingPosition(
         event.transaction.hash,
         event.address,
-        Bytes.fromUTF8(positionId),
+        getVeloV2PositionId(to, event.address),
         to
       )
     }


### PR DESCRIPTION
## Summary

The live `olas-babydegen-base` deployment shows absurd fleet-level APRs (`sma7dAPR` flat 0, `sma7dEthAdjustedAPR` swinging ±1000%). Diagnosed against live data + on-chain state; three bugs, all fixed here:

1. **Bootstrap pagination early-exit** (`veloV2Bootstrap.ts`). Aerodrome LpSugar `forSwaps(limit, offset)` walks **raw factory pool indices** but returns a **filtered** page (zero-reserve pools dropped), so a page shorter than `limit` does not mean end-of-list. The first page returned 488 < 500 and the loop stopped — only 500 of ~28,131 factory indices were scanned. Most Basius LP pools (e.g. msUSD/USDC `0xcefc8b79…` at index ~1000) never got templates, so their positions are invisible and each agent portfolio "loses" ~$14. The loop now pages up to the v2 factory's `allPoolsLength()` and aborts loudly if that call reverts. CL-factory entries past the v2 range are skipped by the existing type filter.

2. **Pending-mint position id mismatch** (`veloV2Pool.ts`, base **and** optimism). The Transfer handler stored the pending mint under a hardcoded `"-velodromev2-"` id, but positions are keyed by `getVeloV2PositionId` (protocol `aerodrome-v2` on Base, `velodrome-v2` on Optimism). The Mint handler's `ProtocolPosition.load(pending.positionId)` always missed, so entry amounts were dropped and every v2 position had `entryAmountUSD = 0`. Same latent bug existed on optimism.

3. **Dead entry-amount backfill** (`veloV2Shared.ts`, base). The fallback that recovers missing entry amounts required `entryTimestamp == 0`, but creation always sets `entryTimestamp`, so it could never fire. It now keys off `entryAmountUSD == 0` alone.

Bugs 2+3 together pinned closed-position ROI at 0 (the `investment > 0` guard), which is why `medianPopulationAPR`/`sma7dAPR` read flat 0.

## Tests

5 new matchstick tests (base suite now 29):
- bootstrap continues past a short filtered page up to `allPoolsLength()`, skips CL-type and non-whitelisted pools, and aborts without calling `forSwaps` when `allPoolsLength()` reverts
- Transfer(0x0 → safe) stores the pending record under the real position id and the same-tx Mint applies entry amounts (and consumes the pending record)
- entry backfill fires when `entryAmountUSD == 0` despite `entryTimestamp` being set, and does NOT overwrite entry amounts that were already recorded

Ran locally per `.github/workflows/ci.yml`: codegen + build + matchstick for both babydegen subgraphs (29 + 15 green), `yarn audit:prod`, `yarn audit:install-hooks`, lockfile-lint on both paths.

## Deployment note

The bootstrap runs `once` at startBlock, so **babydegen-base needs a redeploy with a full resync from startBlock 47163056** for the fix to take effect. Optimism only picks up the (latent) pending-mint id fix; a resync there is only needed if we want historical v2 entry amounts corrected.

## Follow-ups (not in this PR)

- babydegen-optimism's bootstrap uses Velodrome's `all(limit, offset)` and still stops on short pages — needs the same bound-by-factory treatment if v2 pools matter there.
- babydegen-optimism has the same dead `entryTimestamp == 0` fallback condition.
- ETH-adjusted APR annualization (`(roi - ethDelta) × 365/daysActive`) amplifies ETH beta into ±1000% swings on days-old portfolios — design decision pending, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)